### PR TITLE
Support HTML input and fix div-wrapping parsing bug

### DIFF
--- a/src/components/LoadDocument.test.tsx
+++ b/src/components/LoadDocument.test.tsx
@@ -24,7 +24,7 @@ describe('LoadDocument', () => {
 
       // Drop overlay should be visible and mention HTML
       expect(screen.getByText(/drop your document here/i)).toBeInTheDocument();
-      expect(screen.getByText(/PDF.*DOCX.*HTML.*supported/i)).toBeInTheDocument();
+      expect(screen.getByText(/DOCX.*HTML.*supported/i)).toBeInTheDocument();
     });
 
     it('hides drop overlay when drag leaves the page', () => {

--- a/src/components/LoadDocument.test.tsx
+++ b/src/components/LoadDocument.test.tsx
@@ -22,8 +22,9 @@ describe('LoadDocument', () => {
         dataTransfer: { types: ['Files'] },
       });
 
-      // Drop overlay should be visible
+      // Drop overlay should be visible and mention HTML
       expect(screen.getByText(/drop your document here/i)).toBeInTheDocument();
+      expect(screen.getByText(/PDF.*DOCX.*HTML.*supported/i)).toBeInTheDocument();
     });
 
     it('hides drop overlay when drag leaves the page', () => {
@@ -105,6 +106,58 @@ describe('LoadDocument', () => {
     });
   });
 
+  describe('file input', () => {
+    it('accepts HTML files in file input', () => {
+      render(<LoadDocument onConvert={mockOnConvert} />);
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      expect(fileInput.accept).toContain('.html');
+      expect(fileInput.accept).toContain('.htm');
+    });
+  });
+
+  describe('HTML file upload', () => {
+    beforeEach(() => {
+      URL.createObjectURL = vi.fn(() => 'blob:http://localhost/fake-blob-url');
+      window.alert = vi.fn();
+      // jsdom's Blob/File doesn't implement .text(), polyfill it for tests
+      if (!Blob.prototype.text) {
+        Blob.prototype.text = function () {
+          return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result as string);
+            reader.onerror = reject;
+            reader.readAsText(this);
+          });
+        };
+      }
+    });
+
+    it('processes uploaded HTML file and calls onConvert with parsed tree and source URL', async () => {
+      render(<LoadDocument onConvert={mockOnConvert} />);
+
+      const htmlContent = '<h1>Title</h1><p>Content here</p>';
+      const file = new File([htmlContent], 'test.html', { type: 'text/html' });
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      Object.defineProperty(fileInput, 'files', {
+        value: [file],
+        configurable: true,
+      });
+      fireEvent.change(fileInput);
+
+      await vi.waitFor(() => {
+        expect(mockOnConvert).toHaveBeenCalled();
+      });
+
+      const [doc, sourceUrl, html, filename] = mockOnConvert.mock.calls[0];
+      expect(doc.type).toBe('document');
+      expect(doc.children.length).toBeGreaterThan(0);
+      expect(sourceUrl).toBe('blob:http://localhost/fake-blob-url');
+      expect(html).toBe(htmlContent);
+      expect(filename).toBe('test.html');
+    });
+  });
+
   describe('text convert', () => {
     it('calls onConvert with null filename when converting pasted text', () => {
       render(<LoadDocument onConvert={mockOnConvert} />);
@@ -117,6 +170,22 @@ describe('LoadDocument', () => {
         undefined, // html
         null // filename
       );
+    });
+
+    it('calls onConvert with source URL and HTML when pasting HTML content', () => {
+      URL.createObjectURL = vi.fn(() => 'blob:http://localhost/fake-blob-url');
+      render(<LoadDocument onConvert={mockOnConvert} />);
+      const htmlContent = '<h1>Title</h1><p>Some content</p>';
+      const textarea = screen.getByPlaceholderText(/paste unstructured text/i);
+      fireEvent.change(textarea, { target: { value: htmlContent } });
+      fireEvent.click(screen.getByRole('button', { name: /convert text/i }));
+
+      const [doc, sourceUrl, html, filename] = mockOnConvert.mock.calls[0];
+      expect(doc.type).toBe('document');
+      expect(doc.children.length).toBeGreaterThan(0);
+      expect(sourceUrl).toBe('blob:http://localhost/fake-blob-url');
+      expect(html).toBe(htmlContent);
+      expect(filename).toBeNull();
     });
   });
 });

