### PR TITLE
Add number badge to content and list nodes

### DIFF
--- a/src/components/RecursiveTreeNode.test.tsx
+++ b/src/components/RecursiveTreeNode.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { TreeUIStore } from '../stores/TreeUIStore';
 import type {
   ContainerDocumentNode,
+  ContentDocumentNode,
   HeadingDocumentNode,
   LeafDocumentNode,
 } from '../types/document';
@@ -204,6 +205,74 @@ describe('RecursiveTreeNode', () => {
 
       const placeholder = container.querySelector('.border-dashed');
       expect(placeholder).not.toBeNull();
+    });
+
+    test('content node with null number renders a dashed placeholder badge', () => {
+      const node: ContentDocumentNode = {
+        id: 'c-no-num',
+        number: null,
+        type: 'content',
+        contents: { de: 'Some paragraph' },
+        children: [],
+      };
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />);
+
+      const placeholder = container.querySelector('.border-dashed');
+      expect(placeholder).not.toBeNull();
+    });
+
+    test('content node with a number renders a solid badge', () => {
+      const onNumberDoubleClick = vi.fn();
+      const node: ContentDocumentNode = {
+        id: 'c-with-num',
+        number: '2.',
+        type: 'content',
+        contents: { de: 'Numbered paragraph' },
+        children: [],
+      };
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        callbacks: { onNumberDoubleClick },
+      });
+
+      const badge = container.querySelector('.border-gray-300');
+      expect(badge).not.toBeNull();
+      expect(badge?.textContent).toBe('2.');
+      expect(badge?.classList.contains('border-dashed')).toBe(false);
+      fireEvent.doubleClick(badge!);
+      expect(onNumberDoubleClick).toHaveBeenCalledWith(expect.any(Object), 'c-with-num');
+    });
+
+    test('list node with null number renders a dashed placeholder badge', () => {
+      const node: ContainerDocumentNode = {
+        id: 'list-no-num',
+        number: null,
+        type: 'list',
+        children: [],
+      };
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />);
+
+      const placeholder = container.querySelector('.border-dashed');
+      expect(placeholder).not.toBeNull();
+    });
+
+    test('list node with a number renders a solid badge', () => {
+      const onNumberDoubleClick = vi.fn();
+      const node: ContainerDocumentNode = {
+        id: 'list-with-num',
+        number: 'A.',
+        type: 'list',
+        children: [],
+      };
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        callbacks: { onNumberDoubleClick },
+      });
+
+      const badge = container.querySelector('.border-gray-300');
+      expect(badge).not.toBeNull();
+      expect(badge?.textContent).toBe('A.');
+      expect(badge?.classList.contains('border-dashed')).toBe(false);
+      fireEvent.doubleClick(badge!);
+      expect(onNumberDoubleClick).toHaveBeenCalledWith(expect.any(Object), 'list-with-num');
     });
 
     test('footnote with a number renders a solid badge that is double-clickable', () => {

--- a/src/components/RecursiveTreeNode.tsx
+++ b/src/components/RecursiveTreeNode.tsx
@@ -214,7 +214,12 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
       }
 
       if (node.type === 'list') {
-        return <span className="text-gray-400 select-none text-sm">(list)</span>;
+        return (
+          <div className="flex items-baseline flex-1">
+            {renderNumberBadge(node.number, 'font-medium text-gray-500 border-gray-300 bg-gray-50')}{' '}
+            <span className="text-gray-400 select-none text-sm">(list)</span>
+          </div>
+        );
       }
 
       // list_item is a container - render just the marker, children will be nested
@@ -234,7 +239,7 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
       // Nodes with content
       return (
         <div className="flex items-baseline flex-1">
-          {/* Show number badge for headings and footnotes (dashed placeholder when no number) */}
+          {/* Show number badge for headings, footnotes, and content (dashed placeholder when no number) */}
           {node.type === 'heading' &&
             renderNumberBadge(
               node.number,
@@ -245,6 +250,8 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
               node.number,
               'font-medium text-amber-600 border-amber-200 bg-amber-50'
             )}
+          {node.type === 'content' &&
+            renderNumberBadge(node.number, 'font-medium text-gray-600 border-gray-300 bg-gray-50')}
 
           {'contents' in node && (
             <ContentBlock


### PR DESCRIPTION
## Summary
- Adds editable number badge (with dashed placeholder when empty) to **content** and **list** node types
- Matches the existing pattern used for headings, footnotes, and list items
- Closes #51

## Details
All node types in the data model have a `number` field, but only `heading`, `footnote`, and `list_item` rendered an editable badge. Per discussion in #51, `content` and `list` nodes now also show the badge. `document` (virtual root) and `image` are intentionally excluded.

## Test plan
- [x] 4 new tests covering null/non-null number for both `content` and `list` nodes
- [x] All 564 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)