### PR TITLE
Add tabbed left pane with document outline view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@tailwindcss/vite": "^4.1.17",
         "@types/dompurify": "^3.0.5",
         "buffer": "^6.0.3",
@@ -1188,6 +1189,56 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1203,6 +1254,150 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -1211,6 +1406,103 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@tailwindcss/vite": "^4.1.17",
     "@types/dompurify": "^3.0.5",
     "buffer": "^6.0.3",

--- a/src/components/DocumentOutline.test.tsx
+++ b/src/components/DocumentOutline.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import type { ContainerDocumentNode } from '../types/document';
+import { DocumentOutline } from './DocumentOutline';
+
+const makeDoc = (...children: ContainerDocumentNode['children']): ContainerDocumentNode => ({
+  id: 'root',
+  number: null,
+  type: 'document',
+  children,
+});
+
+describe('DocumentOutline', () => {
+  test('renders heading entries with correct indentation', () => {
+    const doc = makeDoc({
+      id: 'h1',
+      number: '1',
+      type: 'heading',
+      contents: { de: 'Top Level' },
+      children: [
+        {
+          id: 'h2',
+          number: '1.1',
+          type: 'heading',
+          contents: { de: 'Nested' },
+          children: [],
+        },
+      ],
+    });
+    render(<DocumentOutline document={doc} language="de" onHeadingClick={() => {}} />);
+
+    expect(screen.getByText('Top Level')).toBeInTheDocument();
+    expect(screen.getByText('Nested')).toBeInTheDocument();
+  });
+
+  test('calls onHeadingClick with node ID when heading is clicked', () => {
+    const onClick = vi.fn();
+    const doc = makeDoc({
+      id: 'h1',
+      number: null,
+      type: 'heading',
+      contents: { de: 'Click me' },
+      children: [],
+    });
+    render(<DocumentOutline document={doc} language="de" onHeadingClick={onClick} />);
+
+    fireEvent.click(screen.getByText('Click me'));
+    expect(onClick).toHaveBeenCalledWith('h1');
+  });
+
+  test('shows heading numbers when present', () => {
+    const doc = makeDoc({
+      id: 'h1',
+      number: 'Art. 1',
+      type: 'heading',
+      contents: { de: 'First Article' },
+      children: [],
+    });
+    render(<DocumentOutline document={doc} language="de" onHeadingClick={() => {}} />);
+
+    expect(screen.getByText('Art. 1')).toBeInTheDocument();
+    expect(screen.getByText('First Article')).toBeInTheDocument();
+  });
+
+  test('renders empty state when no headings exist', () => {
+    const doc = makeDoc({
+      id: 'c1',
+      number: null,
+      type: 'content',
+      contents: { de: 'Text' },
+      children: [],
+    });
+    render(<DocumentOutline document={doc} language="de" onHeadingClick={() => {}} />);
+
+    expect(screen.getByText(/no headings/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/DocumentOutline.tsx
+++ b/src/components/DocumentOutline.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import type { ContainerDocumentNode, Language } from '../types/document';
+import { getDocumentOutline } from '../utils/outline-utils';
+
+interface DocumentOutlineProps {
+  document: ContainerDocumentNode;
+  language: Language;
+  onHeadingClick: (nodeId: string) => void;
+}
+
+export function DocumentOutline({ document, language, onHeadingClick }: DocumentOutlineProps) {
+  const entries = useMemo(() => getDocumentOutline(document, language), [document, language]);
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-400 text-sm">
+        No headings in this document.
+      </div>
+    );
+  }
+
+  return (
+    <nav aria-label="Document outline" className="p-4 overflow-y-auto h-full">
+      <ul className="space-y-0.5">
+        {entries.map((entry) => (
+          <li key={entry.id}>
+            <button
+              type="button"
+              className="w-full text-left px-2 py-1.5 rounded hover:bg-gray-100 transition-colors text-sm cursor-pointer"
+              style={{ paddingLeft: `${entry.depth * 16 + 8}px` }}
+              onClick={() => onHeadingClick(entry.id)}
+            >
+              {entry.number && (
+                <span className="text-gray-400 mr-1.5 font-mono text-xs">{entry.number}</span>
+              )}
+              <span className={entry.depth === 0 ? 'font-semibold' : ''}>{entry.text}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/LeftPane.test.tsx
+++ b/src/components/LeftPane.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+import type { ContainerDocumentNode } from '../types/document';
+import { LeftPane } from './LeftPane';
+
+const makeDoc = (...children: ContainerDocumentNode['children']): ContainerDocumentNode => ({
+  id: 'root',
+  number: null,
+  type: 'document',
+  children,
+});
+
+const docWithHeading = makeDoc({
+  id: 'h1',
+  number: '1',
+  type: 'heading',
+  contents: { de: 'Heading One' },
+  children: [],
+});
+
+describe('LeftPane', () => {
+  test('renders both tabs when pdfUrl is provided', () => {
+    render(
+      <LeftPane
+        pdfUrl="http://example.com/doc.html"
+        document={docWithHeading}
+        language="de"
+        onHeadingClick={() => {}}
+      />
+    );
+
+    expect(screen.getByRole('tab', { name: /original/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /outline/i })).toBeInTheDocument();
+  });
+
+  test('shows Original tab content by default when pdfUrl exists', () => {
+    render(
+      <LeftPane
+        pdfUrl="http://example.com/doc.html"
+        document={docWithHeading}
+        language="de"
+        onHeadingClick={() => {}}
+      />
+    );
+
+    // The Original tab should be selected
+    expect(screen.getByRole('tab', { name: /original/i })).toHaveAttribute('aria-selected', 'true');
+    // Should show the processing warning
+    expect(screen.getByText(/may not correspond/i)).toBeInTheDocument();
+  });
+
+  test('switches to Outline tab on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <LeftPane
+        pdfUrl="http://example.com/doc.html"
+        document={docWithHeading}
+        language="de"
+        onHeadingClick={() => {}}
+      />
+    );
+
+    await user.click(screen.getByRole('tab', { name: /outline/i }));
+
+    expect(screen.getByRole('tab', { name: /outline/i })).toHaveAttribute('aria-selected', 'true');
+    // Outline content should be visible
+    expect(screen.getByText('Heading One')).toBeInTheDocument();
+  });
+
+  test('only shows Outline tab when pdfUrl is null', () => {
+    render(
+      <LeftPane pdfUrl={null} document={docWithHeading} language="de" onHeadingClick={() => {}} />
+    );
+
+    expect(screen.queryByRole('tab', { name: /original/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /outline/i })).toBeInTheDocument();
+    // Outline content should be visible by default
+    expect(screen.getByText('Heading One')).toBeInTheDocument();
+  });
+
+  test('shows processing warning in Original tab', () => {
+    render(
+      <LeftPane
+        pdfUrl="http://example.com/doc.html"
+        document={docWithHeading}
+        language="de"
+        onHeadingClick={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/may not correspond/i)).toBeInTheDocument();
+  });
+
+  test('passes onHeadingClick through to DocumentOutline', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <LeftPane pdfUrl={null} document={docWithHeading} language="de" onHeadingClick={onClick} />
+    );
+
+    await user.click(screen.getByText('Heading One'));
+    expect(onClick).toHaveBeenCalledWith('h1');
+  });
+});

--- a/src/components/LeftPane.tsx
+++ b/src/components/LeftPane.tsx
@@ -1,0 +1,51 @@
+import * as Tabs from '@radix-ui/react-tabs';
+import type { ContainerDocumentNode, Language } from '../types/document';
+import { DocumentOutline } from './DocumentOutline';
+import { SourcePreview } from './SourcePreview';
+
+interface LeftPaneProps {
+  pdfUrl: string | null;
+  document: ContainerDocumentNode;
+  language: Language;
+  onHeadingClick: (nodeId: string) => void;
+}
+
+const tabTriggerClass =
+  'px-4 py-2 text-sm font-medium text-gray-600 border-b-2 border-transparent data-[state=active]:border-blue-500 data-[state=active]:text-blue-600 transition-colors';
+
+export function LeftPane({ pdfUrl, document, language, onHeadingClick }: LeftPaneProps) {
+  return (
+    <div className="flex-1 border-r border-gray-200 bg-gray-50 flex flex-col min-w-0 w-1/2">
+      <Tabs.Root defaultValue={pdfUrl ? 'original' : 'outline'} className="flex flex-col h-full">
+        <Tabs.List className="flex border-b border-gray-200 bg-white px-2 shrink-0">
+          {pdfUrl && (
+            <Tabs.Trigger value="original" className={tabTriggerClass}>
+              Original
+            </Tabs.Trigger>
+          )}
+          <Tabs.Trigger value="outline" className={tabTriggerClass}>
+            Outline
+          </Tabs.Trigger>
+        </Tabs.List>
+        {pdfUrl && (
+          <Tabs.Content value="original" className="flex-1 overflow-hidden flex flex-col">
+            <div className="px-4 py-2 bg-amber-50 border-b border-amber-200 text-amber-700 text-xs shrink-0">
+              This preview has been processed and may not correspond to the original document
+              exactly.
+            </div>
+            <div className="flex-1 min-h-0">
+              <SourcePreview url={pdfUrl} />
+            </div>
+          </Tabs.Content>
+        )}
+        <Tabs.Content value="outline" className="flex-1 overflow-hidden">
+          <DocumentOutline
+            document={document}
+            language={language}
+            onHeadingClick={onHeadingClick}
+          />
+        </Tabs.Content>
+      </Tabs.Root>
+    </div>
+  );
+}

--- a/src/components/SourcePreview.tsx
+++ b/src/components/SourcePreview.tsx
@@ -4,10 +4,8 @@ interface SourcePreviewProps {
 
 export function SourcePreview({ url }: SourcePreviewProps) {
   return (
-    <div className="flex-1 border-r border-gray-200 bg-gray-100 flex flex-col min-w-0 w-1/2">
-      <div className="max-w-5xl mx-auto w-full h-full">
-        <iframe src={url} className="w-full h-full block bg-white p-8" title="Document Viewer" />
-      </div>
+    <div className="max-w-5xl mx-auto w-full h-full">
+      <iframe src={url} className="w-full h-full block bg-white p-8" title="Document Viewer" />
     </div>
   );
 }

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import type { ContainerDocumentNode } from '../types/document';
 import { TreeEditor } from './TreeEditor';
@@ -36,28 +36,30 @@ const renderTreeEditor = () =>
     />
   );
 
-const selectFirstNode = () => {
-  // Click the first heading node to select it
-  const firstHeading = screen.getByText('First Heading');
-  fireEvent.click(firstHeading);
+const getContainer = () => {
+  // The container is the tree editor pane that receives keyboard events
+  return screen.getByTestId('tree-editor-pane');
 };
 
-const getContainer = () => {
-  // The container is the element with tabIndex that receives keyboard events
-  const container = document.querySelector('[tabindex="0"]') as HTMLElement;
-  return container;
+/** Get a within-scoped query object for the tree editor (right pane). */
+const getTreePane = () => within(getContainer());
+
+const selectFirstNode = () => {
+  // Click the first heading node to select it
+  const firstHeading = getTreePane().getByText('First Heading');
+  fireEvent.click(firstHeading);
 };
 
 /** Assert that a node (found by text content) has selected styling. */
 const expectNodeSelected = (text: string) => {
-  const el = screen.getByText(text);
+  const el = getTreePane().getByText(text);
   const wrapper = el.closest('[draggable]') as HTMLElement;
   expect(wrapper.className).toContain('bg-blue');
 };
 
 /** Assert that a node (found by text content) does NOT have selected styling. */
 const expectNodeNotSelected = (text: string) => {
-  const el = screen.getByText(text);
+  const el = getTreePane().getByText(text);
   const wrapper = el.closest('[draggable]') as HTMLElement;
   expect(wrapper.className).not.toContain('bg-blue');
 };
@@ -67,7 +69,7 @@ const expectNodeNotSelected = (text: string) => {
  * Useful for checking DOM nesting relationships.
  */
 const getNodeWrapper = (text: string) => {
-  const el = screen.getByText(text);
+  const el = getTreePane().getByText(text);
   return el.closest('[draggable]') as HTMLElement;
 };
 
@@ -106,7 +108,7 @@ describe('TreeEditor keyboard shortcuts', () => {
       fireEvent.keyDown(container, { key: 'h' });
 
       // The node should still be visible (wasn't deleted or broken)
-      expect(screen.getByText('First Heading')).toBeInTheDocument();
+      expect(getTreePane().getByText('First Heading')).toBeInTheDocument();
     });
 
     test('uppercase keys also work (case insensitive)', () => {
@@ -117,7 +119,7 @@ describe('TreeEditor keyboard shortcuts', () => {
       // Uppercase H should also work
       fireEvent.keyDown(container, { key: 'H' });
 
-      expect(screen.getByText('First Heading')).toBeInTheDocument();
+      expect(getTreePane().getByText('First Heading')).toBeInTheDocument();
     });
   });
 
@@ -130,8 +132,8 @@ describe('TreeEditor keyboard shortcuts', () => {
       fireEvent.keyDown(container, { key: 'h' });
 
       // Both headings should still be there, unchanged
-      expect(screen.getByText('First Heading')).toBeInTheDocument();
-      expect(screen.getByText('Second Heading')).toBeInTheDocument();
+      expect(getTreePane().getByText('First Heading')).toBeInTheDocument();
+      expect(getTreePane().getByText('Second Heading')).toBeInTheDocument();
     });
 
     test('shortcuts do not fire with Ctrl modifier', () => {
@@ -142,7 +144,7 @@ describe('TreeEditor keyboard shortcuts', () => {
       // Ctrl+H should not trigger the shortcut
       fireEvent.keyDown(container, { key: 'h', ctrlKey: true });
 
-      expect(screen.getByText('First Heading')).toBeInTheDocument();
+      expect(getTreePane().getByText('First Heading')).toBeInTheDocument();
     });
 
     test('shortcuts do not fire with Meta modifier', () => {
@@ -153,7 +155,7 @@ describe('TreeEditor keyboard shortcuts', () => {
       // Cmd+H should not trigger the shortcut
       fireEvent.keyDown(container, { key: 'h', metaKey: true });
 
-      expect(screen.getByText('First Heading')).toBeInTheDocument();
+      expect(getTreePane().getByText('First Heading')).toBeInTheDocument();
     });
 
     test('type shortcuts do not fire while in edit mode', async () => {
@@ -164,7 +166,7 @@ describe('TreeEditor keyboard shortcuts', () => {
 
       // Enter edit mode via double-click
       await act(async () => {
-        fireEvent.doubleClick(screen.getByText('First Heading'));
+        fireEvent.doubleClick(getTreePane().getByText('First Heading'));
         vi.runAllTimers();
       });
 
@@ -173,9 +175,9 @@ describe('TreeEditor keyboard shortcuts', () => {
 
       // Node should still be a heading (type indicator visible when selected)
       // If the shortcut had fired, the node would have been converted to footnote
-      expect(screen.getByText('First Heading')).toBeInTheDocument();
+      expect(getTreePane().getByText('First Heading')).toBeInTheDocument();
       // The heading should still be rendered as an h-tag (not converted)
-      const headingEl = screen.getByText('First Heading');
+      const headingEl = getTreePane().getByText('First Heading');
       expect(headingEl.tagName).toMatch(/^H\d$/);
 
       vi.useRealTimers();
@@ -188,7 +190,7 @@ describe('double-click inline editing', () => {
     vi.useFakeTimers();
     renderTreeEditor();
 
-    const firstHeading = screen.getByText('First Heading');
+    const firstHeading = getTreePane().getByText('First Heading');
 
     // Double-click and flush timers in a single act boundary
     await act(async () => {
@@ -208,7 +210,7 @@ describe('double-click inline editing', () => {
     vi.useFakeTimers();
     renderTreeEditor();
 
-    const firstHeading = screen.getByText('First Heading');
+    const firstHeading = getTreePane().getByText('First Heading');
 
     // Enter edit mode via double-click
     await act(async () => {
@@ -240,7 +242,7 @@ describe('double-click inline editing', () => {
     vi.useFakeTimers();
     renderTreeEditor();
 
-    const firstHeading = screen.getByText('First Heading');
+    const firstHeading = getTreePane().getByText('First Heading');
 
     // Enter edit mode via double-click
     await act(async () => {
@@ -306,7 +308,7 @@ describe('selection and navigation', () => {
     renderTreeEditor();
     const container = getContainer();
 
-    fireEvent.click(screen.getByText('Second Heading'));
+    fireEvent.click(getTreePane().getByText('Second Heading'));
     fireEvent.keyDown(container, { key: 'ArrowUp' });
 
     expectNodeSelected('First Heading');
@@ -361,7 +363,7 @@ describe('selection and navigation', () => {
     renderTreeEditor();
     const container = getContainer();
 
-    fireEvent.click(screen.getByText('Second Heading'));
+    fireEvent.click(getTreePane().getByText('Second Heading'));
     fireEvent.keyDown(container, { key: 'ArrowDown' });
 
     expectNodeSelected('Second Heading');
@@ -375,13 +377,13 @@ describe('selection and navigation', () => {
     expectNodeSelected('First Heading');
 
     // Ctrl+click second node to add to selection
-    fireEvent.click(screen.getByText('Second Heading'), { ctrlKey: true });
+    fireEvent.click(getTreePane().getByText('Second Heading'), { ctrlKey: true });
 
     expectNodeSelected('First Heading');
     expectNodeSelected('Second Heading');
 
     // Ctrl+click first node again to deselect it
-    fireEvent.click(screen.getByText('First Heading'), { ctrlKey: true });
+    fireEvent.click(getTreePane().getByText('First Heading'), { ctrlKey: true });
 
     expectNodeNotSelected('First Heading');
     expectNodeSelected('Second Heading');
@@ -400,9 +402,9 @@ describe('node operations via keyboard', () => {
     fireEvent.keyDown(container, { key: 'Delete' });
 
     // First heading should be gone
-    expect(screen.queryByText('First Heading')).not.toBeInTheDocument();
+    expect(getTreePane().queryByText('First Heading')).not.toBeInTheDocument();
     // Second heading should still be there
-    expect(screen.getByText('Second Heading')).toBeInTheDocument();
+    expect(getTreePane().getByText('Second Heading')).toBeInTheDocument();
   });
 
   test('Tab indents selected node under previous sibling', () => {
@@ -442,7 +444,7 @@ describe('node operations via keyboard', () => {
     const container = getContainer();
 
     // Select the content node
-    fireEvent.click(screen.getByText('Child Content'));
+    fireEvent.click(getTreePane().getByText('Child Content'));
 
     // Before indent: content node is a sibling of heading (not nested inside it)
     const headingWrapper = getNodeWrapper('Parent Heading');
@@ -495,7 +497,7 @@ describe('node operations via keyboard', () => {
     const container = getContainer();
 
     // Select the nested content node
-    fireEvent.click(screen.getByText('Nested Content'));
+    fireEvent.click(getTreePane().getByText('Nested Content'));
 
     // Before outdent: content node is nested inside heading
     const headingWrapper = getNodeWrapper('Parent Heading');
@@ -520,13 +522,13 @@ describe('undo and redo', () => {
     // Select and delete a node
     selectFirstNode();
     fireEvent.keyDown(container, { key: 'Delete' });
-    expect(screen.queryByText('First Heading')).not.toBeInTheDocument();
+    expect(getTreePane().queryByText('First Heading')).not.toBeInTheDocument();
 
     // Undo with Ctrl+Z
     fireEvent.keyDown(container, { key: 'z', ctrlKey: true });
 
     // Node should be restored
-    expect(screen.getByText('First Heading')).toBeInTheDocument();
+    expect(getTreePane().getByText('First Heading')).toBeInTheDocument();
   });
 
   test('Ctrl+Y redoes undone operation', () => {
@@ -536,15 +538,15 @@ describe('undo and redo', () => {
     // Select and delete a node
     selectFirstNode();
     fireEvent.keyDown(container, { key: 'Delete' });
-    expect(screen.queryByText('First Heading')).not.toBeInTheDocument();
+    expect(getTreePane().queryByText('First Heading')).not.toBeInTheDocument();
 
     // Undo
     fireEvent.keyDown(container, { key: 'z', ctrlKey: true });
-    expect(screen.getByText('First Heading')).toBeInTheDocument();
+    expect(getTreePane().getByText('First Heading')).toBeInTheDocument();
 
     // Redo with Ctrl+Y
     fireEvent.keyDown(container, { key: 'y', ctrlKey: true });
-    expect(screen.queryByText('First Heading')).not.toBeInTheDocument();
+    expect(getTreePane().queryByText('First Heading')).not.toBeInTheDocument();
   });
 
   test('Cmd+Shift+Z redoes undone operation', () => {
@@ -557,11 +559,11 @@ describe('undo and redo', () => {
 
     // Undo
     fireEvent.keyDown(container, { key: 'z', metaKey: true });
-    expect(screen.getByText('First Heading')).toBeInTheDocument();
+    expect(getTreePane().getByText('First Heading')).toBeInTheDocument();
 
     // Redo with Cmd+Shift+Z
     fireEvent.keyDown(container, { key: 'z', metaKey: true, shiftKey: true });
-    expect(screen.queryByText('First Heading')).not.toBeInTheDocument();
+    expect(getTreePane().queryByText('First Heading')).not.toBeInTheDocument();
   });
 });
 
@@ -625,7 +627,7 @@ describe('edit mode behaviors', () => {
     });
 
     // The empty node should be deleted, only the heading remains
-    expect(screen.getByText('First Heading')).toBeInTheDocument();
+    expect(getTreePane().getByText('First Heading')).toBeInTheDocument();
     const remainingDraggables = document.querySelectorAll('[draggable]');
     expect(remainingDraggables.length).toBe(1);
 
@@ -674,5 +676,28 @@ describe('empty document', () => {
     fireEvent.click(clickTarget);
 
     expect(screen.getByText('Document is empty')).toBeInTheDocument();
+  });
+});
+
+describe('document outline', () => {
+  test('clicking a heading in the outline selects the corresponding node in the tree', async () => {
+    vi.useFakeTimers();
+    // jsdom doesn't implement scrollIntoView
+    Element.prototype.scrollIntoView = vi.fn();
+    renderTreeEditor();
+
+    // The outline tab should be visible (no pdfUrl, so outline is the default tab)
+    const outlineNav = screen.getByRole('navigation', { name: /document outline/i });
+    const outlineButton = within(outlineNav).getByText('First Heading');
+
+    await act(async () => {
+      fireEvent.click(outlineButton);
+      vi.runAllTimers();
+    });
+
+    // The corresponding node in the tree editor should be selected
+    expectNodeSelected('First Heading');
+
+    vi.useRealTimers();
   });
 });

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -5,8 +5,8 @@ import { useTreeEditor } from '../hooks/useTreeEditor';
 import type { ContainerDocumentNode, Language } from '../types/document';
 import { deriveJsonFilename, downloadFile } from '../utils/document-utils';
 import { FloatingToolbar } from './FloatingToolbar';
+import { LeftPane } from './LeftPane';
 import { RecursiveTreeNode } from './RecursiveTreeNode';
-import { SourcePreview } from './SourcePreview';
 import { Toolbar } from './Toolbar';
 import { TreeCallbacksContext, TreeUIStoreContext } from './TreeNodeContext';
 
@@ -94,6 +94,17 @@ export function TreeEditor({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const blockRefs = useRef<{ [key: string]: HTMLElement | null }>({});
+
+  const handleOutlineHeadingClick = useCallback(
+    (nodeId: string) => {
+      store.setSelection(new Set([nodeId]));
+      // Scroll the node into view after React renders the selection change
+      requestAnimationFrame(() => {
+        blockRefs.current[nodeId]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      });
+    },
+    [store]
+  );
 
   // Compute toolbar type for single selected node
   const selectedNodeType = useMemo(() => {
@@ -451,9 +462,15 @@ export function TreeEditor({
         onDownload={handleDownload}
       />
       <div className="flex-1 flex overflow-hidden">
-        {pdfUrl && <SourcePreview url={pdfUrl} />}
+        <LeftPane
+          pdfUrl={pdfUrl}
+          document={document}
+          language={language}
+          onHeadingClick={handleOutlineHeadingClick}
+        />
         <div
           className="flex-1 overflow-y-auto bg-white relative outline-none"
+          data-testid="tree-editor-pane"
           ref={containerRef}
           tabIndex={0}
           onKeyDown={handleGlobalKeyDown}

--- a/src/utils/outline-utils.test.ts
+++ b/src/utils/outline-utils.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'vitest';
+import type { ContainerDocumentNode } from '../types/document';
+import { getDocumentOutline } from './outline-utils';
+
+const makeDoc = (...children: ContainerDocumentNode['children']): ContainerDocumentNode => ({
+  id: 'root',
+  number: null,
+  type: 'document',
+  children,
+});
+
+describe('getDocumentOutline', () => {
+  test('returns empty array for document with no headings', () => {
+    const doc = makeDoc({
+      id: 'c1',
+      number: null,
+      type: 'content',
+      contents: { de: 'Hello' },
+      children: [],
+    });
+    expect(getDocumentOutline(doc, 'de')).toEqual([]);
+  });
+
+  test('extracts a single top-level heading', () => {
+    const doc = makeDoc({
+      id: 'h1',
+      number: '1',
+      type: 'heading',
+      contents: { de: 'Einleitung' },
+      children: [],
+    });
+    expect(getDocumentOutline(doc, 'de')).toEqual([
+      { id: 'h1', number: '1', text: 'Einleitung', depth: 0 },
+    ]);
+  });
+
+  test('extracts nested headings with correct depths', () => {
+    const doc = makeDoc({
+      id: 'h1',
+      number: '1',
+      type: 'heading',
+      contents: { de: 'Top' },
+      children: [
+        {
+          id: 'h2',
+          number: '1.1',
+          type: 'heading',
+          contents: { de: 'Nested' },
+          children: [
+            {
+              id: 'h3',
+              number: '1.1.1',
+              type: 'heading',
+              contents: { de: 'Deep' },
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
+    expect(getDocumentOutline(doc, 'de')).toEqual([
+      { id: 'h1', number: '1', text: 'Top', depth: 0 },
+      { id: 'h2', number: '1.1', text: 'Nested', depth: 1 },
+      { id: 'h3', number: '1.1.1', text: 'Deep', depth: 2 },
+    ]);
+  });
+
+  test('uses specified language for text', () => {
+    const doc = makeDoc({
+      id: 'h1',
+      number: null,
+      type: 'heading',
+      contents: { de: 'German', fr: 'French' },
+      children: [],
+    });
+    expect(getDocumentOutline(doc, 'fr')).toEqual([
+      { id: 'h1', number: null, text: 'French', depth: 0 },
+    ]);
+  });
+
+  test('falls back to first available language when specified language is missing', () => {
+    const doc = makeDoc({
+      id: 'h1',
+      number: null,
+      type: 'heading',
+      contents: { en: 'English only' },
+      children: [],
+    });
+    expect(getDocumentOutline(doc, 'de')).toEqual([
+      { id: 'h1', number: null, text: 'English only', depth: 0 },
+    ]);
+  });
+
+  test('strips HTML tags from heading content', () => {
+    const doc = makeDoc({
+      id: 'h1',
+      number: null,
+      type: 'heading',
+      contents: { de: '<strong>Bold</strong> and <em>italic</em> text' },
+      children: [],
+    });
+    expect(getDocumentOutline(doc, 'de')).toEqual([
+      { id: 'h1', number: null, text: 'Bold and italic text', depth: 0 },
+    ]);
+  });
+
+  test('includes heading number when present', () => {
+    const doc = makeDoc(
+      {
+        id: 'h1',
+        number: 'Art. 1',
+        type: 'heading',
+        contents: { de: 'With number' },
+        children: [],
+      },
+      {
+        id: 'h2',
+        number: null,
+        type: 'heading',
+        contents: { de: 'Without number' },
+        children: [],
+      }
+    );
+    const result = getDocumentOutline(doc, 'de');
+    expect(result[0].number).toBe('Art. 1');
+    expect(result[1].number).toBeNull();
+  });
+
+  test('ignores non-heading nodes (content, list, etc.)', () => {
+    const doc = makeDoc(
+      { id: 'c1', number: null, type: 'content', contents: { de: 'Text' }, children: [] },
+      { id: 'l1', number: null, type: 'list', children: [] },
+      {
+        id: 'h1',
+        number: null,
+        type: 'heading',
+        contents: { de: 'Only heading' },
+        children: [
+          { id: 'c2', number: null, type: 'content', contents: { de: 'More text' }, children: [] },
+        ],
+      }
+    );
+    expect(getDocumentOutline(doc, 'de')).toEqual([
+      { id: 'h1', number: null, text: 'Only heading', depth: 0 },
+    ]);
+  });
+
+  test('returns empty text for heading with no content in any language', () => {
+    const doc = makeDoc({
+      id: 'h1',
+      number: null,
+      type: 'heading',
+      contents: {},
+      children: [],
+    });
+    expect(getDocumentOutline(doc, 'de')).toEqual([{ id: 'h1', number: null, text: '', depth: 0 }]);
+  });
+});

--- a/src/utils/outline-utils.ts
+++ b/src/utils/outline-utils.ts
@@ -1,0 +1,53 @@
+import type { ContainerDocumentNode, DocumentNode, Language } from '../types/document';
+
+export interface OutlineEntry {
+  id: string;
+  number: string | null;
+  text: string;
+  depth: number;
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, '');
+}
+
+function getTextContent(
+  contents: Partial<{ [K in Language]: string }>,
+  language: Language
+): string {
+  const text = contents[language] ?? Object.values(contents)[0] ?? '';
+  return stripHtml(text);
+}
+
+export function getDocumentOutline(
+  root: ContainerDocumentNode,
+  language: Language
+): OutlineEntry[] {
+  const result: OutlineEntry[] = [];
+
+  function walk(node: DocumentNode, depth: number) {
+    if (node.type === 'heading') {
+      result.push({
+        id: node.id,
+        number: node.number,
+        text: getTextContent(node.contents, language),
+        depth,
+      });
+      // Recurse into heading children to find nested headings
+      for (const child of node.children) {
+        walk(child, depth + 1);
+      }
+    } else if ('children' in node && node.children) {
+      // For container nodes (document, list, list_item), look inside for headings
+      for (const child of node.children) {
+        walk(child, depth);
+      }
+    }
+  }
+
+  for (const child of root.children) {
+    walk(child, 0);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Convert the left pane into a tabbed interface using `@radix-ui/react-tabs`
- **Original tab**: shows the processed document preview with a warning banner noting it may not match the original exactly
- **Outline tab**: displays the heading hierarchy as a clickable, read-only tree; clicking a heading selects and scrolls to the corresponding node in the tree editor
- When no source URL is available, only the Outline tab is shown

## Test plan
- [x] `getDocumentOutline` correctly extracts headings with depth, language fallback, HTML stripping (9 tests)
- [x] `DocumentOutline` renders headings, handles clicks, shows empty state (4 tests)
- [x] `LeftPane` renders correct tabs based on pdfUrl, switches tabs, shows warning (6 tests)
- [x] Clicking outline heading selects the node in the tree editor (1 integration test)
- [x] All 560 existing + new tests pass
- [x] Production build succeeds
- [x] Manual: load a document with headings, verify both tabs work, verify click-to-scroll

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)