--- a/src/components/LoadDocument.tsx
+++ b/src/components/LoadDocument.tsx
@@ -252,7 +252,7 @@ export function LoadDocument({ onConvert }: LoadDocumentProps) {
           <div className="text-center">
             <Upload className="w-16 h-16 mx-auto mb-4 text-green-mid" />
             <p className="text-xl font-medium text-gray-700">Drop your document here</p>
-            <p className="text-gray-500">PDF, DOCX, or HTML files supported</p>
+            <p className="text-gray-500">DOCX or HTML files supported</p>
           </div>
         </div>
       )}
@@ -270,7 +270,7 @@ export function LoadDocument({ onConvert }: LoadDocumentProps) {
                 type="file"
                 ref={fileInputRef}
                 className="hidden"
-                accept=".pdf,.docx,.doc,.html,.htm"
+                accept=".docx,.doc,.html,.htm"
                 onChange={handleFileInputChange}
               />
               <Button
@@ -284,7 +284,7 @@ export function LoadDocument({ onConvert }: LoadDocumentProps) {
                 ) : (
                   <Upload className="w-5 h-5 mr-2" />
                 )}
-                Upload File
+                Upload File (DOCX or HTML)
               </Button>
             </div>
 

--- a/src/components/LoadDocument.tsx
+++ b/src/components/LoadDocument.tsx
@@ -77,6 +77,29 @@ export function LoadDocument({ onConvert }: LoadDocumentProps) {
       }
     }
 
