### PR TITLE
Replace React Context with useSyncExternalStore for O(1) selection re-renders

### DIFF
--- a/src/components/RecursiveTreeNode.test.tsx
+++ b/src/components/RecursiveTreeNode.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import type React from 'react';
 import { describe, expect, test, vi } from 'vitest';
+import { TreeUIStore } from '../stores/TreeUIStore';
 import type {
   ContainerDocumentNode,
   HeadingDocumentNode,
@@ -10,8 +11,7 @@ import { RecursiveTreeNode } from './RecursiveTreeNode';
 import {
   TreeCallbacksContext,
   type TreeCallbacksContextValue,
-  TreeStateContext,
-  type TreeStateContextValue,
+  TreeUIStoreContext,
 } from './TreeNodeContext';
 
 const createTestNode = (): HeadingDocumentNode => ({
@@ -41,41 +41,17 @@ const defaultCallbacks: TreeCallbacksContextValue = {
   onAddNodeAfter: vi.fn(),
 };
 
-const defaultState: TreeStateContextValue = {
-  selectedIds: new Set<string>(),
-  editingId: null,
-  editingNumberId: null,
-  draggedNodeId: null,
-  dropTarget: null,
-  receivingParentId: null,
-  hoveredHandleId: null,
-};
-
-const defaultProps = {
-  depth: 1,
-  isSelected: false,
-  isEditing: false,
-  isDragging: false,
-  isDropTarget: false,
-  dropPosition: null as 'top' | 'bottom' | null,
-  isEditingNumber: false,
-  isHoveredHandle: false,
-  isReceivingParent: false,
-  isInvalidDrop: false,
-};
-
 function renderWithContext(
   ui: React.ReactElement,
   overrides: {
     callbacks?: Partial<TreeCallbacksContextValue>;
-    state?: Partial<TreeStateContextValue>;
+    store?: TreeUIStore;
   } = {}
 ) {
+  const store = overrides.store ?? new TreeUIStore();
   return render(
     <TreeCallbacksContext.Provider value={{ ...defaultCallbacks, ...overrides.callbacks }}>
-      <TreeStateContext.Provider value={{ ...defaultState, ...overrides.state }}>
-        {ui}
-      </TreeStateContext.Provider>
+      <TreeUIStoreContext.Provider value={store}>{ui}</TreeUIStoreContext.Provider>
     </TreeCallbacksContext.Provider>
   );
 }
@@ -84,15 +60,14 @@ describe('RecursiveTreeNode', () => {
   describe('drop indicator', () => {
     test('shows blue drop indicator when drop is valid', () => {
       const node = createTestNode();
-      const { container } = renderWithContext(
-        <RecursiveTreeNode
-          {...defaultProps}
-          node={node}
-          isDropTarget={true}
-          dropPosition="top"
-          isInvalidDrop={false}
-        />
-      );
+      const store = new TreeUIStore();
+      store.setDraggedNodeId('other');
+      store.setDropTarget({ id: 'h1', position: 'top' });
+      store.setReceivingParentId('parent');
+
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        store,
+      });
 
       const indicator = container.querySelector('.bg-blue-600');
       expect(indicator).not.toBeNull();
@@ -101,15 +76,14 @@ describe('RecursiveTreeNode', () => {
 
     test('shows red drop indicator when drop is invalid', () => {
       const node = createTestNode();
-      const { container } = renderWithContext(
-        <RecursiveTreeNode
-          {...defaultProps}
-          node={node}
-          isDropTarget={true}
-          dropPosition="top"
-          isInvalidDrop={true}
-        />
-      );
+      const store = new TreeUIStore();
+      store.setDraggedNodeId('other');
+      store.setDropTarget({ id: 'h1', position: 'top' });
+      store.setReceivingParentId(null); // no receiving parent = invalid
+
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        store,
+      });
 
       const indicator = container.querySelector('.bg-red-500');
       expect(indicator).not.toBeNull();
@@ -118,15 +92,14 @@ describe('RecursiveTreeNode', () => {
 
     test('shows blue indicator at bottom position when valid', () => {
       const node = createTestNode();
-      const { container } = renderWithContext(
-        <RecursiveTreeNode
-          {...defaultProps}
-          node={node}
-          isDropTarget={true}
-          dropPosition="bottom"
-          isInvalidDrop={false}
-        />
-      );
+      const store = new TreeUIStore();
+      store.setDraggedNodeId('other');
+      store.setDropTarget({ id: 'h1', position: 'bottom' });
+      store.setReceivingParentId('parent');
+
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        store,
+      });
 
       const indicator = container.querySelector('.bg-blue-600');
       expect(indicator).not.toBeNull();
@@ -135,15 +108,14 @@ describe('RecursiveTreeNode', () => {
 
     test('shows red indicator at bottom position when invalid', () => {
       const node = createTestNode();
-      const { container } = renderWithContext(
-        <RecursiveTreeNode
-          {...defaultProps}
-          node={node}
-          isDropTarget={true}
-          dropPosition="bottom"
-          isInvalidDrop={true}
-        />
-      );
+      const store = new TreeUIStore();
+      store.setDraggedNodeId('other');
+      store.setDropTarget({ id: 'h1', position: 'bottom' });
+      store.setReceivingParentId(null);
+
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        store,
+      });
 
       const indicator = container.querySelector('.bg-red-500');
       expect(indicator).not.toBeNull();
@@ -152,9 +124,7 @@ describe('RecursiveTreeNode', () => {
 
     test('does not show indicator when not a drop target', () => {
       const node = createTestNode();
-      const { container } = renderWithContext(
-        <RecursiveTreeNode {...defaultProps} node={node} isDropTarget={false} dropPosition={null} />
-      );
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />);
 
       expect(container.querySelector('.bg-blue-600')).toBeNull();
       expect(container.querySelector('.bg-red-500')).toBeNull();
@@ -170,7 +140,7 @@ describe('RecursiveTreeNode', () => {
         contents: { de: 'Unnumbered Heading' },
         children: [],
       };
-      const { container } = renderWithContext(<RecursiveTreeNode {...defaultProps} node={node} />);
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />);
 
       const placeholder = container.querySelector('.border-dashed');
       expect(placeholder).not.toBeNull();
@@ -185,7 +155,7 @@ describe('RecursiveTreeNode', () => {
         contents: { de: 'Unnumbered Heading' },
         children: [],
       };
-      const { container } = renderWithContext(<RecursiveTreeNode {...defaultProps} node={node} />, {
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
         callbacks: { onNumberDoubleClick },
       });
 
@@ -197,7 +167,7 @@ describe('RecursiveTreeNode', () => {
 
     test('heading with a number still renders a solid badge (not dashed)', () => {
       const node = createTestNode(); // has number: '1'
-      const { container } = renderWithContext(<RecursiveTreeNode {...defaultProps} node={node} />);
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />);
 
       const solidBadge = container.querySelector('.border-blue-200');
       expect(solidBadge).not.toBeNull();
@@ -212,7 +182,7 @@ describe('RecursiveTreeNode', () => {
         type: 'list_item',
         children: [],
       };
-      const { container } = renderWithContext(<RecursiveTreeNode {...defaultProps} node={node} />, {
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
         callbacks: { onNumberDoubleClick },
       });
 
@@ -230,7 +200,7 @@ describe('RecursiveTreeNode', () => {
         type: 'footnote',
         contents: { de: 'A footnote' },
       };
-      const { container } = renderWithContext(<RecursiveTreeNode {...defaultProps} node={node} />);
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />);
 
       const placeholder = container.querySelector('.border-dashed');
       expect(placeholder).not.toBeNull();
@@ -244,7 +214,7 @@ describe('RecursiveTreeNode', () => {
         type: 'footnote',
         contents: { de: 'A footnote' },
       };
-      const { container } = renderWithContext(<RecursiveTreeNode {...defaultProps} node={node} />, {
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
         callbacks: { onNumberDoubleClick },
       });
 
@@ -260,10 +230,13 @@ describe('RecursiveTreeNode', () => {
     test('calls onAddNodeBefore when clicking add-before button', () => {
       const onAddNodeBefore = vi.fn();
       const node = createTestNode();
-      const { getByTitle } = renderWithContext(
-        <RecursiveTreeNode {...defaultProps} node={node} isSelected={true} />,
-        { callbacks: { onAddNodeBefore } }
-      );
+      const store = new TreeUIStore();
+      store.setSelection(new Set(['h1']));
+
+      const { getByTitle } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        callbacks: { onAddNodeBefore },
+        store,
+      });
 
       fireEvent.click(getByTitle('Add node above'));
       expect(onAddNodeBefore).toHaveBeenCalledWith('h1');
@@ -272,10 +245,13 @@ describe('RecursiveTreeNode', () => {
     test('calls onAddNodeAfter when clicking add-after button', () => {
       const onAddNodeAfter = vi.fn();
       const node = createTestNode();
-      const { getByTitle } = renderWithContext(
-        <RecursiveTreeNode {...defaultProps} node={node} isSelected={true} />,
-        { callbacks: { onAddNodeAfter } }
-      );
+      const store = new TreeUIStore();
+      store.setSelection(new Set(['h1']));
+
+      const { getByTitle } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        callbacks: { onAddNodeAfter },
+        store,
+      });
 
       fireEvent.click(getByTitle('Add node below'));
       expect(onAddNodeAfter).toHaveBeenCalledWith('h1');
@@ -283,9 +259,13 @@ describe('RecursiveTreeNode', () => {
 
     test('hides add buttons when editing', () => {
       const node = createTestNode();
-      const { queryByTitle } = renderWithContext(
-        <RecursiveTreeNode {...defaultProps} node={node} isSelected={true} isEditing={true} />
-      );
+      const store = new TreeUIStore();
+      store.setSelection(new Set(['h1']));
+      store.setEditingId('h1');
+
+      const { queryByTitle } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        store,
+      });
 
       expect(queryByTitle('Add node above')).toBeNull();
       expect(queryByTitle('Add node below')).toBeNull();
@@ -303,65 +283,40 @@ describe('RecursiveTreeNode', () => {
       expect(typeof compare).toBe('function');
     });
 
-    test('skips re-render when all props are identical', () => {
+    test('skips re-render when node and depth are identical', () => {
       const compare = (RecursiveTreeNode as any).compare as (a: any, b: any) => boolean;
       const node = createTestNode();
-      const props = { ...defaultProps, node };
+      const props = { node, depth: 1 };
       expect(compare(props, props)).toBe(true);
-    });
-
-    test('triggers re-render when isSelected changes', () => {
-      const compare = (RecursiveTreeNode as any).compare as (a: any, b: any) => boolean;
-      const node = createTestNode();
-      const prev = { ...defaultProps, node };
-      const next = { ...prev, isSelected: true };
-      expect(compare(prev, next)).toBe(false);
-    });
-
-    test('triggers re-render when isEditing changes', () => {
-      const compare = (RecursiveTreeNode as any).compare as (a: any, b: any) => boolean;
-      const node = createTestNode();
-      const prev = { ...defaultProps, node };
-      const next = { ...prev, isEditing: true };
-      expect(compare(prev, next)).toBe(false);
     });
 
     test('triggers re-render when node reference changes', () => {
       const compare = (RecursiveTreeNode as any).compare as (a: any, b: any) => boolean;
-      const prev = { ...defaultProps, node: createTestNode() };
-      const next = { ...defaultProps, node: createTestNode() };
+      const prev = { node: createTestNode(), depth: 1 };
+      const next = { node: createTestNode(), depth: 1 };
       expect(compare(prev, next)).toBe(false);
     });
 
-    test('triggers re-render when isReceivingParent changes', () => {
+    test('triggers re-render when depth changes', () => {
       const compare = (RecursiveTreeNode as any).compare as (a: any, b: any) => boolean;
       const node = createTestNode();
-      const prev = { ...defaultProps, node };
-      const next = { ...prev, isReceivingParent: true };
+      const prev = { node, depth: 1 };
+      const next = { node, depth: 2 };
       expect(compare(prev, next)).toBe(false);
-    });
-
-    test('does not compare selectedIds (no longer a prop)', () => {
-      const compare = (RecursiveTreeNode as any).compare as (a: any, b: any) => boolean;
-      const node = createTestNode();
-      const prev = { ...defaultProps, node, selectedIds: new Set(['a']) };
-      const next = { ...defaultProps, node, selectedIds: new Set(['b']) };
-      expect(compare(prev, next)).toBe(true);
     });
   });
 
   describe('cursor style during drag', () => {
     test('shows not-allowed cursor when drop is invalid', () => {
       const node = createTestNode();
-      const { container } = renderWithContext(
-        <RecursiveTreeNode
-          {...defaultProps}
-          node={node}
-          isDropTarget={true}
-          dropPosition="top"
-          isInvalidDrop={true}
-        />
-      );
+      const store = new TreeUIStore();
+      store.setDraggedNodeId('other');
+      store.setDropTarget({ id: 'h1', position: 'top' });
+      store.setReceivingParentId(null);
+
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        store,
+      });
 
       const nodeElement = container.firstChild as HTMLElement;
       expect(nodeElement.classList.contains('cursor-not-allowed')).toBe(true);
@@ -369,15 +324,14 @@ describe('RecursiveTreeNode', () => {
 
     test('does not show not-allowed cursor when drop is valid', () => {
       const node = createTestNode();
-      const { container } = renderWithContext(
-        <RecursiveTreeNode
-          {...defaultProps}
-          node={node}
-          isDropTarget={true}
-          dropPosition="top"
-          isInvalidDrop={false}
-        />
-      );
+      const store = new TreeUIStore();
+      store.setDraggedNodeId('other');
+      store.setDropTarget({ id: 'h1', position: 'top' });
+      store.setReceivingParentId('parent');
+
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        store,
+      });
 
       const nodeElement = container.firstChild as HTMLElement;
       expect(nodeElement.classList.contains('cursor-not-allowed')).toBe(false);

--- a/src/components/RecursiveTreeNode.tsx
+++ b/src/components/RecursiveTreeNode.tsx
@@ -1,22 +1,14 @@
 import { GripVertical, Plus } from 'lucide-react';
 import type React from 'react';
 import { memo } from 'react';
+import { useNodeState } from '../hooks/useNodeState';
 import type { DocumentNode } from '../types/document';
 import { ContentBlock } from './ContentBlock';
-import { useTreeCallbacks, useTreeState } from './TreeNodeContext';
+import { useTreeCallbacks, useTreeUIStore } from './TreeNodeContext';
 
 interface RecursiveTreeNodeProps {
   node: DocumentNode;
   depth: number;
-  isSelected: boolean;
-  isEditing: boolean;
-  isDragging: boolean;
-  isDropTarget: boolean;
-  dropPosition: 'top' | 'bottom' | null;
-  isEditingNumber: boolean;
-  isHoveredHandle: boolean;
-  isReceivingParent: boolean;
-  isInvalidDrop: boolean;
 }
 
 const AddNodeButton: React.FC<{
@@ -44,48 +36,25 @@ const AddNodeButton: React.FC<{
 );
 
 /**
- * Bridge component that reads global state from context and computes
- * derived boolean props for each child node. This re-renders on every
- * context change (cheap), but RecursiveTreeNode's memo comparator
- * ensures only nodes with actual prop changes re-render (expensive).
+ * Recursive tree node component. Each node subscribes to its own UI state
+ * via useSyncExternalStore (through useNodeState), so only nodes whose
+ * state actually changes will re-render.
  */
-export const TreeNodeBridge: React.FC<{ node: DocumentNode; depth: number }> = ({
-  node,
-  depth,
-}) => {
-  const ctx = useTreeState();
-  const isDropTarget = ctx.dropTarget?.id === node.id;
-  return (
-    <RecursiveTreeNode
-      node={node}
-      depth={depth}
-      isSelected={ctx.selectedIds.has(node.id)}
-      isEditing={ctx.editingId === node.id}
-      isDragging={ctx.draggedNodeId === node.id}
-      isDropTarget={isDropTarget}
-      dropPosition={isDropTarget ? ctx.dropTarget!.position : null}
-      isEditingNumber={ctx.editingNumberId === node.id}
-      isHoveredHandle={ctx.hoveredHandleId === node.id}
-      isReceivingParent={ctx.receivingParentId === node.id}
-      isInvalidDrop={isDropTarget && ctx.draggedNodeId !== null && ctx.receivingParentId === null}
-    />
-  );
-};
-
 export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
-  ({
-    node,
-    depth,
-    isSelected,
-    isEditing,
-    isDragging,
-    isDropTarget,
-    dropPosition,
-    isEditingNumber,
-    isHoveredHandle,
-    isReceivingParent,
-    isInvalidDrop,
-  }) => {
+  ({ node, depth }) => {
+    const store = useTreeUIStore();
+    const {
+      isSelected,
+      isEditing,
+      isDragging,
+      isDropTarget,
+      dropPosition,
+      isEditingNumber,
+      isHoveredHandle,
+      isReceivingParent,
+      isInvalidDrop,
+    } = useNodeState(store, node.id);
+
     const {
       language,
       blockRefs,
@@ -304,7 +273,7 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
         <div className="space-y-1">
           {hasChildren &&
             node.children.map((child) => (
-              <TreeNodeBridge key={child.id} node={child} depth={depth + 1} />
+              <RecursiveTreeNode key={child.id} node={child} depth={depth + 1} />
             ))}
         </div>
       );
@@ -407,23 +376,12 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
             }}
           >
             {node.children.map((child) => (
-              <TreeNodeBridge key={child.id} node={child} depth={depth + 1} />
+              <RecursiveTreeNode key={child.id} node={child} depth={depth + 1} />
             ))}
           </div>
         )}
       </div>
     );
   },
-  (prev, next) =>
-    prev.node === next.node &&
-    prev.depth === next.depth &&
-    prev.isSelected === next.isSelected &&
-    prev.isEditing === next.isEditing &&
-    prev.isDragging === next.isDragging &&
-    prev.isDropTarget === next.isDropTarget &&
-    prev.dropPosition === next.dropPosition &&
-    prev.isEditingNumber === next.isEditingNumber &&
-    prev.isHoveredHandle === next.isHoveredHandle &&
-    prev.isReceivingParent === next.isReceivingParent &&
-    prev.isInvalidDrop === next.isInvalidDrop
+  (prev, next) => prev.node === next.node && prev.depth === next.depth
 );

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -1,6 +1,6 @@
 import { Plus } from 'lucide-react';
 import type React from 'react';
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
 import { useTreeEditor } from '../hooks/useTreeEditor';
 import type { ContainerDocumentNode, Language } from '../types/document';
 import { deriveJsonFilename, downloadFile } from '../utils/document-utils';
@@ -8,7 +8,7 @@ import { FloatingToolbar } from './FloatingToolbar';
 import { RecursiveTreeNode } from './RecursiveTreeNode';
 import { SourcePreview } from './SourcePreview';
 import { Toolbar } from './Toolbar';
-import { TreeCallbacksContext, TreeStateContext } from './TreeNodeContext';
+import { TreeCallbacksContext, TreeUIStoreContext } from './TreeNodeContext';
 
 interface TreeEditorProps {
   initialDocument: ContainerDocumentNode;
@@ -52,13 +52,7 @@ export function TreeEditor({
   const {
     document,
     flattenedNodes,
-    selectedIds,
-    editingId,
-    setEditingId,
-    editingNumberId,
-    setEditingNumberId,
-    draggedNodeId,
-    setDraggedNodeId,
+    store,
     handleNodeClick,
     handleNodeDoubleClick,
     handleNumberDoubleClick,
@@ -84,17 +78,26 @@ export function TreeEditor({
     getReceivingParentId,
   } = useTreeEditor(initialDocument, language);
 
+  // Subscribe to aggregate store values needed at this level
+  const selectedCount = useSyncExternalStore(
+    store.subscribe,
+    useCallback(() => store.getSelectedCount(), [store])
+  );
+  const editingId = useSyncExternalStore(
+    store.subscribe,
+    useCallback(() => store.getEditingId(), [store])
+  );
+  const selectedIds = useSyncExternalStore(
+    store.subscribe,
+    useCallback(() => store.getSelectedIds(), [store])
+  );
+
   const containerRef = useRef<HTMLDivElement>(null);
   const blockRefs = useRef<{ [key: string]: HTMLElement | null }>({});
-  const [dropTarget, setDropTarget] = useState<{ id: string; position: 'top' | 'bottom' } | null>(
-    null
-  );
-  const [hoveredHandleId, setHoveredHandleId] = useState<string | null>(null);
-  const [receivingParentId, setReceivingParentId] = useState<string | null>(null);
 
   // Compute toolbar type for single selected node
   const selectedNodeType = useMemo(() => {
-    if (selectedIds.size !== 1) return null;
+    if (selectedCount !== 1) return null;
     const selectedId = Array.from(selectedIds)[0];
     const flatNode = flattenedNodes.find((fn) => fn.node.id === selectedId);
     if (!flatNode) return null;
@@ -120,35 +123,43 @@ export function TreeEditor({
       return 'ol';
     }
     return null;
-  }, [selectedIds, flattenedNodes]);
+  }, [selectedCount, selectedIds, flattenedNodes]);
 
   const handleDragStart = (e: React.DragEvent, id: string) => {
-    setDraggedNodeId(id);
+    store.setDraggedNodeId(id);
     e.dataTransfer.effectAllowed = 'move';
   };
 
   const handleDragOver = (e: React.DragEvent, id: string) => {
     e.preventDefault();
+    const draggedNodeId = store.getDraggedNodeId();
     if (draggedNodeId === id) return;
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    setDropTarget({ id, position: e.clientY < rect.top + rect.height / 2 ? 'top' : 'bottom' });
+    store.setDropTarget({
+      id,
+      position: e.clientY < rect.top + rect.height / 2 ? 'top' : 'bottom',
+    });
 
     // Compute receiving parent for visual feedback
     if (draggedNodeId) {
       const parentId = getReceivingParentId(draggedNodeId, id);
-      setReceivingParentId(parentId);
+      store.setReceivingParentId(parentId);
     }
   };
 
   const handleDragEnd = () => {
-    setDraggedNodeId(null);
-    setDropTarget(null);
-    setHoveredHandleId(null);
-    setReceivingParentId(null);
+    store.batch(() => {
+      store.setDraggedNodeId(null);
+      store.setDropTarget(null);
+      store.setHoveredHandleId(null);
+      store.setReceivingParentId(null);
+    });
   };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
+    const draggedNodeId = store.getDraggedNodeId();
+    const dropTarget = store.getDropTarget();
     if (draggedNodeId && dropTarget) {
       moveNodeById(draggedNodeId, dropTarget.id, dropTarget.position);
     }
@@ -158,7 +169,7 @@ export function TreeEditor({
   const handleAddNodeBefore = (id: string) => {
     const newId = addNodeBefore(id);
     if (newId) {
-      setEditingId(newId);
+      store.setEditingId(newId);
       setTimeout(() => blockRefs.current[newId]?.focus(), 0);
     }
   };
@@ -166,7 +177,7 @@ export function TreeEditor({
   const handleAddNodeAfter = (id: string) => {
     const newId = addNodeAfter(id);
     if (newId) {
-      setEditingId(newId);
+      store.setEditingId(newId);
       setTimeout(() => blockRefs.current[newId]?.focus(), 0);
     }
   };
@@ -177,7 +188,7 @@ export function TreeEditor({
       const newId = addNodeAfter(id);
       // Focus the newly created node so the user can type in it immediately
       if (newId) {
-        setEditingId(newId);
+        store.setEditingId(newId);
         setTimeout(() => blockRefs.current[newId]?.focus(), 0);
       }
     } else if (e.key === 'Backspace') {
@@ -198,15 +209,16 @@ export function TreeEditor({
       }
     } else if (e.key === 'Escape') {
       e.preventDefault();
+      e.stopPropagation(); // Prevent global handler from also clearing selection
       // Exit edit mode but keep the node selected
-      setEditingId(null);
+      store.setEditingId(null);
       containerRef.current?.focus();
     } else if (e.key === 'ArrowUp' && isCursorAtStart(e.currentTarget as HTMLElement)) {
       const index = flattenedNodes.findIndex((fn) => fn.node.id === id);
       if (index > 0) {
         e.preventDefault();
         const prevId = flattenedNodes[index - 1].node.id;
-        setEditingId(prevId);
+        store.setEditingId(prevId);
         setTimeout(() => {
           const el = blockRefs.current[prevId];
           if (el) {
@@ -224,7 +236,7 @@ export function TreeEditor({
       if (index < flattenedNodes.length - 1) {
         e.preventDefault();
         const nextId = flattenedNodes[index + 1].node.id;
-        setEditingId(nextId);
+        store.setEditingId(nextId);
         setTimeout(() => blockRefs.current[nextId]?.focus(), 0);
       }
     }
@@ -241,9 +253,11 @@ export function TreeEditor({
       redo();
       return;
     }
-    if (editingId) return;
+    const currentEditingId = store.getEditingId();
+    if (currentEditingId) return;
 
-    if (selectedIds.size === 0) {
+    const currentSelectedIds = store.getSelectedIds();
+    if (currentSelectedIds.size === 0) {
       if (flattenedNodes.length > 0 && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
         e.preventDefault();
         moveSelection(e.key === 'ArrowDown' ? 'down' : 'up', false);
@@ -289,10 +303,13 @@ export function TreeEditor({
   };
 
   const handleBulkUpdateType = (toolbarType: string) => {
-    if (selectedIds.size === 0) return;
+    const currentSelectedIds = store.getSelectedIds();
+    if (currentSelectedIds.size === 0) return;
 
     // Sort IDs by flat order for consistent processing
-    const ids = flattenedNodes.filter((fn) => selectedIds.has(fn.node.id)).map((fn) => fn.node.id);
+    const ids = flattenedNodes
+      .filter((fn) => currentSelectedIds.has(fn.node.id))
+      .map((fn) => fn.node.id);
 
     // Map toolbar type to target type and list style
     type ListStyle = 'unordered' | 'numbered' | 'lettered';
@@ -367,7 +384,15 @@ export function TreeEditor({
 
   const handleUpdateNumber = (id: string, number: string | null) => {
     updateNodeNumber(id, number);
-    setEditingNumberId(null);
+    store.setEditingNumberId(null);
+  };
+
+  const handleSetHoveredHandleId = (id: string | null) => {
+    store.setHoveredHandleId(id);
+  };
+
+  const handleSetEditingId = (id: string) => {
+    store.setEditingId(id);
   };
 
   // Ref indirection: callbacks close over changing state, so we store
@@ -380,10 +405,10 @@ export function TreeEditor({
   cbRef.current.handleDragEnd = handleDragEnd;
   cbRef.current.handleClick = handleClick;
   cbRef.current.handleDoubleClick = handleDoubleClick;
-  cbRef.current.setHoveredHandleId = setHoveredHandleId;
+  cbRef.current.setHoveredHandleId = handleSetHoveredHandleId;
   cbRef.current.updateNodeContents = updateNodeContents;
   cbRef.current.handleBlockKeyDown = handleBlockKeyDown;
-  cbRef.current.setEditingId = setEditingId;
+  cbRef.current.setEditingId = handleSetEditingId;
   cbRef.current.handleNumberDblClick = handleNumberDblClick;
   cbRef.current.handleUpdateNumber = handleUpdateNumber;
   cbRef.current.handleAddNodeBefore = handleAddNodeBefore;
@@ -473,37 +498,15 @@ export function TreeEditor({
                 </div>
               ) : (
                 <TreeCallbacksContext.Provider value={callbacksCtx}>
-                  <TreeStateContext.Provider
-                    value={{
-                      selectedIds,
-                      editingId,
-                      editingNumberId,
-                      draggedNodeId,
-                      dropTarget,
-                      receivingParentId,
-                      hoveredHandleId,
-                    }}
-                  >
-                    <RecursiveTreeNode
-                      node={document}
-                      depth={0}
-                      isSelected={false}
-                      isEditing={false}
-                      isDragging={false}
-                      isDropTarget={false}
-                      dropPosition={null}
-                      isEditingNumber={false}
-                      isHoveredHandle={false}
-                      isReceivingParent={false}
-                      isInvalidDrop={false}
-                    />
-                  </TreeStateContext.Provider>
+                  <TreeUIStoreContext.Provider value={store}>
+                    <RecursiveTreeNode node={document} depth={0} />
+                  </TreeUIStoreContext.Provider>
                 </TreeCallbacksContext.Provider>
               )}
             </div>
           </div>
           <FloatingToolbar
-            selectedCount={selectedIds.size}
+            selectedCount={selectedCount}
             isEditing={!!editingId}
             selectedNodeType={selectedNodeType}
             onUpdateType={handleBulkUpdateType}

--- a/src/components/TreeNodeContext.tsx
+++ b/src/components/TreeNodeContext.tsx
@@ -1,11 +1,12 @@
 import type React from 'react';
 import { createContext, useContext } from 'react';
+import type { TreeUIStore } from '../stores/TreeUIStore';
 import type { Language } from '../types/document';
 
 /**
  * Stable context for callbacks and rarely-changing refs.
- * RecursiveTreeNode reads from this — since the value never changes,
- * useContext here does NOT bypass React.memo.
+ * RecursiveTreeNode reads from this — since the value only changes
+ * when `language` changes, useContext here does NOT bypass React.memo.
  */
 export interface TreeCallbacksContextValue {
   language: Language;
@@ -26,22 +27,14 @@ export interface TreeCallbacksContextValue {
   onAddNodeAfter: (id: string) => void;
 }
 
-/**
- * Frequently-changing state context. Only TreeNodeBridge reads from this.
- * RecursiveTreeNode must NEVER use this context directly.
- */
-export interface TreeStateContextValue {
-  selectedIds: Set<string>;
-  editingId: string | null;
-  editingNumberId: string | null;
-  draggedNodeId: string | null;
-  dropTarget: { id: string; position: 'top' | 'bottom' } | null;
-  receivingParentId: string | null;
-  hoveredHandleId: string | null;
-}
-
 export const TreeCallbacksContext = createContext<TreeCallbacksContextValue>(null!);
-export const TreeStateContext = createContext<TreeStateContextValue>(null!);
+
+/**
+ * Stable context holding the TreeUIStore instance.
+ * The store reference never changes — individual nodes subscribe
+ * to their own state via useSyncExternalStore in useNodeState().
+ */
+export const TreeUIStoreContext = createContext<TreeUIStore>(null!);
 
 export const useTreeCallbacks = () => useContext(TreeCallbacksContext);
-export const useTreeState = () => useContext(TreeStateContext);
+export const useTreeUIStore = () => useContext(TreeUIStoreContext);

--- a/src/hooks/useNodeState.test.ts
+++ b/src/hooks/useNodeState.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TreeUIStore } from '../stores/TreeUIStore';
+import { useNodeState } from './useNodeState';
+
+describe('useNodeState', () => {
+  it('returns initial state for a node', () => {
+    const store = new TreeUIStore();
+    const { result } = renderHook(() => useNodeState(store, 'node-1'));
+
+    expect(result.current.isSelected).toBe(false);
+    expect(result.current.isEditing).toBe(false);
+    expect(result.current.isDragging).toBe(false);
+    expect(result.current.isDropTarget).toBe(false);
+    expect(result.current.dropPosition).toBeNull();
+    expect(result.current.isEditingNumber).toBe(false);
+    expect(result.current.isHoveredHandle).toBe(false);
+    expect(result.current.isReceivingParent).toBe(false);
+    expect(result.current.isInvalidDrop).toBe(false);
+  });
+
+  it('reflects selection changes', () => {
+    const store = new TreeUIStore();
+    const { result } = renderHook(() => useNodeState(store, 'node-1'));
+
+    act(() => store.setSelection(new Set(['node-1'])));
+    expect(result.current.isSelected).toBe(true);
+
+    act(() => store.setSelection(new Set(['node-2'])));
+    expect(result.current.isSelected).toBe(false);
+  });
+
+  it('reflects editing changes', () => {
+    const store = new TreeUIStore();
+    const { result } = renderHook(() => useNodeState(store, 'node-1'));
+
+    act(() => store.setEditingId('node-1'));
+    expect(result.current.isEditing).toBe(true);
+
+    act(() => store.setEditingId(null));
+    expect(result.current.isEditing).toBe(false);
+  });
+
+  it('reflects drop target with position', () => {
+    const store = new TreeUIStore();
+    const { result } = renderHook(() => useNodeState(store, 'node-1'));
+
+    act(() => store.setDropTarget({ id: 'node-1', position: 'bottom' }));
+    expect(result.current.isDropTarget).toBe(true);
+    expect(result.current.dropPosition).toBe('bottom');
+
+    act(() => store.setDropTarget(null));
+    expect(result.current.isDropTarget).toBe(false);
+    expect(result.current.dropPosition).toBeNull();
+  });
+
+  it('reflects invalid drop state', () => {
+    const store = new TreeUIStore();
+    const { result } = renderHook(() => useNodeState(store, 'node-1'));
+
+    act(() => {
+      store.batch(() => {
+        store.setDraggedNodeId('other');
+        store.setDropTarget({ id: 'node-1', position: 'top' });
+        store.setReceivingParentId(null);
+      });
+    });
+    expect(result.current.isInvalidDrop).toBe(true);
+
+    act(() => store.setReceivingParentId('parent'));
+    expect(result.current.isInvalidDrop).toBe(false);
+  });
+
+  it('different nodes get independent state', () => {
+    const store = new TreeUIStore();
+    const { result: r1 } = renderHook(() => useNodeState(store, 'a'));
+    const { result: r2 } = renderHook(() => useNodeState(store, 'b'));
+
+    act(() => store.setSelection(new Set(['a'])));
+    expect(r1.current.isSelected).toBe(true);
+    expect(r2.current.isSelected).toBe(false);
+  });
+});

--- a/src/hooks/useNodeState.ts
+++ b/src/hooks/useNodeState.ts
@@ -1,0 +1,55 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import type { TreeUIStore } from '../stores/TreeUIStore';
+
+export function useNodeState(store: TreeUIStore, id: string) {
+  const subscribe = store.subscribe;
+
+  const isSelected = useSyncExternalStore(
+    subscribe,
+    useCallback(() => store.isSelected(id), [store, id])
+  );
+  const isEditing = useSyncExternalStore(
+    subscribe,
+    useCallback(() => store.isEditing(id), [store, id])
+  );
+  const isEditingNumber = useSyncExternalStore(
+    subscribe,
+    useCallback(() => store.isEditingNumber(id), [store, id])
+  );
+  const isDragging = useSyncExternalStore(
+    subscribe,
+    useCallback(() => store.isDragging(id), [store, id])
+  );
+  const isDropTarget = useSyncExternalStore(
+    subscribe,
+    useCallback(() => store.isDropTarget(id), [store, id])
+  );
+  const dropPosition = useSyncExternalStore(
+    subscribe,
+    useCallback(() => store.getDropPosition(id), [store, id])
+  );
+  const isHoveredHandle = useSyncExternalStore(
+    subscribe,
+    useCallback(() => store.isHoveredHandle(id), [store, id])
+  );
+  const isReceivingParent = useSyncExternalStore(
+    subscribe,
+    useCallback(() => store.isReceivingParent(id), [store, id])
+  );
+  const isInvalidDrop = useSyncExternalStore(
+    subscribe,
+    useCallback(() => store.isInvalidDrop(id), [store, id])
+  );
+
+  return {
+    isSelected,
+    isEditing,
+    isEditingNumber,
+    isDragging,
+    isDropTarget,
+    dropPosition,
+    isHoveredHandle,
+    isReceivingParent,
+    isInvalidDrop,
+  };
+}

--- a/src/hooks/useTreeEditor.test.ts
+++ b/src/hooks/useTreeEditor.test.ts
@@ -57,8 +57,8 @@ describe('useTreeEditor', () => {
     const doc = createTestDocument();
     const { result } = renderHook(() => useTreeEditor(doc));
 
-    expect(result.current.selectedIds.size).toBe(0);
-    expect(result.current.editingId).toBeNull();
+    expect(result.current.store.getSelectedIds().size).toBe(0);
+    expect(result.current.store.getEditingId()).toBeNull();
   });
 
   test('handleNodeClick selects single node', () => {
@@ -69,8 +69,8 @@ describe('useTreeEditor', () => {
       result.current.handleNodeClick('p1', { shiftKey: false, ctrlKey: false, metaKey: false });
     });
 
-    expect(result.current.selectedIds.size).toBe(1);
-    expect(result.current.selectedIds.has('p1')).toBe(true);
+    expect(result.current.store.getSelectedIds().size).toBe(1);
+    expect(result.current.store.getSelectedIds().has('p1')).toBe(true);
   });
 
   test('handleNodeClick with ctrl/meta toggles selection', () => {
@@ -87,18 +87,18 @@ describe('useTreeEditor', () => {
       result.current.handleNodeClick('p2', { shiftKey: false, ctrlKey: true, metaKey: false });
     });
 
-    expect(result.current.selectedIds.size).toBe(2);
-    expect(result.current.selectedIds.has('p1')).toBe(true);
-    expect(result.current.selectedIds.has('p2')).toBe(true);
+    expect(result.current.store.getSelectedIds().size).toBe(2);
+    expect(result.current.store.getSelectedIds().has('p1')).toBe(true);
+    expect(result.current.store.getSelectedIds().has('p2')).toBe(true);
 
     // Ctrl+click p1 again - should remove from selection
     act(() => {
       result.current.handleNodeClick('p1', { shiftKey: false, ctrlKey: true, metaKey: false });
     });
 
-    expect(result.current.selectedIds.size).toBe(1);
-    expect(result.current.selectedIds.has('p1')).toBe(false);
-    expect(result.current.selectedIds.has('p2')).toBe(true);
+    expect(result.current.store.getSelectedIds().size).toBe(1);
+    expect(result.current.store.getSelectedIds().has('p1')).toBe(false);
+    expect(result.current.store.getSelectedIds().has('p2')).toBe(true);
   });
 
   test('handleNodeClick with shift selects range', () => {
@@ -116,10 +116,10 @@ describe('useTreeEditor', () => {
     });
 
     // Should select h1, p1, p2 (all nodes in flat order between anchor and target)
-    expect(result.current.selectedIds.size).toBe(3);
-    expect(result.current.selectedIds.has('h1')).toBe(true);
-    expect(result.current.selectedIds.has('p1')).toBe(true);
-    expect(result.current.selectedIds.has('p2')).toBe(true);
+    expect(result.current.store.getSelectedIds().size).toBe(3);
+    expect(result.current.store.getSelectedIds().has('h1')).toBe(true);
+    expect(result.current.store.getSelectedIds().has('p1')).toBe(true);
+    expect(result.current.store.getSelectedIds().has('p2')).toBe(true);
   });
 
   test('handleNodeDoubleClick enters edit mode', () => {
@@ -130,8 +130,8 @@ describe('useTreeEditor', () => {
       result.current.handleNodeDoubleClick('p1');
     });
 
-    expect(result.current.editingId).toBe('p1');
-    expect(result.current.selectedIds.has('p1')).toBe(true);
+    expect(result.current.store.getEditingId()).toBe('p1');
+    expect(result.current.store.getSelectedIds().has('p1')).toBe(true);
   });
 
   test('clearSelection clears all selection', () => {
@@ -146,14 +146,14 @@ describe('useTreeEditor', () => {
       result.current.handleNodeClick('p2', { shiftKey: false, ctrlKey: true, metaKey: false });
     });
 
-    expect(result.current.selectedIds.size).toBe(2);
+    expect(result.current.store.getSelectedIds().size).toBe(2);
 
     // Clear selection
     act(() => {
       result.current.clearSelection();
     });
 
-    expect(result.current.selectedIds.size).toBe(0);
+    expect(result.current.store.getSelectedIds().size).toBe(0);
   });
 
   test('setEditingId sets and clears edit mode', () => {
@@ -161,16 +161,16 @@ describe('useTreeEditor', () => {
     const { result } = renderHook(() => useTreeEditor(doc));
 
     act(() => {
-      result.current.setEditingId('p1');
+      result.current.store.setEditingId('p1');
     });
 
-    expect(result.current.editingId).toBe('p1');
+    expect(result.current.store.getEditingId()).toBe('p1');
 
     act(() => {
-      result.current.setEditingId(null);
+      result.current.store.setEditingId(null);
     });
 
-    expect(result.current.editingId).toBeNull();
+    expect(result.current.store.getEditingId()).toBeNull();
   });
 
   test('integrates operations with history', () => {
@@ -244,16 +244,16 @@ describe('useTreeEditor', () => {
     act(() => {
       result.current.handleNodeDoubleClick('p1');
     });
-    expect(result.current.editingId).toBe('p1');
+    expect(result.current.store.getEditingId()).toBe('p1');
 
     // Now double-click a number
     act(() => {
       result.current.handleNumberDoubleClick('h1');
     });
 
-    expect(result.current.editingNumberId).toBe('h1');
-    expect(result.current.editingId).toBeNull();
-    expect(result.current.selectedIds.has('h1')).toBe(true);
+    expect(result.current.store.getEditingNumberId()).toBe('h1');
+    expect(result.current.store.getEditingId()).toBeNull();
+    expect(result.current.store.getSelectedIds().has('h1')).toBe(true);
   });
 
   test('handleNodeDoubleClick clears editingNumberId', () => {
@@ -264,15 +264,15 @@ describe('useTreeEditor', () => {
     act(() => {
       result.current.handleNumberDoubleClick('h1');
     });
-    expect(result.current.editingNumberId).toBe('h1');
+    expect(result.current.store.getEditingNumberId()).toBe('h1');
 
     // Now double-click content
     act(() => {
       result.current.handleNodeDoubleClick('p1');
     });
 
-    expect(result.current.editingNumberId).toBeNull();
-    expect(result.current.editingId).toBe('p1');
+    expect(result.current.store.getEditingNumberId()).toBeNull();
+    expect(result.current.store.getEditingId()).toBe('p1');
   });
 
   test('clearSelection clears editingNumberId', () => {
@@ -282,13 +282,13 @@ describe('useTreeEditor', () => {
     act(() => {
       result.current.handleNumberDoubleClick('h1');
     });
-    expect(result.current.editingNumberId).toBe('h1');
+    expect(result.current.store.getEditingNumberId()).toBe('h1');
 
     act(() => {
       result.current.clearSelection();
     });
 
-    expect(result.current.editingNumberId).toBeNull();
+    expect(result.current.store.getEditingNumberId()).toBeNull();
   });
 
   test('exposes getReceivingParentId', () => {
@@ -345,7 +345,7 @@ describe('useTreeEditor', () => {
       result.current.handleNodeClick('p2', { shiftKey: false, ctrlKey: true, metaKey: false });
     });
 
-    expect(result.current.selectedIds.size).toBe(2);
+    expect(result.current.store.getSelectedIds().size).toBe(2);
 
     // Indent selected
     act(() => {
@@ -373,7 +373,7 @@ describe('useTreeEditor', () => {
       result.current.handleNodeClick('p2', { shiftKey: false, ctrlKey: true, metaKey: false });
     });
 
-    expect(result.current.selectedIds.size).toBe(2);
+    expect(result.current.store.getSelectedIds().size).toBe(2);
 
     // Outdent selected
     act(() => {

--- a/src/hooks/useTreeEditor.ts
+++ b/src/hooks/useTreeEditor.ts
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
+import { TreeUIStore } from '../stores/TreeUIStore';
 import type { ContainerDocumentNode, Language } from '../types/document';
 import type { FlattenedNode } from '../types/editor';
 import { DEFAULT_LANGUAGE } from '../utils/document-utils';
@@ -31,15 +32,12 @@ export const useTreeEditor = (
     parentIndex,
   } = useTreeHistory(initialDocument);
 
-  // Selection state
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editingNumberId, setEditingNumberId] = useState<string | null>(null);
+  // UI state store (stable reference, never changes)
+  const store = useRef(new TreeUIStore()).current;
+
+  // Refs for selection anchoring
   const anchorId = useRef<string | null>(null);
   const lastSelectedId = useRef<string | null>(null);
-
-  // Drag state
-  const [draggedNodeId, setDraggedNodeId] = useState<string | null>(null);
 
   // Tree operations
   const {
@@ -95,69 +93,81 @@ export const useTreeEditor = (
             rangeIds.add(flattenedNodes[i].node.id);
           }
 
-          setSelectedIds(rangeIds);
+          store.setSelection(rangeIds);
           lastSelectedId.current = id;
         }
       } else if (ctrlKey || metaKey) {
         // Toggle selection
-        setSelectedIds((prev) => {
-          const next = new Set(prev);
-          if (next.has(id)) {
-            next.delete(id);
-          } else {
-            next.add(id);
-          }
-          return next;
-        });
+        const prev = store.getSelectedIds();
+        const next = new Set(prev);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        store.setSelection(next);
         lastSelectedId.current = id;
         anchorId.current = id;
       } else {
         // Single selection
-        setSelectedIds(new Set([id]));
+        store.setSelection(new Set([id]));
         lastSelectedId.current = id;
         anchorId.current = id;
       }
 
       // Clear edit mode on click (unless double-click handles it)
-      if (editingId && editingId !== id) {
-        setEditingId(null);
+      const currentEditingId = store.getEditingId();
+      if (currentEditingId && currentEditingId !== id) {
+        store.setEditingId(null);
       }
     },
-    [flattenedNodes, nodeIdToFlatIndex, editingId]
+    [flattenedNodes, nodeIdToFlatIndex, store]
   );
 
   /**
    * Handle double click to enter edit mode.
    */
-  const handleNodeDoubleClick = useCallback((id: string) => {
-    setEditingNumberId(null);
-    setSelectedIds(new Set([id]));
-    setEditingId(id);
-    lastSelectedId.current = id;
-    anchorId.current = id;
-  }, []);
+  const handleNodeDoubleClick = useCallback(
+    (id: string) => {
+      store.batch(() => {
+        store.setEditingNumberId(null);
+        store.setSelection(new Set([id]));
+        store.setEditingId(id);
+      });
+      lastSelectedId.current = id;
+      anchorId.current = id;
+    },
+    [store]
+  );
 
   /**
    * Handle double click on a node's number to enter number edit mode.
    */
-  const handleNumberDoubleClick = useCallback((id: string) => {
-    setEditingId(null);
-    setEditingNumberId(id);
-    setSelectedIds(new Set([id]));
-    lastSelectedId.current = id;
-    anchorId.current = id;
-  }, []);
+  const handleNumberDoubleClick = useCallback(
+    (id: string) => {
+      store.batch(() => {
+        store.setEditingId(null);
+        store.setEditingNumberId(id);
+        store.setSelection(new Set([id]));
+      });
+      lastSelectedId.current = id;
+      anchorId.current = id;
+    },
+    [store]
+  );
 
   /**
    * Clear all selection.
    */
   const clearSelection = useCallback(() => {
-    setSelectedIds(new Set());
-    setEditingId(null);
-    setEditingNumberId(null);
+    store.batch(() => {
+      store.setSelection(new Set());
+      store.setEditingId(null);
+      store.setEditingNumberId(null);
+    });
     lastSelectedId.current = null;
     anchorId.current = null;
-  }, []);
+  }, [store]);
 
   /**
    * Move selection up or down.
@@ -173,7 +183,7 @@ export const useTreeEditor = (
           direction === 'down'
             ? flattenedNodes[0].node.id
             : flattenedNodes[flattenedNodes.length - 1].node.id;
-        setSelectedIds(new Set([newId]));
+        store.setSelection(new Set([newId]));
         lastSelectedId.current = newId;
         anchorId.current = newId;
         return;
@@ -203,33 +213,35 @@ export const useTreeEditor = (
             rangeIds.add(flattenedNodes[i].node.id);
           }
 
-          setSelectedIds(rangeIds);
+          store.setSelection(rangeIds);
         }
       } else {
-        setSelectedIds(new Set([newId]));
+        store.setSelection(new Set([newId]));
         anchorId.current = newId;
       }
 
       lastSelectedId.current = newId;
     },
-    [flattenedNodes, nodeIdToFlatIndex]
+    [flattenedNodes, nodeIdToFlatIndex, store]
   );
 
   /**
    * Delete selected nodes.
    */
   const deleteSelected = useCallback(() => {
+    const selectedIds = store.getSelectedIds();
     if (selectedIds.size === 0) return;
 
     const ids = [...selectedIds].filter((id) => nodeIdToFlatIndex.has(id));
     removeNodes(ids);
     clearSelection();
-  }, [selectedIds, nodeIdToFlatIndex, removeNodes, clearSelection]);
+  }, [store, nodeIdToFlatIndex, removeNodes, clearSelection]);
 
   /**
    * Indent selected nodes (Tab).
    */
   const indentSelected = useCallback(() => {
+    const selectedIds = store.getSelectedIds();
     if (selectedIds.size === 0) return;
 
     // Process nodes in flat order
@@ -240,12 +252,13 @@ export const useTreeEditor = (
       .map((item) => item.id);
 
     indentNodes(sortedIds);
-  }, [selectedIds, nodeIdToFlatIndex, indentNodes]);
+  }, [store, nodeIdToFlatIndex, indentNodes]);
 
   /**
    * Outdent selected nodes (Shift+Tab).
    */
   const outdentSelected = useCallback(() => {
+    const selectedIds = store.getSelectedIds();
     if (selectedIds.size === 0) return;
 
     // Sort in flat order; outdentNodes handles reverse processing internally
@@ -256,7 +269,7 @@ export const useTreeEditor = (
       .map((item) => item.id);
 
     outdentNodes(sortedIds);
-  }, [selectedIds, nodeIdToFlatIndex, outdentNodes]);
+  }, [store, nodeIdToFlatIndex, outdentNodes]);
 
   return {
     // Document state
@@ -264,16 +277,8 @@ export const useTreeEditor = (
     flattenedNodes,
     language,
 
-    // Selection state
-    selectedIds,
-    editingId,
-    setEditingId,
-    editingNumberId,
-    setEditingNumberId,
-
-    // Drag state
-    draggedNodeId,
-    setDraggedNodeId,
+    // UI state store
+    store,
 
     // Selection actions
     handleNodeClick,

--- a/src/stores/TreeUIStore.test.ts
+++ b/src/stores/TreeUIStore.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TreeUIStore } from './TreeUIStore';
+
+describe('TreeUIStore', () => {
+  describe('subscription', () => {
+    it('notifies listeners on state change', () => {
+      const store = new TreeUIStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.setSelection(new Set(['a']));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns unsubscribe function', () => {
+      const store = new TreeUIStore();
+      const listener = vi.fn();
+      const unsub = store.subscribe(listener);
+
+      unsub();
+      store.setSelection(new Set(['a']));
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('supports multiple listeners', () => {
+      const store = new TreeUIStore();
+      const l1 = vi.fn();
+      const l2 = vi.fn();
+      store.subscribe(l1);
+      store.subscribe(l2);
+
+      store.setSelection(new Set(['a']));
+      expect(l1).toHaveBeenCalledTimes(1);
+      expect(l2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('selection', () => {
+    it('starts with empty selection', () => {
+      const store = new TreeUIStore();
+      expect(store.isSelected('a')).toBe(false);
+      expect(store.getSelectedIds().size).toBe(0);
+    });
+
+    it('setSelection updates selected state', () => {
+      const store = new TreeUIStore();
+      store.setSelection(new Set(['a', 'b']));
+
+      expect(store.isSelected('a')).toBe(true);
+      expect(store.isSelected('b')).toBe(true);
+      expect(store.isSelected('c')).toBe(false);
+    });
+
+    it('setSelection replaces previous selection', () => {
+      const store = new TreeUIStore();
+      store.setSelection(new Set(['a']));
+      store.setSelection(new Set(['b']));
+
+      expect(store.isSelected('a')).toBe(false);
+      expect(store.isSelected('b')).toBe(true);
+    });
+
+    it('getSelectedIds returns current set', () => {
+      const store = new TreeUIStore();
+      const ids = new Set(['x', 'y']);
+      store.setSelection(ids);
+
+      expect(store.getSelectedIds()).toEqual(new Set(['x', 'y']));
+    });
+
+    it('getSelectedCount returns count', () => {
+      const store = new TreeUIStore();
+      store.setSelection(new Set(['a', 'b', 'c']));
+      expect(store.getSelectedCount()).toBe(3);
+    });
+  });
+
+  describe('editingId', () => {
+    it('starts as null', () => {
+      const store = new TreeUIStore();
+      expect(store.isEditing('a')).toBe(false);
+      expect(store.getEditingId()).toBeNull();
+    });
+
+    it('setEditingId updates editing state', () => {
+      const store = new TreeUIStore();
+      store.setEditingId('a');
+
+      expect(store.isEditing('a')).toBe(true);
+      expect(store.isEditing('b')).toBe(false);
+      expect(store.getEditingId()).toBe('a');
+    });
+
+    it('setEditingId(null) clears editing', () => {
+      const store = new TreeUIStore();
+      store.setEditingId('a');
+      store.setEditingId(null);
+
+      expect(store.isEditing('a')).toBe(false);
+      expect(store.getEditingId()).toBeNull();
+    });
+  });
+
+  describe('editingNumberId', () => {
+    it('starts as null', () => {
+      const store = new TreeUIStore();
+      expect(store.isEditingNumber('a')).toBe(false);
+      expect(store.getEditingNumberId()).toBeNull();
+    });
+
+    it('setEditingNumberId updates state', () => {
+      const store = new TreeUIStore();
+      store.setEditingNumberId('a');
+
+      expect(store.isEditingNumber('a')).toBe(true);
+      expect(store.isEditingNumber('b')).toBe(false);
+    });
+  });
+
+  describe('draggedNodeId', () => {
+    it('starts as null', () => {
+      const store = new TreeUIStore();
+      expect(store.isDragging('a')).toBe(false);
+      expect(store.getDraggedNodeId()).toBeNull();
+    });
+
+    it('setDraggedNodeId updates state', () => {
+      const store = new TreeUIStore();
+      store.setDraggedNodeId('a');
+
+      expect(store.isDragging('a')).toBe(true);
+      expect(store.isDragging('b')).toBe(false);
+      expect(store.getDraggedNodeId()).toBe('a');
+    });
+  });
+
+  describe('dropTarget', () => {
+    it('starts as null', () => {
+      const store = new TreeUIStore();
+      expect(store.isDropTarget('a')).toBe(false);
+      expect(store.getDropPosition('a')).toBeNull();
+      expect(store.getDropTarget()).toBeNull();
+    });
+
+    it('setDropTarget updates state', () => {
+      const store = new TreeUIStore();
+      store.setDropTarget({ id: 'a', position: 'top' });
+
+      expect(store.isDropTarget('a')).toBe(true);
+      expect(store.isDropTarget('b')).toBe(false);
+      expect(store.getDropPosition('a')).toBe('top');
+      expect(store.getDropPosition('b')).toBeNull();
+    });
+
+    it('setDropTarget(null) clears', () => {
+      const store = new TreeUIStore();
+      store.setDropTarget({ id: 'a', position: 'bottom' });
+      store.setDropTarget(null);
+
+      expect(store.isDropTarget('a')).toBe(false);
+    });
+  });
+
+  describe('receivingParentId', () => {
+    it('starts as null', () => {
+      const store = new TreeUIStore();
+      expect(store.isReceivingParent('a')).toBe(false);
+    });
+
+    it('setReceivingParentId updates state', () => {
+      const store = new TreeUIStore();
+      store.setReceivingParentId('a');
+
+      expect(store.isReceivingParent('a')).toBe(true);
+      expect(store.isReceivingParent('b')).toBe(false);
+    });
+  });
+
+  describe('hoveredHandleId', () => {
+    it('starts as null', () => {
+      const store = new TreeUIStore();
+      expect(store.isHoveredHandle('a')).toBe(false);
+    });
+
+    it('setHoveredHandleId updates state', () => {
+      const store = new TreeUIStore();
+      store.setHoveredHandleId('a');
+
+      expect(store.isHoveredHandle('a')).toBe(true);
+      expect(store.isHoveredHandle('b')).toBe(false);
+    });
+  });
+
+  describe('isInvalidDrop', () => {
+    it('returns false when no drop target', () => {
+      const store = new TreeUIStore();
+      expect(store.isInvalidDrop('a')).toBe(false);
+    });
+
+    it('returns false when drop target but has receiving parent', () => {
+      const store = new TreeUIStore();
+      store.setDraggedNodeId('x');
+      store.setDropTarget({ id: 'a', position: 'top' });
+      store.setReceivingParentId('parent');
+
+      expect(store.isInvalidDrop('a')).toBe(false);
+    });
+
+    it('returns true when drop target, dragging, but no receiving parent', () => {
+      const store = new TreeUIStore();
+      store.setDraggedNodeId('x');
+      store.setDropTarget({ id: 'a', position: 'top' });
+      store.setReceivingParentId(null);
+
+      expect(store.isInvalidDrop('a')).toBe(true);
+    });
+
+    it('returns false for non-target nodes', () => {
+      const store = new TreeUIStore();
+      store.setDraggedNodeId('x');
+      store.setDropTarget({ id: 'a', position: 'top' });
+      store.setReceivingParentId(null);
+
+      expect(store.isInvalidDrop('b')).toBe(false);
+    });
+  });
+
+  describe('batch updates', () => {
+    it('batch only notifies once', () => {
+      const store = new TreeUIStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.batch(() => {
+        store.setSelection(new Set(['a']));
+        store.setEditingId('a');
+      });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(store.isSelected('a')).toBe(true);
+      expect(store.isEditing('a')).toBe(true);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('resets all state', () => {
+      const store = new TreeUIStore();
+      store.setSelection(new Set(['a']));
+      store.setEditingId('b');
+      store.setEditingNumberId('c');
+      store.setDraggedNodeId('d');
+      store.setDropTarget({ id: 'e', position: 'top' });
+      store.setReceivingParentId('f');
+      store.setHoveredHandleId('g');
+
+      store.clearAll();
+
+      expect(store.getSelectedIds().size).toBe(0);
+      expect(store.getEditingId()).toBeNull();
+      expect(store.getEditingNumberId()).toBeNull();
+      expect(store.getDraggedNodeId()).toBeNull();
+      expect(store.getDropTarget()).toBeNull();
+      expect(store.isReceivingParent('f')).toBe(false);
+      expect(store.isHoveredHandle('g')).toBe(false);
+    });
+  });
+});

--- a/src/stores/TreeUIStore.ts
+++ b/src/stores/TreeUIStore.ts
@@ -1,0 +1,149 @@
+type Listener = () => void;
+
+export class TreeUIStore {
+  private _selectedIds = new Set<string>();
+  private _editingId: string | null = null;
+  private _editingNumberId: string | null = null;
+  private _draggedNodeId: string | null = null;
+  private _dropTarget: { id: string; position: 'top' | 'bottom' } | null = null;
+  private _receivingParentId: string | null = null;
+  private _hoveredHandleId: string | null = null;
+  private _listeners = new Set<Listener>();
+  private _batching = false;
+  private _batchDirty = false;
+
+  subscribe = (listener: Listener): (() => void) => {
+    this._listeners.add(listener);
+    return () => this._listeners.delete(listener);
+  };
+
+  private _notify(): void {
+    if (this._batching) {
+      this._batchDirty = true;
+      return;
+    }
+    for (const l of this._listeners) l();
+  }
+
+  batch(fn: () => void): void {
+    this._batching = true;
+    this._batchDirty = false;
+    fn();
+    this._batching = false;
+    if (this._batchDirty) {
+      this._batchDirty = false;
+      for (const l of this._listeners) l();
+    }
+  }
+
+  // --- Selection ---
+  isSelected(id: string): boolean {
+    return this._selectedIds.has(id);
+  }
+  getSelectedIds(): Set<string> {
+    return this._selectedIds;
+  }
+  getSelectedCount(): number {
+    return this._selectedIds.size;
+  }
+  setSelection(ids: Set<string>): void {
+    this._selectedIds = ids;
+    this._notify();
+  }
+
+  // --- Editing ---
+  isEditing(id: string): boolean {
+    return this._editingId === id;
+  }
+  getEditingId(): string | null {
+    return this._editingId;
+  }
+  setEditingId(id: string | null): void {
+    this._editingId = id;
+    this._notify();
+  }
+
+  // --- Editing number ---
+  isEditingNumber(id: string): boolean {
+    return this._editingNumberId === id;
+  }
+  getEditingNumberId(): string | null {
+    return this._editingNumberId;
+  }
+  setEditingNumberId(id: string | null): void {
+    this._editingNumberId = id;
+    this._notify();
+  }
+
+  // --- Dragging ---
+  isDragging(id: string): boolean {
+    return this._draggedNodeId === id;
+  }
+  getDraggedNodeId(): string | null {
+    return this._draggedNodeId;
+  }
+  setDraggedNodeId(id: string | null): void {
+    this._draggedNodeId = id;
+    this._notify();
+  }
+
+  // --- Drop target ---
+  isDropTarget(id: string): boolean {
+    return this._dropTarget?.id === id;
+  }
+  getDropPosition(id: string): 'top' | 'bottom' | null {
+    return this._dropTarget?.id === id ? this._dropTarget.position : null;
+  }
+  getDropTarget(): { id: string; position: 'top' | 'bottom' } | null {
+    return this._dropTarget;
+  }
+  setDropTarget(target: { id: string; position: 'top' | 'bottom' } | null): void {
+    this._dropTarget = target;
+    this._notify();
+  }
+
+  // --- Receiving parent ---
+  isReceivingParent(id: string): boolean {
+    return this._receivingParentId === id;
+  }
+  getReceivingParentId(): string | null {
+    return this._receivingParentId;
+  }
+  setReceivingParentId(id: string | null): void {
+    this._receivingParentId = id;
+    this._notify();
+  }
+
+  // --- Hovered handle ---
+  isHoveredHandle(id: string): boolean {
+    return this._hoveredHandleId === id;
+  }
+  getHoveredHandleId(): string | null {
+    return this._hoveredHandleId;
+  }
+  setHoveredHandleId(id: string | null): void {
+    this._hoveredHandleId = id;
+    this._notify();
+  }
+
+  // --- Derived ---
+  isInvalidDrop(id: string): boolean {
+    return (
+      this._dropTarget?.id === id &&
+      this._draggedNodeId !== null &&
+      this._receivingParentId === null
+    );
+  }
+
+  // --- Clear all ---
+  clearAll(): void {
+    this._selectedIds = new Set();
+    this._editingId = null;
+    this._editingNumberId = null;
+    this._draggedNodeId = null;
+    this._dropTarget = null;
+    this._receivingParentId = null;
+    this._hoveredHandleId = null;
+    this._notify();
+  }
+}


### PR DESCRIPTION
## Summary

Improves #41 — reduces CPU spikes on node selection/deselection by replacing React Context-based state propagation with `useSyncExternalStore`.

- Introduces `TreeUIStore` — a lightweight external store for selection, editing, drag-drop, and hover state
- Adds `useNodeState` hook that subscribes individual nodes to only the state slices they need, achieving O(1) re-renders on selection changes instead of O(n)
- Replaces `TreeStateContext` (which triggered re-renders on all tree nodes) with `TreeUIStoreContext` (which passes the store reference without triggering re-renders)

This doesn't fully fix #41 — there may be remaining performance issues in other areas — but it eliminates the main source of unnecessary re-renders during selection.

## Test plan

- [x] `TreeUIStore` has comprehensive unit tests
- [x] `useNodeState` has unit tests for selective subscription
- [x] Existing `RecursiveTreeNode` and `useTreeEditor` tests updated and passing
- [x] Manual testing with large documents to verify reduced CPU usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)