### PR TITLE
Add collapsible table of contents in preview pane

### DIFF
--- a/src/components/DocumentPreview.test.tsx
+++ b/src/components/DocumentPreview.test.tsx
@@ -508,4 +508,52 @@ describe('DocumentPreview', () => {
 
     expect(scrollMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
   });
+
+  test('TOC has a collapse button that hides the TOC list', async () => {
+    const user = userEvent.setup();
+    const doc = makeDoc({
+      id: 'h1',
+      number: 'I.',
+      type: 'heading',
+      contents: { de: 'First Heading' },
+      children: [],
+    });
+
+    render(<DocumentPreview document={doc} language="de" onHeadingClick={() => {}} />);
+
+    const toc = screen.getByRole('navigation', { name: /inhaltsverzeichnis/i });
+    expect(within(toc).getByText('First Heading')).toBeInTheDocument();
+
+    // Click the collapse button
+    const collapseBtn = within(toc).getByRole('button', { name: /collapse/i });
+    await user.click(collapseBtn);
+
+    // TOC entries should be hidden
+    expect(within(toc).queryByText('First Heading')).not.toBeInTheDocument();
+    // The heading title should also be hidden
+    expect(within(toc).queryByText('Inhaltsverzeichnis')).not.toBeInTheDocument();
+  });
+
+  test('collapsed TOC can be expanded again', async () => {
+    const user = userEvent.setup();
+    const doc = makeDoc({
+      id: 'h1',
+      number: 'I.',
+      type: 'heading',
+      contents: { de: 'First Heading' },
+      children: [],
+    });
+
+    render(<DocumentPreview document={doc} language="de" onHeadingClick={() => {}} />);
+
+    const toc = screen.getByRole('navigation', { name: /inhaltsverzeichnis/i });
+
+    // Collapse
+    await user.click(within(toc).getByRole('button', { name: /collapse/i }));
+    expect(within(toc).queryByText('First Heading')).not.toBeInTheDocument();
+
+    // Expand
+    await user.click(within(toc).getByRole('button', { name: /expand/i }));
+    expect(within(toc).getByText('First Heading')).toBeInTheDocument();
+  });
 });

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import type { ContainerDocumentNode, DocumentNode, Language } from '../types/document';
 import { getDocumentOutline, type OutlineEntry } from '../utils/outline-utils';
 
@@ -44,16 +44,40 @@ function PreviewToc({
   entries: OutlineEntry[];
   onEntryClick: (nodeId: string) => void;
 }) {
+  const [collapsed, setCollapsed] = useState(false);
   // Build a tree structure from the flat entries for nested <ul> rendering
   const tree = useMemo(() => buildTocTree(entries), [entries]);
 
   return (
     <nav
       aria-label="Inhaltsverzeichnis"
-      className="w-[32rem] shrink-0 sticky top-0 self-start overflow-y-auto max-h-full p-4 text-sm text-gray-500"
+      className={`${collapsed ? 'w-10 p-2' : 'w-[32rem] p-4'} shrink-0 sticky top-0 self-start overflow-y-auto max-h-full text-sm text-gray-500`}
     >
-      <h3 className="font-medium mb-2 text-gray-700">Inhaltsverzeichnis</h3>
-      <TocList nodes={tree} onEntryClick={onEntryClick} />
+      {collapsed ? (
+        <button
+          type="button"
+          aria-label="Expand table of contents"
+          className="p-1 rounded hover:bg-gray-200 cursor-pointer"
+          onClick={() => setCollapsed(false)}
+        >
+          ▶
+        </button>
+      ) : (
+        <>
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="font-medium text-gray-700">Inhaltsverzeichnis</h3>
+            <button
+              type="button"
+              aria-label="Collapse table of contents"
+              className="p-1 rounded hover:bg-gray-200 cursor-pointer"
+              onClick={() => setCollapsed(true)}
+            >
+              ◀
+            </button>
+          </div>
+          <TocList nodes={tree} onEntryClick={onEntryClick} />
+        </>
+      )}
     </nav>
   );
 }

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -57,6 +57,7 @@ function PreviewToc({
         <button
           type="button"
           aria-label="Expand table of contents"
+          title="Expand table of contents"
           className="p-1 rounded hover:bg-gray-200 cursor-pointer"
           onClick={() => setCollapsed(false)}
         >
@@ -69,6 +70,7 @@ function PreviewToc({
             <button
               type="button"
               aria-label="Collapse table of contents"
+              title="Collapse table of contents"
               className="p-1 rounded hover:bg-gray-200 cursor-pointer"
               onClick={() => setCollapsed(true)}
             >

--- a/src/components/LeftPane.test.tsx
+++ b/src/components/LeftPane.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 import type { ContainerDocumentNode } from '../types/document';
@@ -106,7 +106,7 @@ describe('LeftPane', () => {
 
     // Click the heading in the TOC
     const toc = screen.getByRole('navigation', { name: /inhaltsverzeichnis/i });
-    await user.click(toc.querySelector('button')!);
+    await user.click(within(toc).getByText('Heading One'));
     expect(onClick).toHaveBeenCalledWith('h1');
   });
 });


### PR DESCRIPTION
## Summary
- Add collapse/expand toggle to the TOC sidebar in the document preview pane
- When collapsed, the TOC shrinks to a narrow strip with an expand arrow, reclaiming horizontal space for small screens
- Both buttons include tooltips explaining their function

## Test plan
- [x] Two new tests: collapse hides TOC entries, expand restores them
- [x] Fixed existing LeftPane test to use `getByText` instead of fragile `querySelector('button')`
- [x] All 608 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)