### PR TITLE
Fix cursor disappearing and not moving in editable nodes (#60)

### DIFF
--- a/src/components/RecursiveTreeNode.tsx
+++ b/src/components/RecursiveTreeNode.tsx
@@ -1,6 +1,6 @@
 import { GripVertical, Plus } from 'lucide-react';
 import type React from 'react';
-import { memo } from 'react';
+import { memo, useCallback, useSyncExternalStore } from 'react';
 import { useNodeState } from '../hooks/useNodeState';
 import type { DocumentNode, NodeFormat } from '../types/document';
 import { ContentBlock } from './ContentBlock';
@@ -54,6 +54,14 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
       isReceivingParent,
       isInvalidDrop,
     } = useNodeState(store, node.id);
+    // Firefox suppresses caret-positioning in a contentEditable when any
+    // ancestor has draggable=true (issue #60). Disable draggable on every
+    // node while any node is in edit mode — drag-to-reorder is unavailable
+    // mid-edit anyway, so this is a no-op behaviour-wise.
+    const isAnyNodeEditing = useSyncExternalStore(
+      store.subscribe,
+      useCallback(() => store.getEditingId() !== null, [store])
+    );
 
     const {
       language,
@@ -289,7 +297,7 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
 
     return (
       <div
-        draggable={!isEditing}
+        draggable={!isAnyNodeEditing}
         onDragStart={(e) => {
           e.stopPropagation();
           onDragStart(e, node.id);

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -210,6 +210,106 @@ describe('double-click inline editing', () => {
     vi.useRealTimers();
   });
 
+  // Regression: clicking inside an already-editing field used to bubble up to the
+  // node wrapper's onClick, which called containerRef.focus() unconditionally and
+  // blurred the contentEditable — making the caret disappear (issue #60).
+  test('clicking inside an editing node keeps focus on its contentEditable', async () => {
+    vi.useFakeTimers();
+    renderTreeEditor();
+
+    const firstHeading = getTreePane().getByText('First Heading');
+
+    await act(async () => {
+      fireEvent.doubleClick(firstHeading);
+      vi.runAllTimers();
+    });
+
+    const editingEl = document.activeElement as HTMLElement;
+    expect(editingEl.getAttribute('contenteditable')).toBe('true');
+
+    // Simulate the user clicking inside the field they're editing (e.g. to move
+    // the caret). The bug was synchronous focus theft, so no timers to flush.
+    await act(async () => {
+      fireEvent.click(editingEl);
+    });
+
+    expect(document.activeElement).toBe(editingEl);
+
+    vi.useRealTimers();
+  });
+
+  test('clicking a non-editing node moves focus to the container', () => {
+    renderTreeEditor();
+
+    fireEvent.click(getTreePane().getByText('First Heading'));
+
+    // The container owns keyboard handling; a plain (non-editing) click must
+    // route focus there so arrow keys and shortcuts work.
+    expect(document.activeElement).toBe(getContainer());
+  });
+
+  // Regression: Firefox suppresses caret-positioning in a contentEditable when
+  // any ancestor element has draggable=true. With nested nodes (heading + child
+  // content) the parent wrapper's draggable=true broke clicking inside the
+  // nested editing field (issue #60). All node wrappers must drop draggable
+  // while any node is in edit mode.
+  test('all node wrappers drop draggable while any node is editing', async () => {
+    vi.useFakeTimers();
+    const nestedDoc: ContainerDocumentNode = {
+      id: 'root',
+      number: null,
+      type: 'document',
+      children: [
+        {
+          id: 'h1',
+          number: '1',
+          type: 'heading',
+          format: 'TEXT',
+          contents: { de: 'Parent Heading' },
+          children: [
+            {
+              id: 'c1',
+              number: null,
+              type: 'content',
+              format: 'TEXT',
+              contents: { de: 'Nested Content' },
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    render(
+      <EditorInterface
+        initialDocument={nestedDoc}
+        documentUrl={null}
+        documentName="t.docx"
+        language="de"
+        onBack={() => {}}
+      />
+    );
+
+    // Sanity: before editing, both wrappers are draggable.
+    let wrappers = getContainer().querySelectorAll('[draggable]');
+    expect(wrappers.length).toBe(2);
+    for (const w of wrappers) expect(w.getAttribute('draggable')).toBe('true');
+
+    // Enter edit mode on the nested content node.
+    await act(async () => {
+      fireEvent.doubleClick(getTreePane().getByText('Nested Content'));
+      vi.runAllTimers();
+    });
+
+    // Every wrapper — including the parent heading — must now declare
+    // draggable=false so Firefox lets the browser position the caret.
+    wrappers = getContainer().querySelectorAll('[draggable]');
+    expect(wrappers.length).toBe(2);
+    for (const w of wrappers) expect(w.getAttribute('draggable')).toBe('false');
+
+    vi.useRealTimers();
+  });
+
   test('pressing Enter while editing a TEXT-format node does NOT create a sibling', async () => {
     vi.useFakeTimers();
     renderTreeEditor();

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -360,6 +360,14 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
 
   const handleClick = (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
+    // Click inside the currently-editing node: let the browser position the
+    // caret natively. Do not steal focus to the container and do not run
+    // selection/state updates — Firefox in particular drops the visible caret
+    // when the editing element is touched by a React re-render mid-click
+    // (issue #60).
+    if (store.getEditingId() === id) {
+      return;
+    }
     // Focus the container so keyboard events work
     containerRef.current?.focus();
     handleNodeClick(id, {


### PR DESCRIPTION
## Summary

Two distinct bugs reported under #60 made the caret unreliable in edit mode. This PR fixes both.

**1. Chrome — clicking inside an editing field hid the caret.** Every click on a node wrapper unconditionally called `containerRef.focus()`, blurring the contentEditable mid-click and causing the caret to disappear. `handleClick` now early-returns when the click is for the currently-editing node, leaving focus on the contentEditable so the browser positions the caret natively.

**2. Firefox — clicking inside a *nested* editing node didn't move the cursor.** Firefox suppresses caret-positioning on a contentEditable when any ancestor has `draggable=true`. Only the editing node was dropping `draggable`, so for nested content (e.g. a content node under a heading) the parent heading wrapper kept `draggable=true` and broke clicking inside the child's text. `RecursiveTreeNode` now drops `draggable` on every wrapper while *any* node is being edited (drag-to-reorder is unavailable mid-edit anyway).

## Test plan

- [x] Two regression tests added in `TreeEditor.test.tsx`:
  - clicking inside an editing node keeps focus on its contentEditable
  - every node wrapper drops `draggable` while any node is editing (uses a nested heading + content fixture)
- [x] Both verified RED → GREEN by reverting each fix in turn
- [x] Full suite: 792 passing
- [x] Manual verification in real Firefox (system + Playwright Firefox 148): cursor moves to the click position inside a nested editing field; before the fix it stayed pinned at offset 0
- [x] Manual verification in Chrome: caret stays visible and re-positions on click within the editing field

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)