### PR TITLE
Refactor: Extract EditorInterface from TreeEditor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
+import { EditorInterface } from './components/EditorInterface';
 import { Header } from './components/Header';
 import { LoadDocument } from './components/LoadDocument';
-import { TreeEditor } from './components/TreeEditor';
 import type { ContainerDocumentNode } from './types/document';
 
 function App() {
@@ -42,7 +42,7 @@ function App() {
               <LoadDocument onConvert={handleConvert} />
             </div>
           ) : document ? (
-            <TreeEditor
+            <EditorInterface
               initialDocument={document}
               pdfUrl={pdfUrl}
               documentName={fileName}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import type { ContainerDocumentNode } from './types/document';
 
 function App() {
   const [document, setDocument] = useState<ContainerDocumentNode | null>(null);
-  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+  const [documentUrl, setDocumentUrl] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
   const [view, setView] = useState<'upload' | 'editor'>('upload');
 
@@ -17,7 +17,7 @@ function App() {
     filename?: string | null
   ) => {
     setDocument(doc);
-    setPdfUrl(url);
+    setDocumentUrl(url);
     setFileName(filename ?? null);
     setView('editor');
   };
@@ -26,7 +26,7 @@ function App() {
     if (window.confirm('Are you sure you want to go back? Unsaved changes will be lost.')) {
       setView('upload');
       setDocument(null);
-      setPdfUrl(null);
+      setDocumentUrl(null);
       setFileName(null);
     }
   };
@@ -44,7 +44,7 @@ function App() {
           ) : document ? (
             <EditorInterface
               initialDocument={document}
-              pdfUrl={pdfUrl}
+              documentUrl={documentUrl}
               documentName={fileName}
               onBack={handleBack}
             />

--- a/src/components/EditorInterface.test.tsx
+++ b/src/components/EditorInterface.test.tsx
@@ -29,7 +29,7 @@ const renderEditorInterface = (props?: Partial<Parameters<typeof EditorInterface
   render(
     <EditorInterface
       initialDocument={createTestDocument()}
-      pdfUrl={null}
+      documentUrl={null}
       documentName="test.docx"
       language="de"
       onBack={() => {}}
@@ -102,7 +102,7 @@ describe('document outline', () => {
     Element.prototype.scrollIntoView = vi.fn();
     renderEditorInterface();
 
-    // The preview tab with TOC is visible (no pdfUrl, so preview is the default tab)
+    // The preview tab with TOC is visible (no documentUrl, so preview is the default tab)
     const tocNav = screen.getByRole('navigation', { name: /inhaltsverzeichnis/i });
     const outlineButton = within(tocNav).getByText('First Heading');
 

--- a/src/components/EditorInterface.test.tsx
+++ b/src/components/EditorInterface.test.tsx
@@ -1,0 +1,119 @@
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import type { ContainerDocumentNode } from '../types/document';
+import { EditorInterface } from './EditorInterface';
+
+const createTestDocument = (): ContainerDocumentNode => ({
+  id: 'root',
+  number: null,
+  type: 'document',
+  children: [
+    {
+      id: 'h1',
+      number: '1',
+      type: 'heading',
+      contents: { de: 'First Heading' },
+      children: [],
+    },
+    {
+      id: 'h2',
+      number: '2',
+      type: 'heading',
+      contents: { de: 'Second Heading' },
+      children: [],
+    },
+  ],
+});
+
+const renderEditorInterface = (props?: Partial<Parameters<typeof EditorInterface>[0]>) =>
+  render(
+    <EditorInterface
+      initialDocument={createTestDocument()}
+      pdfUrl={null}
+      documentName="test.docx"
+      language="de"
+      onBack={() => {}}
+      {...props}
+    />
+  );
+
+describe('EditorInterface layout', () => {
+  test('renders Toolbar with Close Editor button', () => {
+    renderEditorInterface();
+    expect(screen.getByText('Close Editor')).toBeInTheDocument();
+  });
+
+  test('renders Toolbar undo/redo buttons', () => {
+    renderEditorInterface();
+    // History counter shows "1 / 1" for initial state
+    expect(screen.getByText('1 / 1')).toBeInTheDocument();
+  });
+
+  test('renders the tree editor pane', () => {
+    renderEditorInterface();
+    expect(screen.getByTestId('tree-editor-pane')).toBeInTheDocument();
+  });
+
+  test('calls onBack when Close Editor is clicked', () => {
+    const onBack = vi.fn();
+    renderEditorInterface({ onBack });
+
+    fireEvent.click(screen.getByText('Close Editor'));
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  test('renders Download JSON button', () => {
+    renderEditorInterface();
+    expect(screen.getByText('Download JSON')).toBeInTheDocument();
+  });
+});
+
+/** Get a within-scoped query object for the tree editor (right pane). */
+const getTreePane = () => within(screen.getByTestId('tree-editor-pane'));
+
+/** Assert that a node (found by text content) has selected styling. */
+const expectNodeSelected = (text: string) => {
+  const el = getTreePane().getByText(text);
+  const wrapper = el.closest('[draggable]') as HTMLElement;
+  expect(wrapper.className).toContain('bg-blue');
+};
+
+describe('FloatingToolbar tooltips', () => {
+  test('toolbar buttons show keyboard shortcuts in tooltips', () => {
+    renderEditorInterface();
+
+    // Click the first heading node to select it
+    const firstHeading = getTreePane().getByText('First Heading');
+    fireEvent.click(firstHeading);
+
+    expect(screen.getByTitle('Heading (H)')).toBeInTheDocument();
+    expect(screen.getByTitle('Content (C)')).toBeInTheDocument();
+    expect(screen.getByTitle('Bullet List (U)')).toBeInTheDocument();
+    expect(screen.getByTitle('Ordered List (O)')).toBeInTheDocument();
+    expect(screen.getByTitle('Alpha List (A)')).toBeInTheDocument();
+    expect(screen.getByTitle('Footnote (F)')).toBeInTheDocument();
+  });
+});
+
+describe('document outline', () => {
+  test('clicking a heading in the outline selects the corresponding node in the tree', async () => {
+    vi.useFakeTimers();
+    // jsdom doesn't implement scrollIntoView
+    Element.prototype.scrollIntoView = vi.fn();
+    renderEditorInterface();
+
+    // The preview tab with TOC is visible (no pdfUrl, so preview is the default tab)
+    const tocNav = screen.getByRole('navigation', { name: /inhaltsverzeichnis/i });
+    const outlineButton = within(tocNav).getByText('First Heading');
+
+    await act(async () => {
+      fireEvent.click(outlineButton);
+      vi.runAllTimers();
+    });
+
+    // The corresponding node in the tree editor should be selected
+    expectNodeSelected('First Heading');
+
+    vi.useRealTimers();
+  });
+});

--- a/src/components/EditorInterface.tsx
+++ b/src/components/EditorInterface.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useRef } from 'react';
+import { useTreeEditor } from '../hooks/useTreeEditor';
+import type { ContainerDocumentNode, Language } from '../types/document';
+import { deriveJsonFilename, downloadFile } from '../utils/document-utils';
+import { LeftPane } from './LeftPane';
+import { Toolbar } from './Toolbar';
+import { TreeEditor } from './TreeEditor';
+
+interface EditorInterfaceProps {
+  initialDocument: ContainerDocumentNode;
+  pdfUrl: string | null;
+  documentName?: string | null;
+  language?: Language;
+  onBack: () => void;
+}
+
+export function EditorInterface({
+  initialDocument,
+  pdfUrl,
+  documentName,
+  language = 'de',
+  onBack,
+}: EditorInterfaceProps) {
+  const editor = useTreeEditor(initialDocument, language);
+
+  const scrollToNodeRef = useRef<((nodeId: string) => void) | null>(null);
+
+  const handleRegisterScrollToNode = useCallback((scrollFn: (nodeId: string) => void) => {
+    scrollToNodeRef.current = scrollFn;
+  }, []);
+
+  const handleOutlineHeadingClick = useCallback(
+    (nodeId: string) => {
+      editor.store.setSelection(new Set([nodeId]));
+      requestAnimationFrame(() => {
+        scrollToNodeRef.current?.(nodeId);
+      });
+    },
+    [editor.store]
+  );
+
+  const handleDownload = () => {
+    downloadFile(
+      JSON.stringify(editor.document, null, 2),
+      deriveJsonFilename(documentName),
+      'application/json'
+    );
+  };
+
+  return (
+    <div className="h-[calc(100vh-64px)] flex flex-col">
+      <Toolbar
+        onBack={onBack}
+        onUndo={editor.undo}
+        onRedo={editor.redo}
+        canUndo={editor.canUndo}
+        canRedo={editor.canRedo}
+        historyIndex={editor.historyIndex}
+        historyLength={editor.historyLength}
+        onDownload={handleDownload}
+      />
+      <div className="flex-1 flex overflow-hidden">
+        <LeftPane
+          pdfUrl={pdfUrl}
+          document={editor.document}
+          language={language}
+          onHeadingClick={handleOutlineHeadingClick}
+        />
+        <TreeEditor
+          editor={editor}
+          language={language}
+          onScrollToNode={handleRegisterScrollToNode}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/EditorInterface.tsx
+++ b/src/components/EditorInterface.tsx
@@ -8,7 +8,7 @@ import { TreeEditor } from './TreeEditor';
 
 interface EditorInterfaceProps {
   initialDocument: ContainerDocumentNode;
-  pdfUrl: string | null;
+  documentUrl: string | null;
   documentName?: string | null;
   language?: Language;
   onBack: () => void;
@@ -16,7 +16,7 @@ interface EditorInterfaceProps {
 
 export function EditorInterface({
   initialDocument,
-  pdfUrl,
+  documentUrl,
   documentName,
   language = 'de',
   onBack,
@@ -61,7 +61,7 @@ export function EditorInterface({
       />
       <div className="flex-1 flex overflow-hidden">
         <LeftPane
-          pdfUrl={pdfUrl}
+          documentUrl={documentUrl}
           document={editor.document}
           language={language}
           onHeadingClick={handleOutlineHeadingClick}

--- a/src/components/LeftPane.test.tsx
+++ b/src/components/LeftPane.test.tsx
@@ -20,10 +20,10 @@ const docWithHeading = makeDoc({
 });
 
 describe('LeftPane', () => {
-  test('renders both tabs when pdfUrl is provided', () => {
+  test('renders both tabs when documentUrl is provided', () => {
     render(
       <LeftPane
-        pdfUrl="http://example.com/doc.html"
+        documentUrl="http://example.com/doc.html"
         document={docWithHeading}
         language="de"
         onHeadingClick={() => {}}
@@ -34,10 +34,10 @@ describe('LeftPane', () => {
     expect(screen.getByRole('tab', { name: /preview/i })).toBeInTheDocument();
   });
 
-  test('shows Original tab content by default when pdfUrl exists', () => {
+  test('shows Original tab content by default when documentUrl exists', () => {
     render(
       <LeftPane
-        pdfUrl="http://example.com/doc.html"
+        documentUrl="http://example.com/doc.html"
         document={docWithHeading}
         language="de"
         onHeadingClick={() => {}}
@@ -48,9 +48,14 @@ describe('LeftPane', () => {
     expect(screen.getByText(/may not correspond/i)).toBeInTheDocument();
   });
 
-  test('shows Preview tab by default when pdfUrl is null', () => {
+  test('shows Preview tab by default when documentUrl is null', () => {
     render(
-      <LeftPane pdfUrl={null} document={docWithHeading} language="de" onHeadingClick={() => {}} />
+      <LeftPane
+        documentUrl={null}
+        document={docWithHeading}
+        language="de"
+        onHeadingClick={() => {}}
+      />
     );
 
     expect(screen.queryByRole('tab', { name: /original/i })).not.toBeInTheDocument();
@@ -60,7 +65,7 @@ describe('LeftPane', () => {
   test('shows processing warning in Original tab', () => {
     render(
       <LeftPane
-        pdfUrl="http://example.com/doc.html"
+        documentUrl="http://example.com/doc.html"
         document={docWithHeading}
         language="de"
         onHeadingClick={() => {}}
@@ -74,7 +79,7 @@ describe('LeftPane', () => {
     const user = userEvent.setup();
     render(
       <LeftPane
-        pdfUrl="http://example.com/doc.html"
+        documentUrl="http://example.com/doc.html"
         document={docWithHeading}
         language="de"
         onHeadingClick={() => {}}
@@ -91,7 +96,12 @@ describe('LeftPane', () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
     render(
-      <LeftPane pdfUrl={null} document={docWithHeading} language="de" onHeadingClick={onClick} />
+      <LeftPane
+        documentUrl={null}
+        document={docWithHeading}
+        language="de"
+        onHeadingClick={onClick}
+      />
     );
 
     // Click the heading in the TOC

--- a/src/components/LeftPane.tsx
+++ b/src/components/LeftPane.tsx
@@ -4,7 +4,7 @@ import { DocumentPreview } from './DocumentPreview';
 import { SourcePreview } from './SourcePreview';
 
 interface LeftPaneProps {
-  pdfUrl: string | null;
+  documentUrl: string | null;
   document: ContainerDocumentNode;
   language: Language;
   onHeadingClick: (nodeId: string) => void;
@@ -13,12 +13,15 @@ interface LeftPaneProps {
 const tabTriggerClass =
   'px-4 py-2 text-sm font-medium text-gray-600 border-b-2 border-transparent data-[state=active]:border-blue-500 data-[state=active]:text-blue-600 transition-colors';
 
-export function LeftPane({ pdfUrl, document, language, onHeadingClick }: LeftPaneProps) {
+export function LeftPane({ documentUrl, document, language, onHeadingClick }: LeftPaneProps) {
   return (
     <div className="flex-1 border-r border-gray-200 bg-gray-50 flex flex-col min-w-0 w-1/2">
-      <Tabs.Root defaultValue={pdfUrl ? 'original' : 'preview'} className="flex flex-col h-full">
+      <Tabs.Root
+        defaultValue={documentUrl ? 'original' : 'preview'}
+        className="flex flex-col h-full"
+      >
         <Tabs.List className="flex border-b border-gray-200 bg-white px-2 shrink-0">
-          {pdfUrl && (
+          {documentUrl && (
             <Tabs.Trigger value="original" className={tabTriggerClass}>
               Original
             </Tabs.Trigger>
@@ -27,14 +30,14 @@ export function LeftPane({ pdfUrl, document, language, onHeadingClick }: LeftPan
             Preview
           </Tabs.Trigger>
         </Tabs.List>
-        {pdfUrl && (
+        {documentUrl && (
           <Tabs.Content value="original" className="flex-1 overflow-hidden flex flex-col">
             <div className="px-4 py-2 bg-amber-50 border-b border-amber-200 text-amber-700 text-xs shrink-0">
               This preview has been processed and may not correspond to the original document
               exactly.
             </div>
             <div className="flex-1 min-h-0">
-              <SourcePreview url={pdfUrl} />
+              <SourcePreview url={documentUrl} />
             </div>
           </Tabs.Content>
         )}

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -1,7 +1,9 @@
+// Tests for TreeEditor behavior (keyboard shortcuts, selection, editing, drag-drop).
+// Rendered via EditorInterface since TreeEditor requires the useTreeEditor hook output as a prop.
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import type { ContainerDocumentNode } from '../types/document';
-import { TreeEditor } from './TreeEditor';
+import { EditorInterface } from './EditorInterface';
 
 const createTestDocument = (): ContainerDocumentNode => ({
   id: 'root',
@@ -27,7 +29,7 @@ const createTestDocument = (): ContainerDocumentNode => ({
 
 const renderTreeEditor = () =>
   render(
-    <TreeEditor
+    <EditorInterface
       initialDocument={createTestDocument()}
       pdfUrl={null}
       documentName="test.docx"
@@ -269,20 +271,6 @@ describe('double-click inline editing', () => {
   });
 });
 
-describe('FloatingToolbar tooltips', () => {
-  test('toolbar buttons show keyboard shortcuts in tooltips', () => {
-    renderTreeEditor();
-    selectFirstNode();
-
-    expect(screen.getByTitle('Heading (H)')).toBeInTheDocument();
-    expect(screen.getByTitle('Content (C)')).toBeInTheDocument();
-    expect(screen.getByTitle('Bullet List (U)')).toBeInTheDocument();
-    expect(screen.getByTitle('Ordered List (O)')).toBeInTheDocument();
-    expect(screen.getByTitle('Alpha List (A)')).toBeInTheDocument();
-    expect(screen.getByTitle('Footnote (F)')).toBeInTheDocument();
-  });
-});
-
 describe('selection and navigation', () => {
   test('ArrowDown selects first node when nothing is selected', () => {
     renderTreeEditor();
@@ -432,7 +420,7 @@ describe('node operations via keyboard', () => {
     };
 
     render(
-      <TreeEditor
+      <EditorInterface
         initialDocument={doc}
         pdfUrl={null}
         documentName="test.docx"
@@ -485,7 +473,7 @@ describe('node operations via keyboard', () => {
     };
 
     render(
-      <TreeEditor
+      <EditorInterface
         initialDocument={doc}
         pdfUrl={null}
         documentName="test.docx"
@@ -595,7 +583,7 @@ describe('edit mode behaviors', () => {
     };
 
     render(
-      <TreeEditor
+      <EditorInterface
         initialDocument={doc}
         pdfUrl={null}
         documentName="test.docx"
@@ -645,7 +633,7 @@ describe('empty document', () => {
 
   test('shows empty state message', () => {
     render(
-      <TreeEditor
+      <EditorInterface
         initialDocument={createEmptyDocument()}
         pdfUrl={null}
         documentName="test.docx"
@@ -660,7 +648,7 @@ describe('empty document', () => {
 
   test('clicking empty state does not crash', () => {
     render(
-      <TreeEditor
+      <EditorInterface
         initialDocument={createEmptyDocument()}
         pdfUrl={null}
         documentName="test.docx"
@@ -676,28 +664,5 @@ describe('empty document', () => {
     fireEvent.click(clickTarget);
 
     expect(screen.getByText('Document is empty')).toBeInTheDocument();
-  });
-});
-
-describe('document outline', () => {
-  test('clicking a heading in the outline selects the corresponding node in the tree', async () => {
-    vi.useFakeTimers();
-    // jsdom doesn't implement scrollIntoView
-    Element.prototype.scrollIntoView = vi.fn();
-    renderTreeEditor();
-
-    // The preview tab with TOC is visible (no pdfUrl, so preview is the default tab)
-    const tocNav = screen.getByRole('navigation', { name: /inhaltsverzeichnis/i });
-    const outlineButton = within(tocNav).getByText('First Heading');
-
-    await act(async () => {
-      fireEvent.click(outlineButton);
-      vi.runAllTimers();
-    });
-
-    // The corresponding node in the tree editor should be selected
-    expectNodeSelected('First Heading');
-
-    vi.useRealTimers();
   });
 });

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -31,7 +31,7 @@ const renderTreeEditor = () =>
   render(
     <EditorInterface
       initialDocument={createTestDocument()}
-      pdfUrl={null}
+      documentUrl={null}
       documentName="test.docx"
       language="de"
       onBack={() => {}}
@@ -422,7 +422,7 @@ describe('node operations via keyboard', () => {
     render(
       <EditorInterface
         initialDocument={doc}
-        pdfUrl={null}
+        documentUrl={null}
         documentName="test.docx"
         language="de"
         onBack={() => {}}
@@ -475,7 +475,7 @@ describe('node operations via keyboard', () => {
     render(
       <EditorInterface
         initialDocument={doc}
-        pdfUrl={null}
+        documentUrl={null}
         documentName="test.docx"
         language="de"
         onBack={() => {}}
@@ -585,7 +585,7 @@ describe('edit mode behaviors', () => {
     render(
       <EditorInterface
         initialDocument={doc}
-        pdfUrl={null}
+        documentUrl={null}
         documentName="test.docx"
         language="de"
         onBack={() => {}}
@@ -635,7 +635,7 @@ describe('empty document', () => {
     render(
       <EditorInterface
         initialDocument={createEmptyDocument()}
-        pdfUrl={null}
+        documentUrl={null}
         documentName="test.docx"
         language="de"
         onBack={() => {}}
@@ -650,7 +650,7 @@ describe('empty document', () => {
     render(
       <EditorInterface
         initialDocument={createEmptyDocument()}
-        pdfUrl={null}
+        documentUrl={null}
         documentName="test.docx"
         language="de"
         onBack={() => {}}

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -13,27 +13,24 @@ interface TreeEditorProps {
   onScrollToNode?: (scrollFn: (nodeId: string) => void) => void;
 }
 
-const isCursorAtStart = (el: HTMLElement) => {
+/** Check whether the collapsed cursor is at the start or end of `el`. */
+const isCursorAtBoundary = (el: HTMLElement, boundary: 'start' | 'end') => {
   const sel = window.getSelection();
   if (!sel || sel.rangeCount === 0) return false;
   const range = sel.getRangeAt(0);
   if (!range.collapsed) return false;
-  const preRange = range.cloneRange();
-  preRange.selectNodeContents(el);
-  preRange.setEnd(range.endContainer, range.endOffset);
-  return preRange.toString().trim().length === 0;
+  const testRange = range.cloneRange();
+  testRange.selectNodeContents(el);
+  if (boundary === 'start') {
+    testRange.setEnd(range.endContainer, range.endOffset);
+  } else {
+    testRange.setStart(range.endContainer, range.endOffset);
+  }
+  return testRange.toString().trim().length === 0;
 };
 
-const isCursorAtEnd = (el: HTMLElement) => {
-  const sel = window.getSelection();
-  if (!sel || sel.rangeCount === 0) return false;
-  const range = sel.getRangeAt(0);
-  if (!range.collapsed) return false;
-  const postRange = range.cloneRange();
-  postRange.selectNodeContents(el);
-  postRange.setStart(range.endContainer, range.endOffset);
-  return postRange.toString().trim().length === 0;
-};
+const isCursorAtStart = (el: HTMLElement) => isCursorAtBoundary(el, 'start');
+const isCursorAtEnd = (el: HTMLElement) => isCursorAtBoundary(el, 'end');
 
 export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -1,22 +1,16 @@
 import { Plus } from 'lucide-react';
 import type React from 'react';
-import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
-import { useTreeEditor } from '../hooks/useTreeEditor';
-import type { ContainerDocumentNode, Language } from '../types/document';
-import { deriveJsonFilename, downloadFile } from '../utils/document-utils';
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+import type { TreeEditorHandle } from '../hooks/useTreeEditor';
+import type { Language } from '../types/document';
 import { FloatingToolbar } from './FloatingToolbar';
-import { LeftPane } from './LeftPane';
 import { RecursiveTreeNode } from './RecursiveTreeNode';
-import { Toolbar } from './Toolbar';
 import { TreeCallbacksContext, TreeUIStoreContext } from './TreeNodeContext';
 
 interface TreeEditorProps {
-  initialDocument: ContainerDocumentNode;
-  pdfUrl: string | null;
-  documentName?: string | null;
-  language?: Language;
-  onBack: () => void;
-  onDownload?: () => void;
+  editor: TreeEditorHandle;
+  language: Language;
+  onScrollToNode?: (scrollFn: (nodeId: string) => void) => void;
 }
 
 const isCursorAtStart = (el: HTMLElement) => {
@@ -41,16 +35,22 @@ const isCursorAtEnd = (el: HTMLElement) => {
   return postRange.toString().trim().length === 0;
 };
 
-export function TreeEditor({
-  initialDocument,
-  pdfUrl,
-  documentName,
-  language = 'de',
-  onBack,
-  onDownload,
-}: TreeEditorProps) {
+export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const blockRefs = useRef<{ [key: string]: HTMLElement | null }>({});
+
+  // Expose scroll-to-node capability to parent via callback registration
+  const scrollToNodeFn = useCallback((nodeId: string) => {
+    blockRefs.current[nodeId]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, []);
+
+  // Register the scroll function with the parent on mount / when it changes
+  useEffect(() => {
+    onScrollToNode?.(scrollToNodeFn);
+  }, [onScrollToNode, scrollToNodeFn]);
+
   const {
-    document,
+    document: treeDocument,
     flattenedNodes,
     store,
     handleNodeClick,
@@ -70,13 +70,9 @@ export function TreeEditor({
     deleteSelected,
     undo,
     redo,
-    canUndo,
-    canRedo,
-    historyIndex,
-    historyLength,
     lastSelectedId,
     getReceivingParentId,
-  } = useTreeEditor(initialDocument, language);
+  } = editor;
 
   // Subscribe to aggregate store values needed at this level
   const selectedCount = useSyncExternalStore(
@@ -90,20 +86,6 @@ export function TreeEditor({
   const selectedIds = useSyncExternalStore(
     store.subscribe,
     useCallback(() => store.getSelectedIds(), [store])
-  );
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  const blockRefs = useRef<{ [key: string]: HTMLElement | null }>({});
-
-  const handleOutlineHeadingClick = useCallback(
-    (nodeId: string) => {
-      store.setSelection(new Set([nodeId]));
-      // Scroll the node into view after React renders the selection change
-      requestAnimationFrame(() => {
-        blockRefs.current[nodeId]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      });
-    },
-    [store]
   );
 
   // Compute toolbar type for single selected node
@@ -234,7 +216,7 @@ export function TreeEditor({
           const el = blockRefs.current[prevId];
           if (el) {
             el.focus();
-            const r = document.createRange();
+            const r = window.document.createRange();
             r.selectNodeContents(el);
             r.collapse(false);
             window.getSelection()?.removeAllRanges();
@@ -251,6 +233,49 @@ export function TreeEditor({
         setTimeout(() => blockRefs.current[nextId]?.focus(), 0);
       }
     }
+  };
+
+  const handleBulkUpdateType = (toolbarType: string) => {
+    const currentSelectedIds = store.getSelectedIds();
+    if (currentSelectedIds.size === 0) return;
+
+    // Sort IDs by flat order for consistent processing
+    const ids = flattenedNodes
+      .filter((fn) => currentSelectedIds.has(fn.node.id))
+      .map((fn) => fn.node.id);
+
+    // Map toolbar type to target type and list style
+    type ListStyle = 'unordered' | 'numbered' | 'lettered';
+    let targetType: 'heading' | 'content' | 'list' | 'footnote';
+    let listStyle: ListStyle | undefined;
+
+    switch (toolbarType) {
+      case 'heading':
+        targetType = 'heading';
+        break;
+      case 'content':
+        targetType = 'content';
+        break;
+      case 'ul':
+        targetType = 'list';
+        listStyle = 'unordered';
+        break;
+      case 'ol':
+        targetType = 'list';
+        listStyle = 'numbered';
+        break;
+      case 'abc':
+        targetType = 'list';
+        listStyle = 'lettered';
+        break;
+      case 'footnote':
+        targetType = 'footnote';
+        break;
+      default:
+        return;
+    }
+
+    changeNodeTypes(ids, targetType, listStyle);
   };
 
   const handleGlobalKeyDown = (e: React.KeyboardEvent) => {
@@ -311,57 +336,6 @@ export function TreeEditor({
         handleBulkUpdateType(toolbarType);
       }
     }
-  };
-
-  const handleBulkUpdateType = (toolbarType: string) => {
-    const currentSelectedIds = store.getSelectedIds();
-    if (currentSelectedIds.size === 0) return;
-
-    // Sort IDs by flat order for consistent processing
-    const ids = flattenedNodes
-      .filter((fn) => currentSelectedIds.has(fn.node.id))
-      .map((fn) => fn.node.id);
-
-    // Map toolbar type to target type and list style
-    type ListStyle = 'unordered' | 'numbered' | 'lettered';
-    let targetType: 'heading' | 'content' | 'list' | 'footnote';
-    let listStyle: ListStyle | undefined;
-
-    switch (toolbarType) {
-      case 'heading':
-        targetType = 'heading';
-        break;
-      case 'content':
-        targetType = 'content';
-        break;
-      case 'ul':
-        targetType = 'list';
-        listStyle = 'unordered';
-        break;
-      case 'ol':
-        targetType = 'list';
-        listStyle = 'numbered';
-        break;
-      case 'abc':
-        targetType = 'list';
-        listStyle = 'lettered';
-        break;
-      case 'footnote':
-        targetType = 'footnote';
-        break;
-      default:
-        return;
-    }
-
-    changeNodeTypes(ids, targetType, listStyle);
-  };
-
-  const handleDownload = () => {
-    downloadFile(
-      JSON.stringify(document, null, 2),
-      deriveJsonFilename(documentName),
-      'application/json'
-    );
   };
 
   const handleClick = (e: React.MouseEvent, id: string) => {
@@ -450,88 +424,68 @@ export function TreeEditor({
   );
 
   return (
-    <div className="h-[calc(100vh-64px)] flex flex-col">
-      <Toolbar
-        onBack={onBack}
-        onUndo={undo}
-        onRedo={redo}
-        canUndo={canUndo}
-        canRedo={canRedo}
-        historyIndex={historyIndex}
-        historyLength={historyLength}
-        onDownload={handleDownload}
-      />
-      <div className="flex-1 flex overflow-hidden">
-        <LeftPane
-          pdfUrl={pdfUrl}
-          document={document}
-          language={language}
-          onHeadingClick={handleOutlineHeadingClick}
-        />
-        <div
-          className="flex-1 overflow-y-auto bg-white relative outline-none"
-          data-testid="tree-editor-pane"
-          ref={containerRef}
-          tabIndex={0}
-          onKeyDown={handleGlobalKeyDown}
-          onClick={clearSelection}
-        >
-          <div className="max-w-5xl mx-auto py-12 pr-8 pl-16 pb-48">
-            <div className="mb-8 pb-4 border-b border-gray-100 flex justify-between items-end">
-              <div>
-                <h2 className="text-2xl font-bold mb-1">Tree Editor</h2>
-                <p className="text-gray-500">
-                  Click to select. Shift+Click to select range. Double-click to edit. Enter to
-                  create a new node.
-                </p>
-              </div>
-              <div className="text-xs text-gray-400 hidden sm:block text-right space-y-1">
-                <div>
-                  <kbd className="bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200 font-sans">
-                    Tab
-                  </kbd>{' '}
-                  indent
-                </div>
-                <div>
-                  <kbd className="bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200 font-sans">
-                    Shift+Tab
-                  </kbd>{' '}
-                  outdent
-                </div>
-              </div>
+    <div
+      className="flex-1 overflow-y-auto bg-white relative outline-none"
+      data-testid="tree-editor-pane"
+      ref={containerRef}
+      tabIndex={0}
+      onKeyDown={handleGlobalKeyDown}
+      onClick={clearSelection}
+    >
+      <div className="max-w-5xl mx-auto py-12 pr-8 pl-16 pb-48">
+        <div className="mb-8 pb-4 border-b border-gray-100 flex justify-between items-end">
+          <div>
+            <h2 className="text-2xl font-bold mb-1">Tree Editor</h2>
+            <p className="text-gray-500">
+              Click to select. Shift+Click to select range. Double-click to edit. Enter to create a
+              new node.
+            </p>
+          </div>
+          <div className="text-xs text-gray-400 hidden sm:block text-right space-y-1">
+            <div>
+              <kbd className="bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200 font-sans">
+                Tab
+              </kbd>{' '}
+              indent
             </div>
-            <div className="min-h-[300px] relative">
-              {document.children.length === 0 ? (
-                <div
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    addNodeAfter(document.id);
-                  }}
-                  className="absolute inset-0 flex flex-col items-center justify-center text-gray-300 cursor-pointer hover:text-gray-500 transition-colors border-2 border-dashed border-gray-100 rounded-xl m-4"
-                >
-                  <Plus size={32} className="mb-2 opacity-50" />
-                  <p className="font-medium">Document is empty</p>
-                  <p className="text-sm">Click here to start writing</p>
-                </div>
-              ) : (
-                <TreeCallbacksContext.Provider value={callbacksCtx}>
-                  <TreeUIStoreContext.Provider value={store}>
-                    <RecursiveTreeNode node={document} depth={0} />
-                  </TreeUIStoreContext.Provider>
-                </TreeCallbacksContext.Provider>
-              )}
+            <div>
+              <kbd className="bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200 font-sans">
+                Shift+Tab
+              </kbd>{' '}
+              outdent
             </div>
           </div>
-          <FloatingToolbar
-            selectedCount={selectedCount}
-            isEditing={!!editingId}
-            selectedNodeType={selectedNodeType}
-            onUpdateType={handleBulkUpdateType}
-            onDelete={deleteSelected}
-            onClearSelection={clearSelection}
-          />
+        </div>
+        <div className="min-h-[300px] relative">
+          {treeDocument.children.length === 0 ? (
+            <div
+              onClick={(e) => {
+                e.stopPropagation();
+                addNodeAfter(treeDocument.id);
+              }}
+              className="absolute inset-0 flex flex-col items-center justify-center text-gray-300 cursor-pointer hover:text-gray-500 transition-colors border-2 border-dashed border-gray-100 rounded-xl m-4"
+            >
+              <Plus size={32} className="mb-2 opacity-50" />
+              <p className="font-medium">Document is empty</p>
+              <p className="text-sm">Click here to start writing</p>
+            </div>
+          ) : (
+            <TreeCallbacksContext.Provider value={callbacksCtx}>
+              <TreeUIStoreContext.Provider value={store}>
+                <RecursiveTreeNode node={treeDocument} depth={0} />
+              </TreeUIStoreContext.Provider>
+            </TreeCallbacksContext.Provider>
+          )}
         </div>
       </div>
+      <FloatingToolbar
+        selectedCount={selectedCount}
+        isEditing={!!editingId}
+        selectedNodeType={selectedNodeType}
+        onUpdateType={handleBulkUpdateType}
+        onDelete={deleteSelected}
+        onClearSelection={clearSelection}
+      />
     </div>
   );
 }

--- a/src/hooks/useTreeEditor.ts
+++ b/src/hooks/useTreeEditor.ts
@@ -324,3 +324,5 @@ export const useTreeEditor = (
     lastSelectedId,
   };
 };
+
+export type TreeEditorHandle = ReturnType<typeof useTreeEditor>;

--- a/src/utils/file-processing.ts
+++ b/src/utils/file-processing.ts
@@ -130,9 +130,9 @@ export async function processPdfFile(_file: File): Promise<ProcessedDocument> {
   // const result = await response.json();
   // if (result?.document?.html_content) {
   //   const htmlContent = result.document.html_content;
-  //   const pdfUrl = URL.createObjectURL(_file);
+  //   const documentUrl = URL.createObjectURL(_file);
   //   const doc = parseHtmlLegalToTree(htmlContent);
-  //   return { doc, sourceUrl: pdfUrl, html: htmlContent };
+  //   return { doc, sourceUrl: documentUrl, html: htmlContent };
   // }
   // throw new Error('Invalid response format');
 }


### PR DESCRIPTION
## Summary

- **Extract EditorInterface from TreeEditor**: TreeEditor was a monolithic component handling both layout (Toolbar, LeftPane, pane split, download) and tree editing. Split into `EditorInterface` (layout orchestration) and a focused `TreeEditor` (right-pane editing only). TreeEditor receives the `useTreeEditor` hook output as a single `editor` prop and owns its own DOM refs, exposing scroll-to-node via a callback registration pattern.
- **Rename `pdfUrl` to `documentUrl`** across the codebase, since DOCX and HTML sources are also supported now.
- **Deduplicate `isCursorAtStart`/`isCursorAtEnd`** into a shared `isCursorAtBoundary` helper.

## Test plan

- [x] All 606 existing tests pass (`npm run test`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Verify in browser: upload a document, check Toolbar, LeftPane, tree editing, keyboard shortcuts, outline click-to-scroll all work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)