+    // HTML Handling (Client-Side)
+    const nameLower = file.name.toLowerCase();
+    if (nameLower.endsWith('.html') || nameLower.endsWith('.htm') || file.type === 'text/html') {
+      try {
+        const html = await file.text();
+        const blob = new Blob([html], { type: 'text/html' });
+        const sourceUrl = URL.createObjectURL(blob);
+
+        setText(html);
+        const doc = parseHtmlLegalToTree(html);
+        onConvert(doc, sourceUrl, html, file.name);
+        setIsLoading(false);
+        if (fileInputRef.current) fileInputRef.current.value = '';
+        return;
+      } catch (err) {
+        console.error('HTML parsing failed', err);
+        alert(`Failed to parse HTML: ${err instanceof Error ? err.message : String(err)}`);
+        setIsLoading(false);
+        if (fileInputRef.current) fileInputRef.current.value = '';
+        return;
+      }
+    }
+
     // PDF Handling via Docling API (Fallback/Alternative)
     try {
       throw new Error('TODO: set up backend for PDF conversion');
@@ -172,6 +195,10 @@ export function LoadDocument({ onConvert }: LoadDocumentProps) {
     if (isHtml) {
       try {
         doc = parseHtmlLegalToTree(text);
+        const blob = new Blob([text], { type: 'text/html' });
+        const sourceUrl = URL.createObjectURL(blob);
+        onConvert(doc, sourceUrl, text, null);
+        return;
       } catch (e) {
         console.error('Failed to parse HTML', e);
         // Fallback: wrap plain text in simple document
@@ -225,7 +252,7 @@ export function LoadDocument({ onConvert }: LoadDocumentProps) {
           <div className="text-center">
             <Upload className="w-16 h-16 mx-auto mb-4 text-green-mid" />
             <p className="text-xl font-medium text-gray-700">Drop your document here</p>
-            <p className="text-gray-500">PDF or DOCX files supported</p>
+            <p className="text-gray-500">PDF, DOCX, or HTML files supported</p>
           </div>
         </div>
       )}
@@ -243,7 +270,7 @@ export function LoadDocument({ onConvert }: LoadDocumentProps) {
                 type="file"
                 ref={fileInputRef}
                 className="hidden"
-                accept=".pdf,.docx,.doc"
+                accept=".pdf,.docx,.doc,.html,.htm"
                 onChange={handleFileInputChange}
               />
               <Button

--- a/src/utils/document-utils.test.ts
+++ b/src/utils/document-utils.test.ts
@@ -402,6 +402,44 @@ describe('Document Utils', () => {
     });
   });
 
+  describe('full HTML document (Docling-style)', () => {
+    it('parses a full HTML document with DOCTYPE, head, style, and body', () => {
+      const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8"/>
+<title>Test document</title>
+<style>html { font-family: Arial; } h1 { color: #333; }</style>
+</head>
+<body>
+<div class='page'>
+<h2>Gesetz über die digitale Verwaltung (DVG) 1</h2>
+<p>(Vom …)</p>
+<p>Der Kantonsrat beschliesst:</p>
+<h2>I. Allgemeine Bestimmungen</h2>
+<h2>§ 1 Gegenstand</h2>
+<ul>
+<li>1 Dieses Gesetz regelt die Rahmenbedingungen.</li>
+</ul>
+<p>2 Es:</p>
+<ol>
+<li style="list-style-type: 'a) ';">definiert die Prinzipien;</li>
+<li style="list-style-type: 'b) ';">schafft die Grundlagen;</li>
+</ol>
+<h2>§ 2 Geltungsbereich</h2>
+<p>Dieses Gesetz gilt für die öffentlichen Organe.</p>
+</div>
+</body>
+</html>`;
+      const doc = parseHtmlToTree(html);
+      expect(doc.type).toBe('document');
+      expect(doc.children.length).toBeGreaterThan(0);
+      // Should contain headings, not just plain content
+      const hasHeadings = doc.children.some((c) => c.type === 'heading');
+      expect(hasHeadings).toBe(true);
+    });
+  });
+
   // Real document integration tests (ported from real-conversion.test.ts)
   describe('Real Document Conversion (Tree)', () => {
     const readFixture = (filename: string) => {

--- a/src/utils/document-utils.ts
+++ b/src/utils/document-utils.ts
@@ -201,8 +201,14 @@ export const parseHtmlToTree = (
       return;
     }
 
-    // Paragraphs and divs - create content nodes
-    if (tagName === 'p' || tagName === 'div') {
+    // Divs - transparent containers, recurse into children
+    if (tagName === 'div') {
+      Array.from(domNode.childNodes).forEach(walkDom);
+      return;
+    }
+
+    // Paragraphs - create content nodes
+    if (tagName === 'p') {
       const content = getInnerHtml(domNode);
       if (content) {
         const contentNode: ContentDocumentNode = {


### PR DESCRIPTION
## Summary
- Add HTML file upload support (`.html`/`.htm` via button and drag-and-drop)
- Fix pasted HTML: now creates a source preview URL and passes HTML to `onConvert` (previously passed `null`/`undefined`, so source preview was blank)
- Fix `<div>` handling in `parseHtmlToTree`: divs are now transparent containers that recurse into children, fixing Docling-style HTML where a wrapper `<div class='page'>` collapsed the entire document into a single content node
- Remove PDF from upload UI since the PDF code path is disabled

## Test plan
- [x] Uploading `.html` files works and produces a tree with headings
- [x] Pasting HTML into textarea parses it and shows source preview
- [x] Pasting plain text still works as before
- [x] Full HTML documents (DOCTYPE, head, style, body, div wrapper) parse correctly
- [x] All 519 tests pass
- [x] Build succeeds

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)