### PR TITLE
Add "+" buttons to create new nodes above or below

### DIFF
--- a/src/components/RecursiveTreeNode.test.tsx
+++ b/src/components/RecursiveTreeNode.test.tsx
@@ -43,6 +43,8 @@ const defaultProps = {
   editingNumberId: null as string | null,
   onNumberDoubleClick: vi.fn(),
   onUpdateNumber: vi.fn(),
+  onAddNodeBefore: vi.fn(),
+  onAddNodeAfter: vi.fn(),
 };
 
 describe('RecursiveTreeNode', () => {
@@ -241,6 +243,56 @@ describe('RecursiveTreeNode', () => {
       expect(badge?.textContent).toBe('i.');
       fireEvent.doubleClick(badge!);
       expect(onNumberDoubleClick).toHaveBeenCalledWith(expect.any(Object), 'fn-with-num');
+    });
+  });
+
+  describe('add node buttons', () => {
+    test('calls onAddNodeBefore when clicking add-before button', () => {
+      const onAddNodeBefore = vi.fn();
+      const node = createTestNode();
+      const { getByTitle } = render(
+        <RecursiveTreeNode
+          {...defaultProps}
+          node={node}
+          isSelected={true}
+          onAddNodeBefore={onAddNodeBefore}
+        />
+      );
+
+      fireEvent.click(getByTitle('Add node above'));
+      expect(onAddNodeBefore).toHaveBeenCalledWith('h1');
+    });
+
+    test('calls onAddNodeAfter when clicking add-after button', () => {
+      const onAddNodeAfter = vi.fn();
+      const node = createTestNode();
+      const { getByTitle } = render(
+        <RecursiveTreeNode
+          {...defaultProps}
+          node={node}
+          isSelected={true}
+          onAddNodeAfter={onAddNodeAfter}
+        />
+      );
+
+      fireEvent.click(getByTitle('Add node below'));
+      expect(onAddNodeAfter).toHaveBeenCalledWith('h1');
+    });
+
+    test('hides add buttons when editing', () => {
+      const node = createTestNode();
+      const { queryByTitle } = render(
+        <RecursiveTreeNode
+          {...defaultProps}
+          node={node}
+          isSelected={true}
+          isEditing={true}
+          editingId="h1"
+        />
+      );
+
+      expect(queryByTitle('Add node above')).toBeNull();
+      expect(queryByTitle('Add node below')).toBeNull();
     });
   });
 

--- a/src/components/RecursiveTreeNode.tsx
+++ b/src/components/RecursiveTreeNode.tsx
@@ -1,4 +1,4 @@
-import { GripVertical } from 'lucide-react';
+import { GripVertical, Plus } from 'lucide-react';
 import type React from 'react';
 import type { DocumentNode, Language } from '../types/document';
 import { ContentBlock } from './ContentBlock';
@@ -32,7 +32,33 @@ interface RecursiveTreeNodeProps {
   editingNumberId: string | null;
   onNumberDoubleClick: (e: React.MouseEvent, id: string) => void;
   onUpdateNumber: (id: string, number: string | null) => void;
+  onAddNodeBefore: (id: string) => void;
+  onAddNodeAfter: (id: string) => void;
 }
