### PR TITLE
Fix indentation and outdentation for multiple selected nodes

### DIFF
--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -64,7 +64,7 @@ export function TreeEditor({
     clearSelection,
     moveSelection,
     addNodeAfter,
-    removeNode,
+    removeNodes,
     updateNodeContents,
     updateNodeNumber,
     changeNodeType,
@@ -163,7 +163,7 @@ export function TreeEditor({
       if (!content || content === '<br>' || content.trim() === '') {
         if (flattenedNodes.length > 0) {
           e.preventDefault();
-          removeNode(id);
+          removeNodes([id]);
         }
       }
     } else if (e.key === 'Tab') {

--- a/src/hooks/useTreeEditor.test.ts
+++ b/src/hooks/useTreeEditor.test.ts
@@ -211,7 +211,7 @@ describe('useTreeEditor', () => {
 
     // Remove a node
     act(() => {
-      result.current.removeNode('p2');
+      result.current.removeNodes(['p2']);
     });
 
     expect(result.current.flattenedNodes.length).toBe(3);
@@ -302,5 +302,89 @@ describe('useTreeEditor', () => {
 
     // Test invalid move (same source and target)
     expect(result.current.getReceivingParentId('h1', 'h1')).toBeNull();
+  });
+
+  test('indentSelected indents all selected nodes', () => {
+    // Create doc: root > [h1, p1, p2]
+    const doc: ContainerDocumentNode = {
+      id: 'root',
+      number: null,
+      type: 'document',
+      children: [
+        {
+          id: 'h1',
+          number: '1',
+          type: 'heading',
+          contents: { de: 'Heading' },
+          children: [],
+        } as HeadingDocumentNode,
+        {
+          id: 'p1',
+          number: null,
+          type: 'content',
+          contents: { de: 'First' },
+          children: [],
+        },
+        {
+          id: 'p2',
+          number: null,
+          type: 'content',
+          contents: { de: 'Second' },
+          children: [],
+        },
+      ],
+    };
+
+    const { result } = renderHook(() => useTreeEditor(doc));
+
+    // Select p1 and p2
+    act(() => {
+      result.current.handleNodeClick('p1', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+    act(() => {
+      result.current.handleNodeClick('p2', { shiftKey: false, ctrlKey: true, metaKey: false });
+    });
+
+    expect(result.current.selectedIds.size).toBe(2);
+
+    // Indent selected
+    act(() => {
+      result.current.indentSelected();
+    });
+
+    // Both p1 and p2 should now be children of h1
+    expect(result.current.document.children.length).toBe(1);
+    const h1 = result.current.document.children[0] as HeadingDocumentNode;
+    expect(h1.children.length).toBe(2);
+    expect(h1.children[0].id).toBe('p1');
+    expect(h1.children[1].id).toBe('p2');
+  });
+
+  test('outdentSelected outdents all selected nodes', () => {
+    // Use default doc: root > [h1 > [p1, p2], h2]
+    const doc = createTestDocument();
+    const { result } = renderHook(() => useTreeEditor(doc));
+
+    // Select p1 and p2 (both children of h1)
+    act(() => {
+      result.current.handleNodeClick('p1', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+    act(() => {
+      result.current.handleNodeClick('p2', { shiftKey: false, ctrlKey: true, metaKey: false });
+    });
+
+    expect(result.current.selectedIds.size).toBe(2);
+
+    // Outdent selected
+    act(() => {
+      result.current.outdentSelected();
+    });
+
+    // Both p1 and p2 should now be root-level siblings after h1
+    expect(result.current.document.children.length).toBe(4);
+    expect(result.current.document.children[0].id).toBe('h1');
+    expect(result.current.document.children[1].id).toBe('p1');
+    expect(result.current.document.children[2].id).toBe('p2');
+    expect(result.current.document.children[3].id).toBe('h2');
   });
 });

--- a/src/hooks/useTreeEditor.ts
+++ b/src/hooks/useTreeEditor.ts
@@ -44,11 +44,11 @@ export const useTreeEditor = (
   // Tree operations
   const {
     addNodeAfter,
-    removeNode,
+    removeNodes,
     updateNodeContents,
     updateNodeNumber,
-    indentNode,
-    outdentNode,
+    indentNodes,
+    outdentNodes,
     changeNodeType,
     moveNodeById,
     getReceivingParentId,
@@ -220,20 +220,10 @@ export const useTreeEditor = (
   const deleteSelected = useCallback(() => {
     if (selectedIds.size === 0) return;
 
-    // Remove nodes in reverse flat order to avoid index shifting issues
-    const sortedIds = [...selectedIds]
-      .map((id) => ({ id, index: nodeIdToFlatIndex.get(id) ?? -1 }))
-      .filter((item) => item.index >= 0)
-      .sort((a, b) => b.index - a.index)
-      .map((item) => item.id);
-
-    // Remove each node
-    sortedIds.forEach((id) => {
-      removeNode(id);
-    });
-
+    const ids = [...selectedIds].filter((id) => nodeIdToFlatIndex.has(id));
+    removeNodes(ids);
     clearSelection();
-  }, [selectedIds, nodeIdToFlatIndex, removeNode, clearSelection]);
+  }, [selectedIds, nodeIdToFlatIndex, removeNodes, clearSelection]);
 
   /**
    * Indent selected nodes (Tab).
@@ -248,10 +238,8 @@ export const useTreeEditor = (
       .sort((a, b) => a.index - b.index)
       .map((item) => item.id);
 
-    sortedIds.forEach((id) => {
-      indentNode(id);
-    });
-  }, [selectedIds, nodeIdToFlatIndex, indentNode]);
+    indentNodes(sortedIds);
+  }, [selectedIds, nodeIdToFlatIndex, indentNodes]);
 
   /**
    * Outdent selected nodes (Shift+Tab).
@@ -259,17 +247,15 @@ export const useTreeEditor = (
   const outdentSelected = useCallback(() => {
     if (selectedIds.size === 0) return;
 
-    // Process nodes in reverse flat order to maintain structure
+    // Sort in flat order; outdentNodes handles reverse processing internally
     const sortedIds = [...selectedIds]
       .map((id) => ({ id, index: nodeIdToFlatIndex.get(id) ?? -1 }))
       .filter((item) => item.index >= 0)
-      .sort((a, b) => b.index - a.index)
+      .sort((a, b) => a.index - b.index)
       .map((item) => item.id);
 
-    sortedIds.forEach((id) => {
-      outdentNode(id);
-    });
-  }, [selectedIds, nodeIdToFlatIndex, outdentNode]);
+    outdentNodes(sortedIds);
+  }, [selectedIds, nodeIdToFlatIndex, outdentNodes]);
 
   return {
     // Document state
@@ -297,11 +283,11 @@ export const useTreeEditor = (
 
     // Tree operations
     addNodeAfter,
-    removeNode,
+    removeNodes,
     updateNodeContents,
     updateNodeNumber,
-    indentNode,
-    outdentNode,
+    indentNodes,
+    outdentNodes,
     changeNodeType,
     moveNodeById,
 

--- a/src/hooks/useTreeOperations.test.ts
+++ b/src/hooks/useTreeOperations.test.ts
@@ -179,12 +179,12 @@ describe('useTreeOperations', () => {
     });
   });
 
-  describe('removeNode', () => {
+  describe('removeNodes', () => {
     test('removes leaf node', () => {
       const { result } = renderTreeOperations();
 
       act(() => {
-        result.current.removeNode('p1');
+        result.current.removeNodes(['p1']);
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
@@ -199,7 +199,7 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations();
 
       act(() => {
-        result.current.removeNode('h2'); // Has p2 as child
+        result.current.removeNodes(['h2']); // Has p2 as child
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
@@ -209,6 +209,22 @@ describe('useTreeOperations', () => {
       expect(h1.children[0].id).toBe('p1');
       // p2 should be gone with h2
       expect(getNodeAtPath(newDoc, [0, 1])).toBeNull();
+    });
+
+    test('removes multiple nodes in a single commit', () => {
+      const { result } = renderTreeOperations();
+
+      // Remove both p1 and h2 (siblings under h1)
+      act(() => {
+        result.current.removeNodes(['p1', 'h2']);
+      });
+
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const h1 = newDoc.children[0] as HeadingDocumentNode;
+
+      // h1 should have no children left
+      expect(h1.children.length).toBe(0);
     });
   });
 
@@ -255,7 +271,7 @@ describe('useTreeOperations', () => {
     });
   });
 
-  describe('indentNode (Tab)', () => {
+  describe('indentNodes (Tab)', () => {
     test('moves content under previous sibling heading', () => {
       // Create doc with h1, then content at same level
       const doc: ContainerDocumentNode = {
@@ -283,7 +299,7 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations(doc);
 
       act(() => {
-        result.current.indentNode('p1');
+        result.current.indentNodes(['p1']);
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
@@ -299,7 +315,7 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations();
 
       act(() => {
-        result.current.indentNode('p1');
+        result.current.indentNodes(['p1']);
       });
 
       // Should not call commit if no-op
@@ -333,7 +349,7 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations(doc);
 
       act(() => {
-        result.current.indentNode('h2');
+        result.current.indentNodes(['h2']);
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
@@ -345,13 +361,11 @@ describe('useTreeOperations', () => {
 
     test.skip('moves list_item into nested list under previous item', () => {
       // Skipped: list_item nesting requires design decision about list_item structure
-      // The current DocumentNode type has list_item as LeafDocumentNode (no children)
-      // Supporting nested lists would require making list_item a hybrid type
       const listDoc = createDocumentWithList();
       const { result } = renderTreeOperations(listDoc);
 
       act(() => {
-        result.current.indentNode('li2');
+        result.current.indentNodes(['li2']);
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
@@ -362,15 +376,97 @@ describe('useTreeOperations', () => {
       expect(list.children[0].id).toBe('li1');
       expect(list.children[1].id).toBe('li3');
     });
+
+    test('indents multiple sibling nodes under previous heading', () => {
+      // doc: h1, p1, p2 at root level → both p1 and p2 should move under h1
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'document',
+        children: [
+          {
+            id: 'h1',
+            number: null,
+            type: 'heading',
+            contents: { de: 'Heading' },
+            children: [],
+          },
+          {
+            id: 'p1',
+            number: null,
+            type: 'content',
+            contents: { de: 'First' },
+            children: [],
+          },
+          {
+            id: 'p2',
+            number: null,
+            type: 'content',
+            contents: { de: 'Second' },
+            children: [],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.indentNodes(['p1', 'p2']);
+      });
+
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      // Only h1 remains at root
+      expect(newDoc.children.length).toBe(1);
+      const h1 = newDoc.children[0] as HeadingDocumentNode;
+      // Both p1 and p2 are now children of h1
+      expect(h1.children.length).toBe(2);
+      expect(h1.children[0].id).toBe('p1');
+      expect(h1.children[1].id).toBe('p2');
+    });
+
+    test('skips nodes that cannot be indented in a batch', () => {
+      // doc: p1, h1 → p1 has no previous heading, h1 has no previous heading
+      // Neither can be indented
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'document',
+        children: [
+          {
+            id: 'p1',
+            number: null,
+            type: 'content',
+            contents: { de: 'First' },
+            children: [],
+          },
+          {
+            id: 'h1',
+            number: null,
+            type: 'heading',
+            contents: { de: 'Heading' },
+            children: [],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.indentNodes(['p1', 'h1']);
+      });
+
+      expect(mockCommit).not.toHaveBeenCalled();
+    });
   });
 
-  describe('outdentNode (Shift-Tab)', () => {
+  describe('outdentNodes (Shift-Tab)', () => {
     test('moves content to be sibling of parent heading', () => {
       const { result } = renderTreeOperations();
 
       // p1 is child of h1, outdent should move it to root level after h1
       act(() => {
-        result.current.outdentNode('p1');
+        result.current.outdentNodes(['p1']);
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
@@ -391,7 +487,7 @@ describe('useTreeOperations', () => {
 
       // h1 is already at document level
       act(() => {
-        result.current.outdentNode('h1');
+        result.current.outdentNodes(['h1']);
       });
 
       expect(mockCommit).not.toHaveBeenCalled();
@@ -402,7 +498,7 @@ describe('useTreeOperations', () => {
 
       // h2 is child of h1, outdent should move it to root level after h1
       act(() => {
-        result.current.outdentNode('h2');
+        result.current.outdentNodes(['h2']);
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
@@ -414,7 +510,6 @@ describe('useTreeOperations', () => {
     });
 
     test('moves list_item out of nested list', () => {
-      // Create a nested list scenario
       const nestedListDoc: ContainerDocumentNode = {
         id: 'root',
         number: null,
@@ -440,7 +535,7 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations(nestedListDoc);
 
       act(() => {
-        result.current.outdentNode('li2');
+        result.current.outdentNodes(['li2']);
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
@@ -451,8 +546,6 @@ describe('useTreeOperations', () => {
     });
 
     test('does nothing when outdenting list_item would place it outside any list', () => {
-      // document -> list -> list_item
-      // Outdenting list_item would make it a child of document, which is invalid
       const docWithTopLevelList: ContainerDocumentNode = {
         id: 'root',
         number: null,
@@ -473,16 +566,13 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations(docWithTopLevelList);
 
       act(() => {
-        result.current.outdentNode('li1');
+        result.current.outdentNodes(['li1']);
       });
 
-      // Should NOT have called commit because the operation is invalid
       expect(mockCommit).not.toHaveBeenCalled();
     });
 
     test('does nothing when outdenting list_item in list under heading would violate rules', () => {
-      // document -> heading -> list -> list_item
-      // Outdenting list_item would make it a child of heading, which is invalid
       const docWithListUnderHeading: ContainerDocumentNode = {
         id: 'root',
         number: null,
@@ -508,15 +598,36 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations(docWithListUnderHeading);
 
       act(() => {
-        result.current.outdentNode('li1');
+        result.current.outdentNodes(['li1']);
       });
 
-      // Should NOT have called commit because list_item cannot be child of heading
       expect(mockCommit).not.toHaveBeenCalled();
+    });
+
+    test('outdents multiple nested nodes', () => {
+      // h1 has children p1 and h2. Outdent both → both become root-level siblings after h1
+      const { result } = renderTreeOperations();
+
+      act(() => {
+        result.current.outdentNodes(['p1', 'h2']);
+      });
+
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      // Should have: h1, p1, h2 (with p2 child), h1b
+      expect(newDoc.children.length).toBe(4);
+      expect(newDoc.children[0].id).toBe('h1');
+      expect(newDoc.children[1].id).toBe('p1');
+      expect(newDoc.children[2].id).toBe('h2');
+      expect(newDoc.children[3].id).toBe('h1b');
+
+      // h1 should have no children left
+      const h1 = newDoc.children[0] as HeadingDocumentNode;
+      expect(h1.children.length).toBe(0);
     });
   });
 
-  describe('indentNode footnote into content', () => {
+  describe('indentNodes footnote into content', () => {
     test('moves footnote under previous sibling content', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
@@ -542,7 +653,7 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations(doc);
 
       act(() => {
-        result.current.indentNode('fn1');
+        result.current.indentNodes(['fn1']);
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
@@ -579,7 +690,7 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations(doc);
 
       act(() => {
-        result.current.indentNode('fn2');
+        result.current.indentNodes(['fn2']);
       });
 
       // Should not indent footnote into another footnote
@@ -611,7 +722,7 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations(doc);
 
       act(() => {
-        result.current.indentNode('fn1');
+        result.current.indentNodes(['fn1']);
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
@@ -625,7 +736,7 @@ describe('useTreeOperations', () => {
     });
   });
 
-  describe('outdentNode footnote from content', () => {
+  describe('outdentNodes footnote from content', () => {
     test('moves footnote to be sibling of parent content', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
@@ -652,7 +763,7 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations(doc);
 
       act(() => {
-        result.current.outdentNode('fn1');
+        result.current.outdentNodes(['fn1']);
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
@@ -700,7 +811,7 @@ describe('useTreeOperations', () => {
       const { result } = renderTreeOperations(doc);
 
       act(() => {
-        result.current.outdentNode('fn1');
+        result.current.outdentNodes(['fn1']);
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;

--- a/src/hooks/useTreeOperations.ts
+++ b/src/hooks/useTreeOperations.ts
@@ -12,6 +12,7 @@ import { canBeChildOf } from '../types/document';
 import type { NodePath } from '../types/editor';
 import { generateId } from '../utils/document-utils';
 import {
+  buildIndices,
   getNodeAtPath,
   insertNodeAtPath,
   mergeAdjacentLists,
@@ -90,15 +91,29 @@ export const useTreeOperations = ({
   );
 
   /**
-   * Remove a node and its subtree.
+   * Remove nodes and their subtrees.
+   * Rebuilds indices between iterations so processing order doesn't matter.
    */
-  const removeNode = useCallback(
-    (id: string) => {
-      const path = nodeIndex.get(id);
-      if (!path || path.length === 0) return; // Can't remove root
+  const removeNodes = useCallback(
+    (ids: string[]) => {
+      let doc = document;
+      let changed = false;
 
-      const newDoc = removeNodeAtPath(document, path);
-      commit(newDoc);
+      // Process in reverse order to avoid index shifting issues
+      const reversed = [...ids].reverse();
+
+      for (const id of reversed) {
+        const idx = changed ? buildIndices(doc).nodeIndex : nodeIndex;
+        const path = idx.get(id);
+        if (!path || path.length === 0) continue;
+
+        doc = removeNodeAtPath(doc, path);
+        changed = true;
+      }
+
+      if (changed) {
+        commit(doc);
+      }
     },
     [document, nodeIndex, commit]
   );
@@ -152,113 +167,151 @@ export const useTreeOperations = ({
   };
 
   /**
-   * Tab: Nest node deeper into the tree.
-   * For content/heading: move to become last child of previous sibling heading.
-   * For list_item: more complex handling (create nested list).
+   * Indent a single node in a document (pure function, no commit).
+   * Returns the new document, or null if the operation can't be performed.
    */
-  const indentNode = useCallback(
-    (id: string) => {
-      const path = nodeIndex.get(id);
-      if (!path || path.length === 0) return;
+  const indentNodeInDoc = (
+    doc: ContainerDocumentNode,
+    idx: Map<string, NodePath>,
+    id: string
+  ): ContainerDocumentNode | null => {
+    const path = idx.get(id);
+    if (!path || path.length === 0) return null;
 
-      const parentPath = path.slice(0, -1);
-      const childIndex = path[path.length - 1];
-      const parent = parentPath.length === 0 ? document : getNodeAtPath(document, parentPath);
-      const node = getNodeAtPath(document, path);
+    const parentPath = path.slice(0, -1);
+    const childIndex = path[path.length - 1];
+    const parent = parentPath.length === 0 ? doc : getNodeAtPath(doc, parentPath);
+    const node = getNodeAtPath(doc, path);
 
-      if (!parent || !node || !('children' in parent)) return;
+    if (!parent || !node || !('children' in parent)) return null;
 
-      // Special case: list items - for now, skip this complex case
-      if (node.type === 'list_item') {
-        // TODO: Implement nested list handling
-        // This would require converting a list_item to have a nested list
-        return;
+    // Special case: list items - for now, skip this complex case
+    if (node.type === 'list_item') {
+      return null;
+    }
+
+    // Find previous sibling that can accept this node as child
+    const target = findPreviousSiblingTarget(parent, childIndex, node.type);
+    if (!target) {
+      return null;
+    }
+
+    // Remove node from current location
+    let newDoc = removeNodeAtPath(doc, path);
+
+    // The target path might have shifted if target was after the removed node
+    // But since we're looking for previous siblings, target.index < childIndex
+    // so the path is still valid
+    const targetPath = [...parentPath, target.index];
+
+    // Add node as last child of target (heading or content)
+    newDoc = updateNodeAtPath(newDoc, targetPath, (targetNode) => ({
+      ...targetNode,
+      children: [...(targetNode as HeadingDocumentNode | ContentDocumentNode).children, node],
+    }));
+
+    return newDoc;
+  };
+
+  /**
+   * Tab: Nest nodes deeper into the tree.
+   * Processes multiple nodes, rebuilding indices between each operation.
+   */
+  const indentNodes = useCallback(
+    (ids: string[]) => {
+      let doc = document;
+      let changed = false;
+
+      for (const id of ids) {
+        const idx = changed ? buildIndices(doc).nodeIndex : nodeIndex;
+        const result = indentNodeInDoc(doc, idx, id);
+        if (result) {
+          doc = result;
+          changed = true;
+        }
       }
 
-      // Find previous sibling that can accept this node as child
-      const target = findPreviousSiblingTarget(parent, childIndex, node.type);
-      if (!target) {
-        // No valid target to nest under
-        return;
+      if (changed) {
+        commit(doc);
       }
-
-      // Remove node from current location
-      let newDoc = removeNodeAtPath(document, path);
-
-      // The target path might have shifted if target was after the removed node
-      // But since we're looking for previous siblings, target.index < childIndex
-      // so the path is still valid
-      const targetPath = [...parentPath, target.index];
-
-      // Add node as last child of target (heading or content)
-      newDoc = updateNodeAtPath(newDoc, targetPath, (targetNode) => ({
-        ...targetNode,
-        children: [...(targetNode as HeadingDocumentNode | ContentDocumentNode).children, node],
-      }));
-
-      commit(newDoc);
     },
     [document, nodeIndex, commit]
   );
 
   /**
-   * Shift-Tab: Unnest node to be a sibling of parent.
+   * Outdent a single node in a document (pure function, no commit).
+   * Returns the new document, or null if the operation can't be performed.
    */
-  const outdentNode = useCallback(
-    (id: string) => {
-      const path = nodeIndex.get(id);
-      if (!path || path.length <= 1) {
-        // Can't outdent if at document level (path length 1 means direct child of root)
-        return;
-      }
+  const outdentNodeInDoc = (
+    doc: ContainerDocumentNode,
+    idx: Map<string, NodePath>,
+    id: string
+  ): ContainerDocumentNode | null => {
+    const path = idx.get(id);
+    if (!path || path.length <= 1) {
+      return null;
+    }
 
-      const parentPath = path.slice(0, -1);
-      const _childIndex = path[path.length - 1];
-      const parent = getNodeAtPath(document, parentPath);
-      const node = getNodeAtPath(document, path);
+    const parentPath = path.slice(0, -1);
+    const parent = getNodeAtPath(doc, parentPath);
+    const node = getNodeAtPath(doc, path);
 
-      if (!parent || !node) return;
+    if (!parent || !node) return null;
 
-      // Parent must be a heading, list, or content to outdent from
-      if (parent.type !== 'heading' && parent.type !== 'list' && parent.type !== 'content') return;
+    if (parent.type !== 'heading' && parent.type !== 'list' && parent.type !== 'content')
+      return null;
 
-      // Special case: if parent is list and node is list_item
-      if (parent.type === 'list' && node.type === 'list_item') {
-        // Need to find grandparent and check if list_item can be its child
-        const grandparentPath = parentPath.slice(0, -1);
-        const parentIndexInGrandparent = parentPath[parentPath.length - 1];
-        const grandparent =
-          grandparentPath.length === 0 ? document : getNodeAtPath(document, grandparentPath);
-
-        if (!grandparent || !('children' in grandparent)) return;
-
-        // Validate that list_item can be a child of grandparent
-        // list_item can only be a child of list
-        if (!canBeChildOf(node.type, grandparent.type as ParentType)) {
-          // Cannot outdent - would create invalid parent-child relationship
-          return;
-        }
-
-        // Remove from nested list
-        let newDoc = removeNodeAtPath(document, path);
-
-        // Insert into grandparent list after the nested list
-        newDoc = insertNodeAtPath(newDoc, grandparentPath, parentIndexInGrandparent + 1, node);
-        commit(newDoc);
-        return;
-      }
-
-      // Standard case: move node to be sibling of parent
+    // Special case: if parent is list and node is list_item
+    if (parent.type === 'list' && node.type === 'list_item') {
       const grandparentPath = parentPath.slice(0, -1);
       const parentIndexInGrandparent = parentPath[parentPath.length - 1];
+      const grandparent = grandparentPath.length === 0 ? doc : getNodeAtPath(doc, grandparentPath);
 
-      // Remove node from parent
-      let newDoc = removeNodeAtPath(document, path);
+      if (!grandparent || !('children' in grandparent)) return null;
 
-      // Insert as sibling after parent in grandparent
+      if (!canBeChildOf(node.type, grandparent.type as ParentType)) {
+        return null;
+      }
+
+      let newDoc = removeNodeAtPath(doc, path);
       newDoc = insertNodeAtPath(newDoc, grandparentPath, parentIndexInGrandparent + 1, node);
+      return newDoc;
+    }
 
-      commit(newDoc);
+    // Standard case: move node to be sibling of parent
+    const grandparentPath = parentPath.slice(0, -1);
+    const parentIndexInGrandparent = parentPath[parentPath.length - 1];
+
+    let newDoc = removeNodeAtPath(doc, path);
+    newDoc = insertNodeAtPath(newDoc, grandparentPath, parentIndexInGrandparent + 1, node);
+    return newDoc;
+  };
+
+  /**
+   * Shift-Tab: Unnest nodes to be siblings of their parents.
+   * Processes multiple nodes, rebuilding indices between each operation.
+   * Processes in reverse flat order to maintain correct indices.
+   */
+  const outdentNodes = useCallback(
+    (ids: string[]) => {
+      let doc = document;
+      let changed = false;
+
+      // Process in reverse order to avoid index shifting issues
+      const reversed = [...ids].reverse();
+
+      for (const id of reversed) {
+        const idx = changed ? buildIndices(doc).nodeIndex : nodeIndex;
+        const result = outdentNodeInDoc(doc, idx, id);
+        if (result) {
+          doc = result;
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        commit(doc);
+      }
     },
     [document, nodeIndex, commit]
   );
@@ -681,11 +734,11 @@ export const useTreeOperations = ({
 
   return {
     addNodeAfter,
-    removeNode,
+    removeNodes,
     updateNodeContents,
     updateNodeNumber,
-    indentNode,
-    outdentNode,
+    indentNodes,
+    outdentNodes,
     changeNodeType,
     moveNodeById,
     getReceivingParentId,


### PR DESCRIPTION
## Summary
- Replace single-node `indentNode`/`outdentNode`/`removeNode` with batch versions `indentNodes`/`outdentNodes`/`removeNodes` that process all IDs in a single commit
- Extract core indent/outdent logic into pure functions (`indentNodeInDoc`, `outdentNodeInDoc`) that return new documents without committing, enabling sequential batch processing with index rebuilding between iterations
- Update `useTreeEditor` bulk operations (`indentSelected`, `outdentSelected`, `deleteSelected`) to delegate to the new batch functions
- Update `TreeEditor.tsx` backspace handler to use `removeNodes([id])`

## Test plan
- [x] Existing single-node indent/outdent/remove tests updated and passing
- [x] New multi-node indent test: two sibling content nodes indent under previous heading
- [x] New multi-node outdent test: two nested nodes outdent to become siblings of parent
- [x] New multi-node remove test: two nodes removed in a single commit
- [x] New integration tests in `useTreeEditor`: `indentSelected` and `outdentSelected` with multi-selection
- [x] Full test suite passes (396 tests)
- [x] Build succeeds
- [ ] Manual test: select multiple nodes with Ctrl+click, press Tab → all indent; Shift+Tab → all outdent

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)