### PR TITLE
Improve TreeEditor test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file-coverage-mode: changes
-          threshold-icons: "{0: '🔴', 75: '🟠', 90: '🟢'}"
+          threshold-icons: "{0: '🔴', 80: '🟠', 90: '🟢'}"
 
   deploy:
     name: Deploy to GitHub Pages

--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -95,6 +95,7 @@ export function FloatingToolbar({
       <button
         onClick={onClearSelection}
         className="ml-2 p-2 hover:bg-gray-700 rounded-full text-gray-400 hover:text-white transition-colors"
+        title="Clear Selection"
       >
         <X size={16} />
       </button>

--- a/src/components/LoadDocument.test.tsx
+++ b/src/components/LoadDocument.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LoadDocument } from './LoadDocument';
 
@@ -44,6 +44,8 @@ describe('LoadDocument', () => {
     });
 
     it('hides drop overlay after file is dropped', async () => {
+      // Suppress expected error from mock File lacking arrayBuffer()
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       render(<LoadDocument onConvert={mockOnConvert} />);
 
       const container = screen.getByTestId('drop-zone');
@@ -59,16 +61,19 @@ describe('LoadDocument', () => {
         type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       });
 
-      // Drop the file
-      fireEvent.drop(container, {
-        dataTransfer: {
-          files: [file],
-          types: ['Files'],
-        },
+      // Drop the file — handleFile is async, so wrap in act to flush state updates
+      await act(async () => {
+        fireEvent.drop(container, {
+          dataTransfer: {
+            files: [file],
+            types: ['Files'],
+          },
+        });
       });
 
       // Overlay should be hidden
       expect(screen.queryByText(/drop your document here/i)).not.toBeInTheDocument();
+      errorSpy.mockRestore();
     });
 
     it('prevents default browser behavior on drag over', () => {
@@ -84,7 +89,7 @@ describe('LoadDocument', () => {
       expect(preventDefaultSpy).toHaveBeenCalled();
     });
 
-    it('prevents default browser behavior on drop', () => {
+    it('prevents default browser behavior on drop', async () => {
       render(<LoadDocument onConvert={mockOnConvert} />);
 
       const container = screen.getByTestId('drop-zone');
@@ -100,7 +105,9 @@ describe('LoadDocument', () => {
       });
       const preventDefaultSpy = vi.spyOn(dropEvent, 'preventDefault');
 
-      container.dispatchEvent(dropEvent);
+      await act(async () => {
+        container.dispatchEvent(dropEvent);
+      });
 
       expect(preventDefaultSpy).toHaveBeenCalled();
     });
@@ -143,10 +150,11 @@ describe('LoadDocument', () => {
         value: [file],
         configurable: true,
       });
-      fireEvent.change(fileInput);
-
-      await vi.waitFor(() => {
-        expect(mockOnConvert).toHaveBeenCalled();
+      await act(async () => {
+        fireEvent.change(fileInput);
+        await vi.waitFor(() => {
+          expect(mockOnConvert).toHaveBeenCalled();
+        });
       });
 
       const [doc, sourceUrl, html, filename] = mockOnConvert.mock.calls[0];

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -395,6 +395,29 @@ describe('node operations via keyboard', () => {
     expect(getTreePane().getByText('Second Heading')).toBeInTheDocument();
   });
 
+  test('Enter key in selection mode creates a new node after the selected one', () => {
+    renderTreeEditor();
+    const container = getContainer();
+
+    selectFirstNode();
+
+    // Press Enter while in selection mode (not editing)
+    fireEvent.keyDown(container, { key: 'Enter' });
+
+    // A new empty node should appear between the two headings
+    const allDraggables = container.querySelectorAll('[draggable]');
+    expect(allDraggables.length).toBe(3);
+
+    // The new node sits between First Heading and Second Heading
+    expect(allDraggables[0].textContent).toContain('First Heading');
+    expect(allDraggables[2].textContent).toContain('Second Heading');
+
+    // The new node is an empty content node with an editable area
+    const newNodeEditable = allDraggables[1].querySelector('[contenteditable]');
+    expect(newNodeEditable).not.toBeNull();
+    expect(newNodeEditable!.textContent).toBe('');
+  });
+
   test('Tab indents selected node under previous sibling', () => {
     // Need heading followed by content at same level for indent to work
     const doc: ContainerDocumentNode = {

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -666,3 +666,71 @@ describe('empty document', () => {
     expect(screen.getByText('Document is empty')).toBeInTheDocument();
   });
 });
+
+describe('FloatingToolbar button clicks', () => {
+  test('clicking a type button changes the selected node type', () => {
+    renderTreeEditor();
+    selectFirstNode();
+
+    // The first heading renders as an H1
+    const headingEl = getTreePane().getByText('First Heading');
+    expect(headingEl.tagName).toMatch(/^H\d$/);
+
+    // Click "Content (C)" in the floating toolbar to change type
+    fireEvent.click(screen.getByTitle('Content (C)'));
+
+    // After type change, content nodes render as DIV instead of H-tag
+    const contentEl = getTreePane().getByText('First Heading');
+    expect(contentEl.tagName).toBe('DIV');
+  });
+
+  test('clicking delete removes the selected node', () => {
+    renderTreeEditor();
+    selectFirstNode();
+
+    fireEvent.click(screen.getByTitle('Delete Selected'));
+
+    expect(getTreePane().queryByText('First Heading')).not.toBeInTheDocument();
+    expect(getTreePane().getByText('Second Heading')).toBeInTheDocument();
+  });
+
+  test('clicking a type button applies to all selected nodes', () => {
+    renderTreeEditor();
+
+    // Multi-select both headings
+    selectFirstNode();
+    fireEvent.click(getTreePane().getByText('Second Heading'), { ctrlKey: true });
+    expectNodeSelected('First Heading');
+    expectNodeSelected('Second Heading');
+
+    // Change both to content via toolbar
+    fireEvent.click(screen.getByTitle('Content (C)'));
+
+    // Both should now render as DIV (content) instead of H-tags
+    expect(getTreePane().getByText('First Heading').tagName).toBe('DIV');
+    expect(getTreePane().getByText('Second Heading').tagName).toBe('DIV');
+  });
+
+  test('clicking delete removes all selected nodes', () => {
+    renderTreeEditor();
+
+    // Multi-select both headings
+    selectFirstNode();
+    fireEvent.click(getTreePane().getByText('Second Heading'), { ctrlKey: true });
+
+    fireEvent.click(screen.getByTitle('Delete Selected'));
+
+    expect(getTreePane().queryByText('First Heading')).not.toBeInTheDocument();
+    expect(getTreePane().queryByText('Second Heading')).not.toBeInTheDocument();
+  });
+
+  test('clicking clear selection deselects all nodes', () => {
+    renderTreeEditor();
+    selectFirstNode();
+    expectNodeSelected('First Heading');
+
+    fireEvent.click(screen.getByTitle('Clear Selection'));
+
+    expectNodeNotSelected('First Heading');
+  });
+});

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -690,6 +690,124 @@ describe('empty document', () => {
   });
 });
 
+describe('drag and drop reordering', () => {
+  const createThreeNodeDocument = (): ContainerDocumentNode => ({
+    id: 'root',
+    number: null,
+    type: 'document',
+    children: [
+      {
+        id: 'h1',
+        number: '1',
+        type: 'heading',
+        contents: { de: 'First' },
+        children: [],
+      },
+      {
+        id: 'h2',
+        number: '2',
+        type: 'heading',
+        contents: { de: 'Second' },
+        children: [],
+      },
+      {
+        id: 'h3',
+        number: '3',
+        type: 'heading',
+        contents: { de: 'Third' },
+        children: [],
+      },
+    ],
+  });
+
+  const renderThreeNodes = () =>
+    render(
+      <EditorInterface
+        initialDocument={createThreeNodeDocument()}
+        documentUrl={null}
+        documentName="test.docx"
+        language="de"
+        onBack={() => {}}
+      />
+    );
+
+  /** Get ordered text content of all draggable nodes in the tree pane. */
+  const getNodeOrder = () => {
+    const container = getContainer();
+    const draggables = container.querySelectorAll('[draggable]');
+    return Array.from(draggables).map(
+      (el) => el.querySelector('[contenteditable]')?.textContent?.trim() ?? ''
+    );
+  };
+
+  /**
+   * Simulate a full drag-and-drop sequence: drag sourceText's node and drop
+   * it after targetText's node.
+   *
+   * Note: jsdom has no layout engine, so getBoundingClientRect returns zeros
+   * and the top/bottom half detection in handleDragOver always resolves to
+   * 'bottom' (insert after target). This still exercises all four drag
+   * handlers (handleDragStart, handleDragOver, handleDrop, handleDragEnd).
+   */
+  const dragAndDropAfter = (sourceText: string, targetText: string) => {
+    const sourceWrapper = getNodeWrapper(sourceText);
+    const targetWrapper = getNodeWrapper(targetText);
+
+    fireEvent.dragStart(sourceWrapper, {
+      dataTransfer: { effectAllowed: 'move' },
+    });
+    fireEvent.dragOver(targetWrapper);
+    fireEvent.drop(targetWrapper);
+    fireEvent.dragEnd(sourceWrapper);
+  };
+
+  test('dragging a node forward moves it after the target', () => {
+    renderThreeNodes();
+
+    expect(getNodeOrder()).toEqual(['First', 'Second', 'Third']);
+
+    // Drag "First" onto "Third" → First moves after Third
+    dragAndDropAfter('First', 'Third');
+
+    expect(getNodeOrder()).toEqual(['Second', 'Third', 'First']);
+  });
+
+  test('dragging a node backward moves it after the target', () => {
+    renderThreeNodes();
+
+    // Drag "Third" onto "First" → Third moves after First
+    dragAndDropAfter('Third', 'First');
+
+    expect(getNodeOrder()).toEqual(['First', 'Third', 'Second']);
+  });
+
+  test('dragging a node onto itself does not change the order', () => {
+    renderThreeNodes();
+
+    dragAndDropAfter('Second', 'Second');
+
+    expect(getNodeOrder()).toEqual(['First', 'Second', 'Third']);
+  });
+
+  test('drag end without a valid drop resets state without reordering', () => {
+    renderThreeNodes();
+
+    const sourceWrapper = getNodeWrapper('First');
+
+    // Start dragging but cancel (dragEnd without drop)
+    fireEvent.dragStart(sourceWrapper, {
+      dataTransfer: { effectAllowed: 'move' },
+    });
+    fireEvent.dragEnd(sourceWrapper);
+
+    // Order should remain unchanged
+    expect(getNodeOrder()).toEqual(['First', 'Second', 'Third']);
+
+    // Nodes should not have drag-in-progress styling (opacity-30)
+    expect(sourceWrapper.className).not.toContain('opacity-30');
+  });
+});
+
 describe('FloatingToolbar button clicks', () => {
   test('clicking a type button changes the selected node type', () => {
     renderTreeEditor();

--- a/src/utils/file-processing.integration.test.ts
+++ b/src/utils/file-processing.integration.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { ContentDocumentNode, HeadingDocumentNode } from '../types/document';
 import { processDocxFile } from './file-processing';
 
@@ -15,9 +15,11 @@ describe('file-processing integration', () => {
     let allNodes: Array<{ type: string; contents?: Partial<Record<string, string>> }>;
     let headings: typeof allNodes;
     let contentNodes: typeof allNodes;
+    let warnSpy: ReturnType<typeof vi.spyOn>;
 
     // Run processDocxFile once, share across assertions
     beforeAll(async () => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       URL.createObjectURL = vi.fn(() => 'blob:fake-url');
       // jsdom polyfill — File.arrayBuffer() not implemented
       if (!Blob.prototype.arrayBuffer) {
@@ -42,6 +44,14 @@ describe('file-processing integration', () => {
       allNodes = flattenTree(result.doc);
       headings = allNodes.filter((n) => n.type === 'heading');
       contentNodes = allNodes.filter((n) => n.type === 'content');
+    });
+
+    afterAll(() => {
+      // Ensure we only silenced the expected Mammoth warnings, not something unexpected
+      for (const call of warnSpy.mock.calls) {
+        expect(call[0]).toBe('Mammoth conversion warnings:');
+      }
+      warnSpy.mockRestore();
     });
 
     it('produces non-empty HTML containing the law title', () => {


### PR DESCRIPTION
## Summary
- Raise coverage report threshold: under 80% is now unacceptable
- Fix test suite warnings (act() wrapping and Mammoth console noise)
- Add FloatingToolbar button click tests (type change, delete, clear selection)
- Add test for Enter key creating a new node in selection mode
- Add drag & drop reordering tests covering all four drag handlers

## Test plan
- [x] All 44 TreeEditor tests pass
- [x] Full test suite passes with no warnings
- [x] Code reviewed by subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)