+
+const AddNodeButton: React.FC<{
+  position: 'top' | 'bottom';
+  isSelected: boolean;
+  onClick: () => void;
+}> = ({ position, isSelected, onClick }) => (
+  <button
+    className={`
+      absolute ${position === 'top' ? '-top-3' : '-bottom-3'} left-1/2 -translate-x-1/2 z-30
+      w-6 h-6 rounded-lg flex items-center justify-center
+      bg-gray-100 text-gray-400 hover:bg-blue-100 hover:text-blue-600
+      transition-all duration-150 cursor-pointer border border-gray-200
+      ${isSelected ? 'opacity-60 hover:!opacity-100' : 'opacity-0 pointer-events-none'}
+    `}
+    onClick={(e) => {
+      e.stopPropagation();
+      onClick();
+    }}
+    onMouseDown={(e) => e.preventDefault()}
+    title={position === 'top' ? 'Add node above' : 'Add node below'}
+  >
+    <Plus size={12} />
+  </button>
+);
 
 export const RecursiveTreeNode: React.FC<RecursiveTreeNodeProps> = ({
   node,
@@ -63,6 +89,8 @@ export const RecursiveTreeNode: React.FC<RecursiveTreeNodeProps> = ({
   editingNumberId,
   onNumberDoubleClick,
   onUpdateNumber,
+  onAddNodeBefore,
+  onAddNodeAfter,
 }) => {
   // Determine if node has children
   const hasChildren = 'children' in node && node.children.length > 0;
@@ -293,6 +321,8 @@ export const RecursiveTreeNode: React.FC<RecursiveTreeNodeProps> = ({
               editingNumberId={editingNumberId}
               onNumberDoubleClick={onNumberDoubleClick}
               onUpdateNumber={onUpdateNumber}
+              onAddNodeBefore={onAddNodeBefore}
+              onAddNodeAfter={onAddNodeAfter}
             />
           ))}
       </div>
@@ -357,6 +387,22 @@ export const RecursiveTreeNode: React.FC<RecursiveTreeNodeProps> = ({
         </div>
       </div>
 
+      {/* Add node buttons */}
+      {!isEditing && (
+        <AddNodeButton
+          position="top"
+          isSelected={isSelected}
+          onClick={() => onAddNodeBefore(node.id)}
+        />
+      )}
+      {!isEditing && (
+        <AddNodeButton
+          position="bottom"
+          isSelected={isSelected}
+          onClick={() => onAddNodeAfter(node.id)}
+        />
+      )}
+
       {/* Node type indicator */}
       <span
         className={`
@@ -410,6 +456,8 @@ export const RecursiveTreeNode: React.FC<RecursiveTreeNodeProps> = ({
               editingNumberId={editingNumberId}
               onNumberDoubleClick={onNumberDoubleClick}
               onUpdateNumber={onUpdateNumber}
+              onAddNodeBefore={onAddNodeBefore}
+              onAddNodeAfter={onAddNodeAfter}
             />
           ))}
         </div>

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -64,6 +64,7 @@ export function TreeEditor({
     clearSelection,
     moveSelection,
     addNodeAfter,
+    addNodeBefore,
     removeNodes,
     updateNodeContents,
     updateNodeNumber,
@@ -151,6 +152,22 @@ export function TreeEditor({
       moveNodeById(draggedNodeId, dropTarget.id, dropTarget.position);
     }
     handleDragEnd();
+  };
+
+  const handleAddNodeBefore = (id: string) => {
+    const newId = addNodeBefore(id);
+    if (newId) {
+      setEditingId(newId);
+      setTimeout(() => blockRefs.current[newId]?.focus(), 0);
+    }
+  };
+
+  const handleAddNodeAfter = (id: string) => {
+    const newId = addNodeAfter(id);
+    if (newId) {
+      setEditingId(newId);
+      setTimeout(() => blockRefs.current[newId]?.focus(), 0);
+    }
   };
 
   const handleBlockKeyDown = (e: React.KeyboardEvent, id: string) => {
@@ -440,6 +457,8 @@ export function TreeEditor({
                   editingNumberId={editingNumberId}
                   onNumberDoubleClick={handleNumberDblClick}
                   onUpdateNumber={handleUpdateNumber}
+                  onAddNodeBefore={handleAddNodeBefore}
+                  onAddNodeAfter={handleAddNodeAfter}
                 />
               )}
             </div>

--- a/src/hooks/useTreeEditor.ts
+++ b/src/hooks/useTreeEditor.ts
@@ -44,6 +44,7 @@ export const useTreeEditor = (
   // Tree operations
   const {
     addNodeAfter,
+    addNodeBefore,
     removeNodes,
     updateNodeContents,
     updateNodeNumber,
@@ -283,6 +284,7 @@ export const useTreeEditor = (
 
     // Tree operations
     addNodeAfter,
+    addNodeBefore,
     removeNodes,
     updateNodeContents,
     updateNodeNumber,

--- a/src/hooks/useTreeOperations.test.ts
+++ b/src/hooks/useTreeOperations.test.ts
@@ -179,6 +179,88 @@ describe('useTreeOperations', () => {
     });
   });
 
+  describe('addNodeBefore', () => {
+    test('inserts sibling before specified node', () => {
+      const { result } = renderTreeOperations();
+
+      act(() => {
+        result.current.addNodeBefore('h2');
+      });
+
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const h1 = newDoc.children[0] as HeadingDocumentNode;
+
+      // New node should be inserted before h2 (was at index 1, now at index 2)
+      expect(h1.children.length).toBe(3);
+      expect(h1.children[0].id).toBe('p1');
+      expect(h1.children[2].id).toBe('h2');
+      // New node is in the middle
+      const newNode = h1.children[1] as LeafDocumentNode;
+      expect(newNode.type).toBe('content');
+      expect(newNode.contents.de).toBe('');
+    });
+
+    test('creates content node by default', () => {
+      const { result } = renderTreeOperations();
+
+      act(() => {
+        result.current.addNodeBefore('p1');
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const h1 = newDoc.children[0] as HeadingDocumentNode;
+      const newNode = h1.children[0] as LeafDocumentNode;
+      expect(newNode.type).toBe('content');
+      expect(newNode.contents.de).toBe('');
+    });
+
+    test('creates list_item when parent is list', () => {
+      const listDoc = createDocumentWithList();
+      const { result } = renderTreeOperations(listDoc);
+
+      act(() => {
+        result.current.addNodeBefore('li2');
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const h1 = newDoc.children[0] as HeadingDocumentNode;
+      const list = h1.children[0] as ContainerDocumentNode;
+
+      expect(list.children.length).toBe(4);
+      // New item should be at index 1 (before li2 which shifts to index 2)
+      const newItem = list.children[1] as ContainerDocumentNode;
+      expect(newItem.type).toBe('list_item');
+      expect(list.children[2].id).toBe('li2');
+    });
+
+    test('returns the new node ID', () => {
+      const { result } = renderTreeOperations();
+      let newId: string | undefined;
+
+      act(() => {
+        newId = result.current.addNodeBefore('p1');
+      });
+
+      expect(newId).toBeDefined();
+      expect(typeof newId).toBe('string');
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const h1 = newDoc.children[0] as HeadingDocumentNode;
+      expect(h1.children[0].id).toBe(newId);
+    });
+
+    test('does nothing for root node', () => {
+      const { result } = renderTreeOperations();
+
+      act(() => {
+        result.current.addNodeBefore('root');
+      });
+
+      expect(mockCommit).not.toHaveBeenCalled();
+    });
+  });
+
   describe('removeNodes', () => {
     test('removes leaf node', () => {
       const { result } = renderTreeOperations();

--- a/src/hooks/useTreeOperations.ts
+++ b/src/hooks/useTreeOperations.ts
@@ -31,6 +31,34 @@ interface UseTreeOperationsProps {
   language: Language;
 }
 
+/** Create a new empty sibling node appropriate for the given parent. */
+function createNewSiblingNode(parent: DocumentNode, language: Language): DocumentNode {
+  if (parent.type === 'list') {
+    return {
+      id: generateId(),
+      number: null,
+      type: 'list_item',
+      children: [
+        {
+          id: generateId(),
+          number: null,
+          type: 'content',
+          contents: { [language]: '' },
+          children: [],
+        } as ContentDocumentNode,
+      ],
+    } as ContainerDocumentNode;
+  }
+
+  return {
+    id: generateId(),
+    number: null,
+    type: 'content',
+    contents: { [language]: '' },
+    children: [],
+  } as ContentDocumentNode;
+}
+
 export const useTreeOperations = ({
   document,
   commit,
@@ -52,42 +80,36 @@ export const useTreeOperations = ({
 
       if (!parent || !('children' in parent)) return;
 
-      // Determine new node type based on parent context
-      let newNode: DocumentNode;
-
-      if (parent.type === 'list') {
-        // Inside a list, create a list_item (container with child content node)
-        newNode = {
-          id: generateId(),
-          number: null,
-          type: 'list_item',
-          children: [
-            {
-              id: generateId(),
-              number: null,
-              type: 'content',
-              contents: { [language]: '' },
-              children: [],
-            } as ContentDocumentNode,
-          ],
-        } as ContainerDocumentNode;
-      } else {
-        // Default to content node
-        newNode = {
-          id: generateId(),
-          number: null,
-          type: 'content',
-          contents: { [language]: '' },
-          children: [],
-        } as ContentDocumentNode;
-      }
-
+      const newNode = createNewSiblingNode(parent, language);
       const newDoc = insertNodeAtPath(document, parentPath, siblingIndex + 1, newNode);
       commit(newDoc);
 
       return newNode.id;
     },
-    [document, nodeIndex, parentIndex, language, commit]
+    [document, nodeIndex, language, commit]
+  );
+
+  /**
+   * Add a new sibling node before the specified node.
+   */
+  const addNodeBefore = useCallback(
+    (beforeId: string) => {
+      const path = nodeIndex.get(beforeId);
+      if (!path || path.length === 0) return;
+
+      const parentPath = path.slice(0, -1);
+      const siblingIndex = path[path.length - 1];
+      const parent = parentPath.length === 0 ? document : getNodeAtPath(document, parentPath);
+
+      if (!parent || !('children' in parent)) return;
+
+      const newNode = createNewSiblingNode(parent, language);
+      const newDoc = insertNodeAtPath(document, parentPath, siblingIndex, newNode);
+      commit(newDoc);
+
+      return newNode.id;
+    },
+    [document, nodeIndex, language, commit]
   );
 
   /**
@@ -747,6 +769,7 @@ export const useTreeOperations = ({
 
   return {
     addNodeAfter,
+    addNodeBefore,
     removeNodes,
     updateNodeContents,
     updateNodeNumber,


### PR DESCRIPTION
## Summary
- Add `addNodeBefore` operation mirroring existing `addNodeAfter`, with shared `createNewSiblingNode` helper
- Render "+" buttons above/below each selected node (hidden on hover to reduce visual noise in nested trees)
- Clicking a "+" button creates an empty node and enters edit mode immediately

## Test plan
- [x] 5 unit tests for `addNodeBefore` in useTreeOperations
- [x] 3 component tests for "+" button rendering and interaction
- [x] Full test suite passes (410 tests)
- [x] Production build succeeds
- [x] Manual: select a node → "+" buttons appear above/below → click adds empty node in edit mode

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)