### PR TITLE
Render `number` field as MARKDOWN_MINIMAL; drop auto-superscript

### DIFF
--- a/src/components/DocumentPreview.test.tsx
+++ b/src/components/DocumentPreview.test.tsx
@@ -81,7 +81,7 @@ describe('DocumentPreview', () => {
     expect(screen.getByText('First paragraph text.')).toBeInTheDocument();
   });
 
-  test('renders content node with superscript number', () => {
+  test('renders content node number without auto-superscript wrapper', () => {
     const doc = makeDoc({
       id: 'h1',
       number: null,
@@ -101,8 +101,9 @@ describe('DocumentPreview', () => {
     });
 
     render(<DocumentPreview document={doc} language="de" />);
-    const sup = screen.getByText('1');
-    expect(sup.tagName).toBe('SUP');
+    const number = screen.getByText('1');
+    expect(number.tagName).not.toBe('SUP');
+    expect(number.closest('sup')).toBeNull();
   });
 
   test('renders list items with their number labels', () => {
@@ -154,11 +155,11 @@ describe('DocumentPreview', () => {
     });
 
     render(<DocumentPreview document={doc} language="de" />);
-    // Numbers should be rendered as superscript
+    // Numbers should NOT be auto-superscripted any more.
     const labelA = screen.getByText('a)');
-    expect(labelA.tagName).toBe('SUP');
+    expect(labelA.closest('sup')).toBeNull();
     const labelB = screen.getByText('b)');
-    expect(labelB.tagName).toBe('SUP');
+    expect(labelB.closest('sup')).toBeNull();
     expect(screen.getByText('First item text.')).toBeInTheDocument();
     expect(screen.getByText('Second item text.')).toBeInTheDocument();
   });
@@ -372,7 +373,7 @@ describe('DocumentPreview', () => {
     expect(screen.getByText('•')).toBeInTheDocument();
   });
 
-  test('list item number is rendered as superscript before content', () => {
+  test('list item number renders inline (not superscript) before content', () => {
     const doc = makeDoc({
       id: 'h1',
       number: null,
@@ -406,11 +407,12 @@ describe('DocumentPreview', () => {
     });
 
     render(<DocumentPreview document={doc} language="de" />);
-    const sup = screen.getByText('1.');
-    expect(sup.tagName).toBe('SUP');
+    const marker = screen.getByText('1.');
+    expect(marker.tagName).not.toBe('SUP');
+    expect(marker.closest('sup')).toBeNull();
     // The marker and text must share the same parent so they render on one line
     const content = screen.getByText('Numbered item text.');
-    expect(sup.parentElement).toBe(content.parentElement);
+    expect(marker.parentElement).toBe(content.parentElement);
   });
 
   test('bullet and text share the same parent element', () => {
@@ -625,5 +627,158 @@ describe('DocumentPreview', () => {
     // Expand
     await user.click(within(toc).getByRole('button', { name: /expand/i }));
     expect(within(toc).getByText('First Heading')).toBeInTheDocument();
+  });
+
+  describe('number field MARKDOWN_MINIMAL rendering', () => {
+    test('renders content number with markdown bold', () => {
+      const doc = makeDoc({
+        id: 'c1',
+        number: '**1**',
+        type: 'content',
+        format: 'TEXT',
+        contents: { de: 'Bold-numbered paragraph.' },
+        children: [],
+      });
+
+      render(<DocumentPreview document={doc} language="de" />);
+      const paragraph = screen.getByText('Bold-numbered paragraph.').parentElement!;
+      const strong = paragraph.querySelector('strong');
+      expect(strong).not.toBeNull();
+      expect(strong?.textContent).toBe('1');
+    });
+
+    test('renders content number as superscript when markdown sup syntax is used', () => {
+      const doc = makeDoc({
+        id: 'c1',
+        number: '^1^',
+        type: 'content',
+        format: 'TEXT',
+        contents: { de: 'Sup-numbered paragraph.' },
+        children: [],
+      });
+
+      render(<DocumentPreview document={doc} language="de" />);
+      const paragraph = screen.getByText('Sup-numbered paragraph.').parentElement!;
+      const sup = paragraph.querySelector('sup');
+      expect(sup).not.toBeNull();
+      expect(sup?.textContent).toBe('1');
+    });
+
+    test('renders list item number with markdown italic', () => {
+      const doc = makeDoc({
+        id: 'l1',
+        number: null,
+        type: 'list',
+        children: [
+          {
+            id: 'li1',
+            number: '*a)*',
+            type: 'list_item',
+            children: [
+              {
+                id: 'c1',
+                number: null,
+                type: 'content',
+                format: 'TEXT',
+                contents: { de: 'Italic-marker item.' },
+                children: [],
+              },
+            ],
+          },
+        ],
+      });
+
+      render(<DocumentPreview document={doc} language="de" />);
+      const paragraph = screen.getByText('Italic-marker item.').parentElement!;
+      const em = paragraph.querySelector('em');
+      expect(em).not.toBeNull();
+      expect(em?.textContent).toBe('a)');
+    });
+
+    test('renders footnote number with markdown formatting', () => {
+      const doc = makeDoc({
+        id: 'h1',
+        number: null,
+        type: 'heading',
+        format: 'TEXT',
+        contents: { de: 'Title' },
+        children: [
+          {
+            id: 'c1',
+            number: null,
+            type: 'content',
+            format: 'TEXT',
+            contents: { de: 'Some text.' },
+            children: [
+              {
+                id: 'fn1',
+                number: '^1^',
+                type: 'footnote',
+                format: 'TEXT',
+                contents: { de: 'Footnote content.' },
+              },
+            ],
+          },
+        ],
+      });
+
+      render(<DocumentPreview document={doc} language="de" />);
+      const footnoteParagraph = screen.getByText('Footnote content.').parentElement!;
+      const sup = footnoteParagraph.querySelector('sup');
+      expect(sup).not.toBeNull();
+      expect(sup?.textContent).toBe('1');
+    });
+
+    test('renders heading number with markdown formatting', () => {
+      const doc = makeDoc({
+        id: 'h1',
+        number: '**Art. 1**',
+        type: 'heading',
+        format: 'TEXT',
+        contents: { de: 'Gegenstand' },
+        children: [],
+      });
+
+      render(<DocumentPreview document={doc} language="de" />);
+      const heading = screen.getByRole('heading', { level: 1 });
+      const strong = heading.querySelector('strong');
+      expect(strong).not.toBeNull();
+      expect(strong?.textContent).toBe('Art. 1');
+    });
+
+    test('renders TOC entry number with markdown formatting', () => {
+      const doc = makeDoc({
+        id: 'h1',
+        number: '**I.**',
+        type: 'heading',
+        format: 'TEXT',
+        contents: { de: 'Allgemeine Bestimmungen' },
+        children: [],
+      });
+
+      render(<DocumentPreview document={doc} language="de" onHeadingClick={() => {}} />);
+      const toc = screen.getByRole('navigation', { name: /inhaltsverzeichnis/i });
+      const entry = within(toc).getByText('Allgemeine Bestimmungen').closest('button')!;
+      const strong = entry.querySelector('strong');
+      expect(strong).not.toBeNull();
+      expect(strong?.textContent).toBe('I.');
+    });
+
+    test('escapes raw HTML in numbers', () => {
+      const doc = makeDoc({
+        id: 'c1',
+        number: '<script>alert(1)</script>',
+        type: 'content',
+        format: 'TEXT',
+        contents: { de: 'Paragraph with hostile number.' },
+        children: [],
+      });
+
+      const { container } = render(<DocumentPreview document={doc} language="de" />);
+      // The hostile tag must not become a real element.
+      expect(container.querySelector('script')).toBeNull();
+      // ...but its source text is visible (escaped) in the rendered DOM.
+      expect(container.textContent).toContain('<script>alert(1)</script>');
+    });
   });
 });

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -4,6 +4,7 @@ import { useResizable } from '../hooks/useResizable';
 import type { ContainerDocumentNode, DocumentNode, Language } from '../types/document';
 import { getDocumentOutline, type OutlineEntry } from '../utils/outline-utils';
 import { DragHandle } from './DragHandle';
+import { NumberMarkup } from './NumberMarkup';
 
 interface DocumentPreviewProps {
   document: ContainerDocumentNode;
@@ -187,7 +188,7 @@ function TocListItem({
         className="block w-full text-left py-1 -my-1 px-2 rounded text-nowrap text-ellipsis overflow-hidden hover:bg-gray-200 cursor-pointer"
         onClick={() => onEntryClick(entry.id)}
       >
-        {entry.number && <strong className="mr-1">{entry.number}</strong>}
+        {entry.number && <NumberMarkup value={entry.number} className="font-bold mr-1" />}
         {entry.text}
       </button>
       {children.length > 0 && (
@@ -254,7 +255,7 @@ function HeadingNode({
   return (
     <section id={node.id} className="mb-2">
       <Tag className={className}>
-        {node.number && <span className="mr-2">{node.number}</span>}
+        {node.number && <NumberMarkup value={node.number} className="mr-2" />}
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: content from user-uploaded documents */}
         <span dangerouslySetInnerHTML={{ __html: text }} />
       </Tag>
@@ -279,7 +280,7 @@ function ContentNode({
   return (
     <div className="my-1">
       <p className="leading-relaxed">
-        {node.number && <sup className="font-bold mr-1">{node.number}</sup>}
+        {node.number && <NumberMarkup value={node.number} className="font-bold mr-1" />}
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: content from user-uploaded documents */}
         <span dangerouslySetInnerHTML={{ __html: text }} />
       </p>
@@ -328,7 +329,7 @@ function ListItemNode({
     : [];
 
   const marker = node.number ? (
-    <sup className="font-bold mr-1">{node.number}</sup>
+    <NumberMarkup value={node.number} className="font-bold mr-1" />
   ) : (
     <span className="mr-2">•</span>
   );
@@ -377,7 +378,7 @@ function FootnoteSection({
           const text = fn.contents[language] ?? '';
           return (
             <p key={fn.id} className="text-sm">
-              {fn.number && <sup className="font-bold mr-1">{fn.number}</sup>}
+              {fn.number && <NumberMarkup value={fn.number} className="font-bold mr-1" />}
               {/* biome-ignore lint/security/noDangerouslySetInnerHtml: content from user-uploaded documents */}
               <span dangerouslySetInnerHTML={{ __html: text }} />
             </p>

--- a/src/components/NumberMarkup.tsx
+++ b/src/components/NumberMarkup.tsx
@@ -1,0 +1,17 @@
+import { renderContent } from '../utils/format-render';
+
+/**
+ * The `number` field on document nodes is always rendered through the
+ * MARKDOWN_MINIMAL pipeline — superscript / bold / italic / etc. are explicit
+ * formatting decisions the user encodes in the source string (e.g. `^1^` for
+ * superscript, `**1**` for bold), never automatic presentation.
+ */
+export function NumberMarkup({ value, className }: { value: string; className?: string }) {
+  return (
+    <span
+      className={className}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: renderContent sanitizes via DOMPurify
+      dangerouslySetInnerHTML={{ __html: renderContent(value, 'MARKDOWN_MINIMAL') }}
+    />
+  );
+}

--- a/src/components/RecursiveTreeNode.test.tsx
+++ b/src/components/RecursiveTreeNode.test.tsx
@@ -300,6 +300,45 @@ describe('RecursiveTreeNode', () => {
       fireEvent.doubleClick(badge!);
       expect(onNumberDoubleClick).toHaveBeenCalledWith(expect.any(Object), 'fn-with-num');
     });
+
+    test('badge in display mode renders the number as MARKDOWN_MINIMAL', () => {
+      const node: HeadingDocumentNode = {
+        id: 'h-md',
+        number: '**1**',
+        type: 'heading',
+        format: 'TEXT',
+        contents: { de: 'Bold number heading' },
+        children: [],
+      };
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />);
+
+      const badge = container.querySelector('.border-blue-200');
+      expect(badge).not.toBeNull();
+      // The asterisks are consumed by the renderer; only the inner text remains.
+      expect(badge?.textContent).toBe('1');
+      expect(badge?.querySelector('strong')?.textContent).toBe('1');
+    });
+
+    test('badge in edit mode shows the raw markdown source for editing', () => {
+      const node: HeadingDocumentNode = {
+        id: 'h-md-edit',
+        number: '**1**',
+        type: 'heading',
+        format: 'TEXT',
+        contents: { de: 'Bold number heading' },
+        children: [],
+      };
+      const store = new TreeUIStore();
+      store.setEditingNumberId('h-md-edit');
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        store,
+      });
+
+      const input = container.querySelector('input[type="text"]') as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      // The input must show the raw markdown source so the user can edit it.
+      expect(input?.value).toBe('**1**');
+    });
   });
 
   describe('add node buttons', () => {

--- a/src/components/RecursiveTreeNode.tsx
+++ b/src/components/RecursiveTreeNode.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useSyncExternalStore } from 'react';
 import { useNodeState } from '../hooks/useNodeState';
 import type { DocumentNode, NodeFormat } from '../types/document';
 import { ContentBlock } from './ContentBlock';
+import { NumberMarkup } from './NumberMarkup';
 import { useTreeCallbacks, useTreeUIStore } from './TreeNodeContext';
 
 interface RecursiveTreeNodeProps {
@@ -186,7 +187,7 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
             onDoubleClick={(e) => onNumberDoubleClick(e, node.id)}
             title="Double-click to edit number"
           >
-            {currentNumber}
+            <NumberMarkup value={currentNumber} />
           </div>
         );
       }


### PR DESCRIPTION
## Summary
- The `number` field on document nodes is now always rendered through the MARKDOWN_MINIMAL pipeline. Superscript / bold / italic / etc. are explicit user formatting decisions (e.g. `^1^`, `**1**`), never automatic.
- Removed the auto-`<sup>` wrapper around content / list_item / footnote numbers in the Preview tab.
- Tree-editor badges now show rendered markdown when not being edited; the `<input>` still shows raw source while editing.
- New shared `NumberMarkup` component used by both `DocumentPreview` and `RecursiveTreeNode` so the rendering rule has a single home.
- Unblocks #66.

## Test plan
- [x] `npm run test --run` (801 passed)
- [x] `npm run build`
- [x] `npm run lint`
- [x] Manually verify in `npm run dev`: numbers render inline (not superscript) in the Preview tab; editing a number to `^1^` renders as `<sup>1</sup>`; `**1**` renders bold; `<script>` is escaped; double-clicking a tree-editor badge shows the raw markdown source in the input.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)