### PR TITLE
Preserve number across list <-> content conversions (#80)

### DIFF
--- a/src/hooks/useTreeOperations.test.ts
+++ b/src/hooks/useTreeOperations.test.ts
@@ -1707,7 +1707,10 @@ describe('useTreeOperations', () => {
         expect(mockCommit).not.toHaveBeenCalled();
       });
 
-      test('cannot convert container nodes (list)', () => {
+      test('cannot convert list to footnote', () => {
+        // list -> content is valid (issue #80: flattens with number preservation),
+        // and list -> heading is a no-op (covered elsewhere). list -> footnote
+        // remains unsupported because there's no meaningful semantics for it.
         const doc: ContainerDocumentNode = {
           id: 'root',
           number: null,
@@ -1725,7 +1728,7 @@ describe('useTreeOperations', () => {
         const { result } = renderTreeOperations(doc);
 
         act(() => {
-          result.current.changeNodeTypes(['list1'], 'content');
+          result.current.changeNodeTypes(['list1'], 'footnote');
         });
 
         expect(mockCommit).not.toHaveBeenCalled();
@@ -2272,6 +2275,630 @@ describe('useTreeOperations', () => {
         expect(mockCommit).not.toHaveBeenCalled();
       });
     });
+
+    // Issue #80: lossless number preservation between lists and content nodes.
+    describe('list_item -> content (number preservation, issue #80)', () => {
+      test('preserves list_item.number on the converted content node when it is the only item', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [createListItem('li1', 'Art. 5', 'Article body')],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['li1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const converted = newDoc.children[0] as ContentDocumentNode;
+
+        expect(converted.type).toBe('content');
+        expect(converted.number).toBe('Art. 5');
+        expect(converted.contents.de).toBe('Article body');
+      });
+
+      test('preserves the list_item content format when converting to content', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [
+                {
+                  id: 'li1',
+                  number: '1.',
+                  type: 'list_item',
+                  children: [
+                    {
+                      id: 'li1-content',
+                      number: null,
+                      type: 'content',
+                      format: 'MARKDOWN',
+                      contents: { de: '**bold**' },
+                      children: [],
+                    } as ContentDocumentNode,
+                  ],
+                } as ContainerDocumentNode,
+              ],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['li1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const converted = newDoc.children[0] as ContentDocumentNode;
+
+        expect(converted.format).toBe('MARKDOWN');
+        expect(converted.contents.de).toBe('**bold**');
+      });
+
+      test('preserves list_item.number when extracted from a multi-item list', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [
+                createListItem('li1', '1.', 'First'),
+                createListItem('li2', '2.', 'Second'),
+              ],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['li2'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+
+        // Remaining list_item is untouched
+        const list = newDoc.children[0] as ContainerDocumentNode;
+        expect((list.children[0] as ContainerDocumentNode).number).toBe('1.');
+
+        // Extracted content carries its old list_item number
+        const converted = newDoc.children[1] as ContentDocumentNode;
+        expect(converted.type).toBe('content');
+        expect(converted.number).toBe('2.');
+      });
+    });
+
+    describe('list_item -> heading (number preservation, issue #80)', () => {
+      test('preserves list_item.number on the converted heading node', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [createListItem('li1', 'Art. 7', 'Heading body')],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['li1'], 'heading');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const converted = newDoc.children[0] as HeadingDocumentNode;
+
+        expect(converted.type).toBe('heading');
+        expect(converted.number).toBe('Art. 7');
+      });
+    });
+
+    describe('list -> content (issue #80)', () => {
+      test('flattens all list_items into content nodes, preserving each number', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [
+                createListItem('li1', '1.', 'A'),
+                createListItem('li2', '2.', 'B'),
+                createListItem('li3', '3.', 'C'),
+              ],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['list1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+
+        expect(newDoc.children.length).toBe(3);
+
+        const c0 = newDoc.children[0] as ContentDocumentNode;
+        const c1 = newDoc.children[1] as ContentDocumentNode;
+        const c2 = newDoc.children[2] as ContentDocumentNode;
+
+        expect(c0.type).toBe('content');
+        expect(c0.number).toBe('1.');
+        expect(c0.contents.de).toBe('A');
+        expect(c1.type).toBe('content');
+        expect(c1.number).toBe('2.');
+        expect(c1.contents.de).toBe('B');
+        expect(c2.type).toBe('content');
+        expect(c2.number).toBe('3.');
+        expect(c2.contents.de).toBe('C');
+      });
+
+      test('preserves null number for unnumbered items', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [createListItem('li1', null, 'A'), createListItem('li2', null, 'B')],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['list1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+
+        expect(newDoc.children.length).toBe(2);
+        expect((newDoc.children[0] as ContentDocumentNode).number).toBeNull();
+        expect((newDoc.children[1] as ContentDocumentNode).number).toBeNull();
+      });
+
+      test('flattens nested list recursively, preserving inner numbers', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [
+                {
+                  id: 'li1',
+                  number: '1.',
+                  type: 'list_item',
+                  children: [
+                    {
+                      id: 'li1-content',
+                      number: null,
+                      type: 'content',
+                      format: 'TEXT',
+                      contents: { de: 'Outer 1' },
+                      children: [],
+                    } as ContentDocumentNode,
+                    {
+                      id: 'sublist',
+                      number: null,
+                      type: 'list',
+                      children: [
+                        createListItem('lia', 'a.', 'Inner a'),
+                        createListItem('lib', 'b.', 'Inner b'),
+                      ],
+                    },
+                  ],
+                } as ContainerDocumentNode,
+                createListItem('li2', '2.', 'Outer 2'),
+              ],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['list1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+
+        expect(newDoc.children.length).toBe(4);
+
+        const c0 = newDoc.children[0] as ContentDocumentNode;
+        const c1 = newDoc.children[1] as ContentDocumentNode;
+        const c2 = newDoc.children[2] as ContentDocumentNode;
+        const c3 = newDoc.children[3] as ContentDocumentNode;
+
+        expect(c0.number).toBe('1.');
+        expect(c0.contents.de).toBe('Outer 1');
+        expect(c1.number).toBe('a.');
+        expect(c1.contents.de).toBe('Inner a');
+        expect(c2.number).toBe('b.');
+        expect(c2.contents.de).toBe('Inner b');
+        expect(c3.number).toBe('2.');
+        expect(c3.contents.de).toBe('Outer 2');
+      });
+
+      test('preserves source order when nested list precedes the content child', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [
+                {
+                  id: 'li1',
+                  number: '1.',
+                  type: 'list_item',
+                  children: [
+                    {
+                      id: 'sublist',
+                      number: null,
+                      type: 'list',
+                      children: [createListItem('lia', 'a.', 'Inner a')],
+                    },
+                    {
+                      id: 'li1-content',
+                      number: null,
+                      type: 'content',
+                      format: 'TEXT',
+                      contents: { de: 'Outer text' },
+                      children: [],
+                    } as ContentDocumentNode,
+                  ],
+                } as ContainerDocumentNode,
+              ],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['list1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+
+        expect(newDoc.children.length).toBe(2);
+
+        // Source order: nested 'a.' first (it appeared before the content child),
+        // then the outer text content carrying li1's number.
+        const c0 = newDoc.children[0] as ContentDocumentNode;
+        const c1 = newDoc.children[1] as ContentDocumentNode;
+        expect(c0.number).toBe('a.');
+        expect(c0.contents.de).toBe('Inner a');
+        expect(c1.number).toBe('1.');
+        expect(c1.contents.de).toBe('Outer text');
+      });
+
+      test('preserves the source content format on the flattened content node', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [
+                {
+                  id: 'li1',
+                  number: '1.',
+                  type: 'list_item',
+                  children: [
+                    {
+                      id: 'li1-content',
+                      number: null,
+                      type: 'content',
+                      format: 'MARKDOWN',
+                      contents: { de: '**bold**' },
+                      children: [],
+                    } as ContentDocumentNode,
+                  ],
+                } as ContainerDocumentNode,
+              ],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['list1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const converted = newDoc.children[0] as ContentDocumentNode;
+
+        expect(converted.format).toBe('MARKDOWN');
+        expect(converted.contents.de).toBe('**bold**');
+      });
+
+      test('preserves footnote children of the list_item content', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [
+                {
+                  id: 'li1',
+                  number: '1.',
+                  type: 'list_item',
+                  children: [
+                    {
+                      id: 'li1-content',
+                      number: null,
+                      type: 'content',
+                      format: 'TEXT',
+                      contents: { de: 'Item with note' },
+                      children: [
+                        {
+                          id: 'fn1',
+                          number: 'i.',
+                          type: 'footnote',
+                          format: 'TEXT',
+                          contents: { de: 'Note text' },
+                        } as LeafDocumentNode,
+                      ],
+                    } as ContentDocumentNode,
+                  ],
+                } as ContainerDocumentNode,
+              ],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['list1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const converted = newDoc.children[0] as ContentDocumentNode;
+
+        expect(converted.children.length).toBe(1);
+        expect(converted.children[0].id).toBe('fn1');
+        expect(converted.children[0].type).toBe('footnote');
+      });
+
+      test('list -> heading is still a no-op', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [createListItem('li1', '1.', 'Item')],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['list1'], 'heading');
+        });
+
+        expect(mockCommit).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('content -> list (number preservation, issue #80)', () => {
+      test('unordered preserves the content original number on the new list_item', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'p1',
+              number: 'Art. 5',
+              type: 'content',
+              format: 'TEXT',
+              contents: { de: 'Body' },
+              children: [],
+            } as ContentDocumentNode,
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['p1'], 'list', 'unordered');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const list = newDoc.children[0] as ContainerDocumentNode;
+        const item = list.children[0] as ContainerDocumentNode;
+
+        expect(item.number).toBe('Art. 5');
+      });
+
+      test('numbered overwrites the content number with the generated sequence', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'p1',
+              number: 'Art. 5',
+              type: 'content',
+              format: 'TEXT',
+              contents: { de: 'Body' },
+              children: [],
+            } as ContentDocumentNode,
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['p1'], 'list', 'numbered');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const list = newDoc.children[0] as ContainerDocumentNode;
+        const item = list.children[0] as ContainerDocumentNode;
+
+        expect(item.number).toBe('1.');
+      });
+
+      test('lettered overwrites the content number with the generated sequence', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'p1',
+              number: 'Art. 5',
+              type: 'content',
+              format: 'TEXT',
+              contents: { de: 'Body' },
+              children: [],
+            } as ContentDocumentNode,
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['p1'], 'list', 'lettered');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const list = newDoc.children[0] as ContainerDocumentNode;
+        const item = list.children[0] as ContainerDocumentNode;
+
+        expect(item.number).toBe('a.');
+      });
+
+      test('unordered with null content number stays null', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'p1',
+              number: null,
+              type: 'content',
+              format: 'TEXT',
+              contents: { de: 'Body' },
+              children: [],
+            } as ContentDocumentNode,
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['p1'], 'list', 'unordered');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const list = newDoc.children[0] as ContainerDocumentNode;
+        const item = list.children[0] as ContainerDocumentNode;
+
+        expect(item.number).toBeNull();
+      });
+    });
+
+    describe('roundtrip content <-> unordered list (issue #80)', () => {
+      test('content -> unordered list -> content preserves number', () => {
+        const startDoc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'p1',
+              number: 'Art. 5',
+              type: 'content',
+              format: 'TEXT',
+              contents: { de: 'Body' },
+              children: [],
+            } as ContentDocumentNode,
+          ],
+        };
+
+        // Step 1: content -> unordered list
+        const { result } = renderTreeOperations(startDoc);
+        act(() => {
+          result.current.changeNodeTypes(['p1'], 'list', 'unordered');
+        });
+        const afterToList = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const list = afterToList.children[0] as ContainerDocumentNode;
+        const listItem = list.children[0] as ContainerDocumentNode;
+        expect(listItem.number).toBe('Art. 5');
+
+        // Step 2: list_item -> content (rebuild hook over the new doc)
+        mockCommit.mockClear();
+        const { result: result2 } = renderTreeOperations(afterToList);
+        act(() => {
+          result2.current.changeNodeTypes([listItem.id], 'content');
+        });
+        const afterRoundtrip = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const finalContent = afterRoundtrip.children[0] as ContentDocumentNode;
+
+        expect(finalContent.type).toBe('content');
+        expect(finalContent.number).toBe('Art. 5');
+      });
+    });
   });
 
   describe('changeNodeTypes (batch)', () => {
@@ -2367,6 +2994,104 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).not.toHaveBeenCalled();
+    });
+
+    test('numbers a numbered-list batch sequentially (1., 2., 3.)', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'document',
+        children: [
+          {
+            id: 'p1',
+            number: null,
+            type: 'content',
+            format: 'TEXT',
+            contents: { de: 'A' },
+            children: [],
+          } as ContentDocumentNode,
+          {
+            id: 'p2',
+            number: null,
+            type: 'content',
+            format: 'TEXT',
+            contents: { de: 'B' },
+            children: [],
+          } as ContentDocumentNode,
+          {
+            id: 'p3',
+            number: null,
+            type: 'content',
+            format: 'TEXT',
+            contents: { de: 'C' },
+            children: [],
+          } as ContentDocumentNode,
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.changeNodeTypes(['p1', 'p2', 'p3'], 'list', 'numbered');
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+
+      expect(newDoc.children.length).toBe(1);
+      const list = newDoc.children[0] as ContainerDocumentNode;
+      expect(list.type).toBe('list');
+      expect(list.children.length).toBe(3);
+      expect((list.children[0] as ContainerDocumentNode).number).toBe('1.');
+      expect((list.children[1] as ContainerDocumentNode).number).toBe('2.');
+      expect((list.children[2] as ContainerDocumentNode).number).toBe('3.');
+    });
+
+    test('letters a lettered-list batch sequentially (a., b., c.)', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'document',
+        children: [
+          {
+            id: 'p1',
+            number: null,
+            type: 'content',
+            format: 'TEXT',
+            contents: { de: 'A' },
+            children: [],
+          } as ContentDocumentNode,
+          {
+            id: 'p2',
+            number: null,
+            type: 'content',
+            format: 'TEXT',
+            contents: { de: 'B' },
+            children: [],
+          } as ContentDocumentNode,
+          {
+            id: 'p3',
+            number: null,
+            type: 'content',
+            format: 'TEXT',
+            contents: { de: 'C' },
+            children: [],
+          } as ContentDocumentNode,
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.changeNodeTypes(['p1', 'p2', 'p3'], 'list', 'lettered');
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+
+      const list = newDoc.children[0] as ContainerDocumentNode;
+      expect(list.children.length).toBe(3);
+      expect((list.children[0] as ContainerDocumentNode).number).toBe('a.');
+      expect((list.children[1] as ContainerDocumentNode).number).toBe('b.');
+      expect((list.children[2] as ContainerDocumentNode).number).toBe('c.');
     });
   });
 

