### PR TITLE
Extract numbers from existing HTML headings

### DIFF
--- a/src/utils/legal-transforms/heading-number-extract.test.ts
+++ b/src/utils/legal-transforms/heading-number-extract.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { HeadingDocumentNode } from '../../types/document';
+import { headingNumberExtractTransform } from './heading-number-extract';
+import { content, createDoc, heading } from './test-helpers';
+
+describe('headingNumberExtractTransform', () => {
+  it('extracts roman numeral from heading', () => {
+    const input = createDoc([heading('I. Allgemeine Bestimmungen')]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBe('I.');
+    expect(h.contents.de).toBe('Allgemeine Bestimmungen');
+  });
+
+  it('extracts article number from heading', () => {
+    const input = createDoc([heading('§ 31 Übergangsbestimmung')]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBe('§ 31');
+    expect(h.contents.de).toBe('Übergangsbestimmung');
+  });
+
+  it('extracts full article ref with Abs.', () => {
+    const input = createDoc([heading('§ 10a Abs. 3')]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBe('§ 10a Abs. 3');
+    expect(h.contents.de).toBe('');
+  });
+
+  it('extracts uppercase letter section', () => {
+    const input = createDoc([heading('A. Allgemeines')]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBe('A.');
+    expect(h.contents.de).toBe('Allgemeines');
+  });
+
+  it('extracts Bst. pattern', () => {
+    const input = createDoc([heading('§ 29 Abs. 1 Bst. f')]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBe('§ 29 Abs. 1 Bst. f');
+    expect(h.contents.de).toBe('');
+  });
+
+  it('leaves heading unchanged if no pattern matches', () => {
+    const input = createDoc([heading('Some title')]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBeNull();
+    expect(h.contents.de).toBe('Some title');
+  });
+
+  it('does not extract number from middle of text', () => {
+    const input = createDoc([heading('Lorem § 10a ipsum')]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBeNull();
+    expect(h.contents.de).toBe('Lorem § 10a ipsum');
+  });
+
+  it('does not extract roman numeral from middle of text', () => {
+    const input = createDoc([heading('See section I. for details')]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBeNull();
+    expect(h.contents.de).toBe('See section I. for details');
+  });
+
+  it('does not re-extract number from heading that already has one', () => {
+    const h: HeadingDocumentNode = {
+      id: 'test',
+      number: 'existing',
+      type: 'heading',
+      contents: { de: 'I. Allgemeine Bestimmungen' },
+      children: [],
+    };
+    const input = createDoc([h]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    const resultH = result.children[0] as HeadingDocumentNode;
+    expect(resultH.number).toBe('existing');
+    expect(resultH.contents.de).toBe('I. Allgemeine Bestimmungen');
+  });
+
+  it('recurses into heading children', () => {
+    const inner = heading('§ 5 Title');
+    const outer = heading('I. Section', [inner]);
+    const input = createDoc([outer]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    const outerH = result.children[0] as HeadingDocumentNode;
+    expect(outerH.number).toBe('I.');
+    const innerH = outerH.children[0] as HeadingDocumentNode;
+    expect(innerH.number).toBe('§ 5');
+    expect(innerH.contents.de).toBe('Title');
+  });
+
+  it('preserves content nodes unchanged', () => {
+    const input = createDoc([content('I. Not a heading')]);
+
+    const result = headingNumberExtractTransform(input, 'de');
+
+    expect(result.children[0].type).toBe('content');
+    expect(result.children[0].number).toBeNull();
+  });
+});

--- a/src/utils/legal-transforms/heading-number-extract.ts
+++ b/src/utils/legal-transforms/heading-number-extract.ts
@@ -1,0 +1,92 @@
+import type {
+  ContainerDocumentNode,
+  DocumentNode,
+  HeadingDocumentNode,
+  Language,
+} from '../../types/document';
+import {
+  extractCleanText,
+  matchArticle,
+  matchRomanSection,
+  matchUppercaseLetterSection,
+} from './patterns';
+import type { TreeTransform } from './types';
+
+/**
+ * Try to extract a number from heading text using legal patterns.
+ * Tries matchers in priority order: romanSection → article → uppercaseLetterSection.
+ */
+function tryExtractNumber(text: string): { number: string; rest: string } | null {
+  const roman = matchRomanSection(text);
+  if (roman.matched && roman.number && roman.rest !== undefined) {
+    return { number: roman.number, rest: roman.rest };
+  }
+
+  const article = matchArticle(text);
+  if (article.matched && article.number && article.rest !== undefined) {
+    return { number: article.number, rest: article.rest };
+  }
+
+  const letter = matchUppercaseLetterSection(text);
+  if (letter.matched && letter.number && letter.rest !== undefined) {
+    return { number: letter.number, rest: letter.rest };
+  }
+
+  return null;
+}
+
+/**
+ * Process a single node, extracting number from headings and recursing into children.
+ */
+function processNode(node: DocumentNode, language: Language): DocumentNode {
+  if (node.type === 'heading') {
+    const heading = node as HeadingDocumentNode;
+    const processedChildren = heading.children.map((child) => processNode(child, language));
+
+    if (heading.number !== null) {
+      return { ...heading, children: processedChildren };
+    }
+
+    const lang = (Object.keys(heading.contents)[0] as Language) || language;
+    const text = extractCleanText(heading.contents[lang] || '');
+    const extracted = tryExtractNumber(text);
+
+    if (extracted) {
+      return {
+        ...heading,
+        number: extracted.number,
+        contents: { ...heading.contents, [lang]: extracted.rest },
+        children: processedChildren,
+      };
+    }
+
+    return { ...heading, children: processedChildren };
+  }
+
+  if ('children' in node && Array.isArray((node as ContainerDocumentNode).children)) {
+    const container = node as ContainerDocumentNode;
+    return {
+      ...container,
+      children: container.children.map((child) => processNode(child, language)),
+    };
+  }
+
+  return node;
+}
+
+/**
+ * Extracts numbers from existing heading nodes that have number === null.
+ *
+ * Walks the tree recursively and applies pattern matching to heading content text.
+ * Does not create new headings or restructure the tree — only populates the
+ * `number` field on headings that already exist.
+ */
+export const headingNumberExtractTransform: TreeTransform = (
+  root: ContainerDocumentNode,
+  language: Language
+): ContainerDocumentNode => {
+  return {
+    ...root,
+    children: root.children.map((child) => processNode(child, language)),
+  };
+};

--- a/src/utils/legal-transforms/index.ts
+++ b/src/utils/legal-transforms/index.ts
@@ -1,11 +1,13 @@
 import type { ContainerDocumentNode, Language } from '../../types/document';
 import { articleTransform } from './article';
+import { headingNumberExtractTransform } from './heading-number-extract';
 import { letteredItemsTransform } from './lettered-items';
 import { listNumberDedupTransform } from './list-number-dedup';
 import { romanSectionTransform } from './roman-section';
 import type { TreeTransform } from './types';
 
 export { articleTransform } from './article';
+export { headingNumberExtractTransform } from './heading-number-extract';
 export { letteredItemsTransform } from './lettered-items';
 export { listNumberDedupTransform } from './list-number-dedup';
 export { LEGAL_PATTERNS } from './patterns';
@@ -17,6 +19,8 @@ export type { TreeTransform } from './types';
  * Configuration for the legal transform pipeline
  */
 export interface LegalTransformConfig {
+  /** Enable heading number extraction from existing headings. Default: true */
+  headingNumberExtract?: boolean;
   /** Enable roman numeral section detection (I., II., etc.). Default: true */
   romanSections?: boolean;
   /** Enable article pattern detection (Art. X, § X). Default: true */
@@ -40,10 +44,11 @@ export function composeTransforms(...transforms: TreeTransform[]): TreeTransform
  * Apply Swiss legal document transforms to a tree.
  *
  * Transform order matters:
- * 1. List number dedup first - Fixes duplicate numbering from Mammoth's ol/sup output
- * 2. Roman sections - Creates top-level structure (I., II., III.)
- * 3. Articles - Creates nested structure within sections (Art. 1, Art. 2)
- * 4. Lettered items last - Groups items within articles (a., b., c.)
+ * 1. Heading number extract - Populates number field on existing headings
+ * 2. List number dedup - Fixes duplicate numbering from Mammoth's ol/sup output
+ * 3. Roman sections - Creates top-level structure (I., II., III.)
+ * 4. Articles - Creates nested structure within sections (Art. 1, Art. 2)
+ * 5. Lettered items last - Groups items within articles (a., b., c.)
  *
  * @param root - The document tree to transform
  * @param language - The language of the document content
@@ -56,6 +61,7 @@ export function applySwissLegalTransforms(
   config: LegalTransformConfig = {}
 ): ContainerDocumentNode {
   const {
+    headingNumberExtract = true,
     romanSections = true,
     articles = true,
     letteredItems = true,
@@ -64,6 +70,9 @@ export function applySwissLegalTransforms(
 
   const transforms: TreeTransform[] = [];
 
+  if (headingNumberExtract) {
+    transforms.push(headingNumberExtractTransform);
+  }
   if (listNumberDedup) {
     transforms.push(listNumberDedupTransform);
   }

--- a/src/utils/legal-transforms/patterns.test.ts
+++ b/src/utils/legal-transforms/patterns.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { extractCleanText, matchArticle, matchLetteredItem, matchRomanSection } from './patterns';
+import {
+  extractCleanText,
+  matchArticle,
+  matchLetteredItem,
+  matchRomanSection,
+  matchUppercaseLetterSection,
+} from './patterns';
 
 describe('patterns', () => {
   describe('matchRomanSection', () => {
@@ -92,6 +98,16 @@ describe('patterns', () => {
     });
 
     it.each([
+      ['§ 29 Abs. 1 Bst. f', '§ 29 Abs. 1 Bst. f', ''],
+      ['Art. 5 Abs. 2 Bst. a Some title', 'Art. 5 Abs. 2 Bst. a', 'Some title'],
+    ])('extracts Bst. from %s → number=%s, rest=%s', (input, expectedNumber, expectedRest) => {
+      const result = matchArticle(input);
+      expect(result.matched).toBe(true);
+      expect(result.number).toBe(expectedNumber);
+      expect(result.rest).toBe(expectedRest);
+    });
+
+    it.each([
       ['Article 1 Some title', 'Article spelled out'],
       ['Art 1 No period', 'Art without period'],
       ['See Art. 5 for details', 'Art. in middle of text'],
@@ -121,6 +137,34 @@ describe('patterns', () => {
       ['See item a. here', 'letter in middle of text'],
     ])('does not match: %s (%s)', (input) => {
       expect(matchLetteredItem(input).matched).toBe(false);
+    });
+  });
+
+  describe('matchUppercaseLetterSection', () => {
+    it.each([
+      ['A. Allgemeines', 'A.', 'Allgemeines'],
+      ['B. Übergangsrecht', 'B.', 'Übergangsrecht'],
+      ['Z. Last section', 'Z.', 'Last section'],
+    ])('extracts number from %s → number=%s, rest=%s', (input, expectedNumber, expectedRest) => {
+      const result = matchUppercaseLetterSection(input);
+      expect(result.matched).toBe(true);
+      expect(result.number).toBe(expectedNumber);
+      expect(result.rest).toBe(expectedRest);
+    });
+
+    it('returns undefined number/rest for non-match', () => {
+      const result = matchUppercaseLetterSection('Not a letter section');
+      expect(result.number).toBeUndefined();
+      expect(result.rest).toBeUndefined();
+    });
+
+    it.each([
+      ['a. lowercase', 'lowercase letter'],
+      ['AB. Double letter', 'multiple letters'],
+      ['A No period', 'missing period'],
+      ['Middle A. text', 'letter in middle of text'],
+    ])('does not match: %s (%s)', (input) => {
+      expect(matchUppercaseLetterSection(input).matched).toBe(false);
     });
   });
 

--- a/src/utils/legal-transforms/patterns.ts
+++ b/src/utils/legal-transforms/patterns.ts
@@ -5,7 +5,7 @@
  */
 export const LEGAL_PATTERNS = {
   /** Art. 1 or § 1 patterns (case-insensitive) */
-  article: /^(Art\.|§)\s*\d+[a-z]?(\s+Abs\.\s*\d+)?(\s+[a-z]\))?/i,
+  article: /^(Art\.|§)\s*\d+[a-z]?(\s+Abs\.\s*\d+)?(\s+Bst\.\s*[a-z])?(\s+[a-z]\))?/i,
 
   /** Section headers I. II. III. IV. V. VI. VII. VIII. IX. X. etc. */
   romanSection: /^(I{1,3}|IV|VI{0,3}|IX|X{1,3})\.(\s|$)/,
@@ -15,6 +15,9 @@ export const LEGAL_PATTERNS = {
 
   /** 1 Text..., 2 Text... (numbered paragraph at start) */
   numberedPara: /^\d+\s+[A-ZÄÖÜ]/,
+
+  /** A. text, B. text - uppercase letter section headers */
+  uppercaseLetterSection: /^([A-Z])\.(\s|$)/,
 
   /** a. text, b. text, c. text - lettered list items */
   letteredItem: /^([a-z])\.\s+(.*)$/,
@@ -60,6 +63,19 @@ export function matchArticle(text: string): PatternMatchResult {
   return {
     matched: true,
     number: match[0],
+    rest: text.slice(match[0].length).trim(),
+  };
+}
+
+/**
+ * Check if text matches an uppercase letter section pattern (A., B., etc.)
+ */
+export function matchUppercaseLetterSection(text: string): PatternMatchResult {
+  const match = text.match(LEGAL_PATTERNS.uppercaseLetterSection);
+  if (!match) return { matched: false };
+  return {
+    matched: true,
+    number: `${match[1]}.`,
     rest: text.slice(match[0].length).trim(),
   };
 }


### PR DESCRIPTION
## Summary
- Adds a `headingNumberExtractTransform` that populates the `number` field on headings parsed from HTML `<h1>`–`<h6>` elements (which previously had `number: null` with the number embedded in the text)
- Extends the article pattern to support `Bst. [a-z]` references (e.g. `§ 29 Abs. 1 Bst. f`)
- Adds uppercase letter section matching (`A.`, `B.`, etc.) via new `matchUppercaseLetterSection` pattern

## Test plan
- [x] 11 new transform tests covering all extraction cases, negative cases, recursion, and skip-when-already-set
- [x] 10 new pattern tests for `matchUppercaseLetterSection` and `Bst.` support
- [x] All 540 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)