### PR TITLE
Remove text formatting options (bold/italic)

### DIFF
--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -1,15 +1,4 @@
-import {
-  Asterisk,
-  Bold,
-  Heading,
-  Italic,
-  List,
-  ListOrdered,
-  SortAsc,
-  Trash2,
-  Type,
-  X,
-} from 'lucide-react';
+import { Asterisk, Heading, List, ListOrdered, SortAsc, Trash2, Type, X } from 'lucide-react';
 
 type ToolbarBlockType = 'heading' | 'p' | 'ul' | 'ol' | 'abc' | 'footnote';
 
@@ -17,7 +6,6 @@ interface FloatingToolbarProps {
   selectedCount: number;
   isEditing: boolean;
   selectedNodeType?: ToolbarBlockType | null;
-  onFormat: (format: 'bold' | 'italic') => void;
   onUpdateType: (type: ToolbarBlockType) => void;
   onDelete: () => void;
   onClearSelection: () => void;
@@ -27,7 +15,6 @@ export function FloatingToolbar({
   selectedCount,
   isEditing,
   selectedNodeType,
-  onFormat,
   onUpdateType,
   onDelete,
   onClearSelection,
@@ -50,22 +37,6 @@ export function FloatingToolbar({
           {selectedCount} selected
         </div>
       )}
-
-      <button
-        onClick={() => onFormat('bold')}
-        className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
-        title="Bold (Ctrl+B)"
-      >
-        <Bold size={18} />
-      </button>
-      <button
-        onClick={() => onFormat('italic')}
-        className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
-        title="Italic (Ctrl+I)"
-      >
-        <Italic size={18} />
-      </button>
-      <div className="w-px h-6 bg-gray-700 mx-1" />
 
       <button
         onClick={() => onUpdateType('heading')}

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -131,16 +131,6 @@ export function TreeEditor({
   };
 
   const handleBlockKeyDown = (e: React.KeyboardEvent, id: string) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === 'b') {
-      e.preventDefault();
-      handleFormat('bold');
-      return;
-    }
-    if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
-      e.preventDefault();
-      handleFormat('italic');
-      return;
-    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       addNodeAfter(id);
@@ -200,16 +190,6 @@ export function TreeEditor({
       redo();
       return;
     }
-    if ((e.metaKey || e.ctrlKey) && e.key === 'b') {
-      e.preventDefault();
-      handleFormat('bold');
-      return;
-    }
-    if ((e.metaKey || e.ctrlKey) && e.key === 'i') {
-      e.preventDefault();
-      handleFormat('italic');
-      return;
-    }
     if (editingId) return;
 
     if (selectedIds.size === 0) {
@@ -239,26 +219,6 @@ export function TreeEditor({
     } else if (e.key === 'Escape') {
       e.preventDefault();
       clearSelection();
-    }
-  };
-
-  const handleFormat = (command: 'bold' | 'italic') => {
-    if (editingId) {
-      window.document.execCommand(command, false);
-    } else {
-      // Format selected nodes - wrap/unwrap content
-      const tag = command === 'bold' ? 'b' : 'i';
-      selectedIds.forEach((id) => {
-        const node = flattenedNodes.find((fn) => fn.node.id === id);
-        if (node && 'contents' in node.node) {
-          const content = node.node.contents[language] || '';
-          const isWrapped = content.startsWith(`<${tag}>`) && content.endsWith(`</${tag}>`);
-          const newContent = isWrapped
-            ? content.slice(tag.length + 2, -(tag.length + 3))
-            : `<${tag}>${content}</${tag}>`;
-          updateNodeContents(id, newContent);
-        }
-      });
     }
   };
 
@@ -409,7 +369,6 @@ export function TreeEditor({
             selectedCount={selectedIds.size}
             isEditing={!!editingId}
             selectedNodeType={selectedNodeType}
-            onFormat={handleFormat}
             onUpdateType={handleBulkUpdateType}
             onDelete={deleteSelected}
             onClearSelection={clearSelection}

--- a/src/utils/document-utils.test.ts
+++ b/src/utils/document-utils.test.ts
@@ -127,12 +127,11 @@ describe('Document Utils', () => {
       expect(item2.number).toBe('2.');
     });
 
-    it('preserves inline formatting in contents', () => {
+    it('strips inline formatting from contents', () => {
       const html = '<p><b>Bold</b> and <i>italic</i></p>';
       const doc = parseHtmlToTree(html);
       const content = doc.children[0] as LeafDocumentNode;
-      expect(content.contents.de).toContain('<b>');
-      expect(content.contents.de).toContain('<i>');
+      expect(content.contents.de).toBe('Bold and italic');
     });
 
     it('uses de language by default', () => {

--- a/src/utils/document-utils.ts
+++ b/src/utils/document-utils.ts
@@ -93,8 +93,10 @@ export const parseHtmlToTree = (
   const getInnerHtml = (node: Node): string => {
     if (node instanceof HTMLElement) {
       let content = node.innerHTML.trim();
-      // Strip nested block tags but keep inline formatting
+      // Strip nested block tags
       content = content.replace(/<\/?(div|p|h[1-6]|ul|ol|li)[^>]*>/gi, '');
+      // Strip inline formatting tags (Demokratis platform doesn't support formatting)
+      content = content.replace(/<\/?(b|i|em|strong|u|s|strike|span|code|sub|sup)[^>]*>/gi, '');
       return content;
     }
     return (node.textContent || '').replace(/[\s\n]+/g, ' ').trim();

--- a/src/utils/legal-transforms/lettered-items.test.ts
+++ b/src/utils/legal-transforms/lettered-items.test.ts
@@ -192,14 +192,16 @@ describe('letteredItemsTransform', () => {
     expect(l2.children[0].type).toBe('list');
   });
 
-  it('preserves HTML formatting in content', () => {
-    const input = createDoc([content('a. <b>Bold</b> item')]);
+  it('preserves plain text content after stripping letter prefix', () => {
+    // Note: HTML formatting is stripped at parse time in document-utils.ts
+    // so input to this transform is already plain text
+    const input = createDoc([content('a. Bold item')]);
 
     const result = letteredItemsTransform(input, 'de');
 
     const listNode = result.children[0] as ContainerDocumentNode;
     const listItem = listNode.children[0] as ContainerDocumentNode;
     const contentNode = listItem.children[0] as ContentDocumentNode;
-    expect(contentNode.contents.de).toBe('<b>Bold</b> item');
+    expect(contentNode.contents.de).toBe('Bold item');
   });
 });


### PR DESCRIPTION
## Summary
- Remove bold and italic buttons from the FloatingToolbar
- Remove Ctrl+B and Ctrl+I keyboard shortcuts  
- Strip inline formatting tags (`<b>`, `<i>`, `<em>`, `<strong>`, `<u>`, `<s>`, `<strike>`, `<span>`, `<code>`, `<sub>`, `<sup>`) during HTML parsing

The Demokratis platform doesn't support any formatting inside text nodes, so these options needed to be removed.

## Test plan
- [x] All existing tests pass
- [x] Build succeeds
- [x] Manual verification: Bold/Italic buttons are removed from floating toolbar
- [x] Manual verification: Ctrl+B and Ctrl+I shortcuts do nothing
- [x] Manual verification: Imported documents have formatting tags stripped

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)