--- a/src/hooks/useTreeOperations.test.ts
+++ b/src/hooks/useTreeOperations.test.ts
@@ -2307,6 +2307,44 @@ describe('useTreeOperations', () => {
         expect(converted.contents.de).toBe('Article body');
       });
 
+      test('handles a list_item with no content child (empty contents, default format)', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [
+                {
+                  id: 'li1',
+                  number: '1.',
+                  type: 'list_item',
+                  children: [],
+                } as ContainerDocumentNode,
+              ],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['li1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const converted = newDoc.children[0] as ContentDocumentNode;
+
+        expect(converted.type).toBe('content');
+        expect(converted.id).toBe('li1');
+        expect(converted.number).toBe('1.');
+        expect(converted.contents).toEqual({});
+        expect(converted.format).toBe('TEXT');
+      });
+
       test('preserves the list_item content format when converting to content', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
@@ -2656,6 +2694,107 @@ describe('useTreeOperations', () => {
 
         expect(converted.format).toBe('MARKDOWN');
         expect(converted.contents.de).toBe('**bold**');
+      });
+
+      test('lifts a list_item with multiple content children, attaching the number to the first', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [
+                {
+                  id: 'li1',
+                  number: '1.',
+                  type: 'list_item',
+                  children: [
+                    {
+                      id: 'p1',
+                      number: null,
+                      type: 'content',
+                      format: 'TEXT',
+                      contents: { de: 'First paragraph' },
+                      children: [],
+                    } as ContentDocumentNode,
+                    {
+                      id: 'p2',
+                      number: null,
+                      type: 'content',
+                      format: 'TEXT',
+                      contents: { de: 'Second paragraph' },
+                      children: [],
+                    } as ContentDocumentNode,
+                  ],
+                } as ContainerDocumentNode,
+              ],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['list1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+
+        expect(newDoc.children.length).toBe(2);
+
+        // First content carries li1's id and number
+        const c0 = newDoc.children[0] as ContentDocumentNode;
+        expect(c0.id).toBe('li1');
+        expect(c0.number).toBe('1.');
+        expect(c0.contents.de).toBe('First paragraph');
+
+        // Subsequent content is lifted as-is, keeping its own id and number
+        const c1 = newDoc.children[1] as ContentDocumentNode;
+        expect(c1.id).toBe('p2');
+        expect(c1.number).toBeNull();
+        expect(c1.contents.de).toBe('Second paragraph');
+      });
+
+      test('synthesizes a placeholder content node for a list_item with no content child', () => {
+        const doc: ContainerDocumentNode = {
+          id: 'root',
+          number: null,
+          type: 'document',
+          children: [
+            {
+              id: 'list1',
+              number: null,
+              type: 'list',
+              children: [
+                {
+                  id: 'li1',
+                  number: '1.',
+                  type: 'list_item',
+                  children: [],
+                } as ContainerDocumentNode,
+              ],
+            },
+          ],
+        };
+
+        const { result } = renderTreeOperations(doc);
+
+        act(() => {
+          result.current.changeNodeTypes(['list1'], 'content');
+        });
+
+        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+
+        expect(newDoc.children.length).toBe(1);
+        const placeholder = newDoc.children[0] as ContentDocumentNode;
+        expect(placeholder.type).toBe('content');
+        expect(placeholder.id).toBe('li1');
+        expect(placeholder.number).toBe('1.');
+        expect(placeholder.contents).toEqual({});
+        expect(placeholder.format).toBe('TEXT');
       });
 
       test('preserves footnote children of the list_item content', () => {

--- a/src/hooks/useTreeOperations.ts
+++ b/src/hooks/useTreeOperations.ts
@@ -48,6 +48,61 @@ interface UseTreeOperationsProps {
   language: Language;
 }
 
+/**
+ * Flatten a list (and any nested lists inside its list_items) to a sequence of
+ * content nodes. Each list_item becomes one content node carrying the
+ * list_item's `number`; any nested list is flattened recursively and emitted
+ * after that content node. Other list_item children (extra content nodes,
+ * headings, leaves) are lifted in source order.
+ */
+function flattenListToContents(list: ContainerDocumentNode): DocumentNode[] {
+  const out: DocumentNode[] = [];
+  for (const item of list.children) {
+    if (item.type !== 'list_item') continue;
+    const listItem = item as ContainerDocumentNode;
+
+    const flattenedChildren: DocumentNode[] = [];
+    let numberAttached = false;
+
+    for (const child of listItem.children) {
+      if (child.type === 'list') {
+        flattenedChildren.push(...flattenListToContents(child as ContainerDocumentNode));
+      } else if (child.type === 'content' && !numberAttached) {
+        // Promote the first content child: it carries the list_item's id/number.
+        const c = child as ContentDocumentNode;
+        flattenedChildren.push({
+          id: listItem.id,
+          number: listItem.number,
+          type: 'content',
+          format: c.format,
+          contents: c.contents,
+          children: c.children,
+        });
+        numberAttached = true;
+      } else {
+        flattenedChildren.push(child);
+      }
+    }
+
+    if (!numberAttached) {
+      // No content child to carry the list_item's id/number — synthesize a
+      // placeholder so the label survives. Place it at the start so the
+      // number appears where the list_item used to begin.
+      flattenedChildren.unshift({
+        id: listItem.id,
+        number: listItem.number,
+        type: 'content',
+        format: 'TEXT',
+        contents: {},
+        children: [],
+      });
+    }
+
+    out.push(...flattenedChildren);
+  }
+  return out;
+}
+
 /** Create a new empty sibling node appropriate for the given parent. */
 function createNewSiblingNode(parent: DocumentNode, language: Language): DocumentNode {
   if (parent.type === 'list') {
@@ -465,7 +520,7 @@ export const useTreeOperations = ({
       return extractAndConvertListItemInDoc(doc, path, node as ContainerDocumentNode, targetType);
     }
 
-    // Handle list node - can only change list style
+    // Handle list node - can only change list style or flatten to content
     if (node.type === 'list') {
       if (targetType === 'list') {
         const style = listStyle || 'numbered';
@@ -478,6 +533,17 @@ export const useTreeOperations = ({
           ...node,
           children: newChildren,
         }));
+      }
+      if (targetType === 'content') {
+        // Hoist list_items as content nodes, preserving each number. Nested
+        // lists are flattened recursively because content nodes can't host
+        // arbitrary nesting.
+        const flattened = flattenListToContents(node as ContainerDocumentNode);
+        let newDoc = removeNodeAtPath(doc, path);
+        for (let i = 0; i < flattened.length; i++) {
+          newDoc = insertNodeAtPath(newDoc, parentPath, nodeIdxInParent + i, flattened[i]);
+        }
+        return newDoc;
       }
       return null;
     }
@@ -588,9 +654,25 @@ export const useTreeOperations = ({
     if (targetType === 'list') {
       const style = listStyle || 'numbered';
 
+      // For unordered lists we keep the source node's number on the new
+      // list_item. Numbered/lettered styles deliberately renumber: picking
+      // those styles is the user asking for a fresh sequence. The effective
+      // index for that sequence accounts for items in immediately-preceding
+      // adjacent lists, since mergeAdjacentLists below will fold those in —
+      // this is what makes batch conversions yield 1., 2., 3. instead of
+      // three '1.'s.
+      let effectiveIndex = 0;
+      for (let i = nodeIdxInParent - 1; i >= 0; i--) {
+        const sibling = parent.children[i];
+        if (sibling.type !== 'list') break;
+        effectiveIndex += (sibling as ContainerDocumentNode).children.length;
+      }
+      const itemNumber =
+        style === 'unordered' ? node.number : getNumberForStyle(style, effectiveIndex);
+
       const listItem: ContainerDocumentNode = {
         id: generateId(),
-        number: getNumberForStyle(style, 0),
+        number: itemNumber,
         type: 'list_item',
         children: [
           {
@@ -683,26 +765,33 @@ export const useTreeOperations = ({
 
     if (!list || list.type !== 'list') return null;
 
-    // Extract contents from the first child content node
+    // Extract contents and format from the first child content node
     const firstChild = item.children[0];
     const contents = firstChild && 'contents' in firstChild ? firstChild.contents : {};
+    const childFormat =
+      firstChild && 'format' in firstChild
+        ? (firstChild as { format: NodeFormat }).format
+        : undefined;
 
-    // Create the converted node
+    // Preserve the list_item's number on the new node so the visible label
+    // ("1.", "Art. 5", etc.) survives the conversion. Carry the source format
+    // when valid for the target so single-item conversions match the multi-item
+    // (list -> content) flatten path.
     const convertedNode: DocumentNode =
       targetType === 'heading'
         ? ({
             id: item.id,
-            number: null,
+            number: item.number,
             type: 'heading',
-            format: 'TEXT',
+            format: carryFormatOrDefault(childFormat, 'heading'),
             contents,
             children: [],
           } as HeadingDocumentNode)
         : ({
             id: item.id,
-            number: null,
+            number: item.number,
             type: 'content',
-            format: 'TEXT',
+            format: carryFormatOrDefault(childFormat, 'content'),
             contents,
             children: [],
           } as ContentDocumentNode);


### PR DESCRIPTION
## Summary
- `list_item -> content`/`heading`: preserve `list_item.number` on the new node
- `list -> content`: hoist all `list_item`s as `content` nodes, recursively flatten nested lists, preserve every number
- `content -> unordered list`: preserve `content.number` on the new `list_item` (`numbered`/`lettered` still renumber, by design)
- `list_item -> content`/`heading` also carries the source content's `format`, matching the new `list -> content` flatten path
- batch `content -> numbered`/`lettered list` now produces a coherent sequence (`1.`, `2.`, `3.` / `a.`, `b.`, `c.`) instead of every item being `1.` / `a.`. Achieved by counting items in immediately-preceding adjacent lists when picking the new list_item's index, so the numbering survives `mergeAdjacentLists`.

## Test plan
- [x] 19 new unit tests in `src/hooks/useTreeOperations.test.ts` covering each conversion direction, the `list -> content` flattening (incl. null numbers, nested recursion, preserved source order, format preservation, footnote children), the content-to-list per-style behavior, the round-trip `content (number=X) -> unordered list -> content`, and the batch-numbering regression.
- [x] All 819 unit tests pass, build (`npm run build`) succeeds.
- [x] Manual: open a document with numbered list items, change one item to `content` — number visible. Change the whole list to `content` — every number visible. Change a numbered `content` node to `unordered list` — number preserved as `list_item` label. Select multiple `content` nodes, change to `numbered list` — items numbered `1.`, `2.`, `3.` (not all `1.`).

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)