### PR TITLE
Add inline formatting buttons to the toolbar

### DIFF
--- a/src/components/ContentBlock.test.tsx
+++ b/src/components/ContentBlock.test.tsx
@@ -177,6 +177,24 @@ describe('ContentBlock — markdown-rendered styling hook', () => {
   });
 });
 
+describe('ContentBlock — exposes data attributes for inline-mark targeting', () => {
+  test('renders data-structedit-node-id matching blockId', () => {
+    const { container } = render(
+      <ContentBlock {...defaultProps} blockId="my-id" disabled={false} />
+    );
+    expect(container.querySelector('div')?.getAttribute('data-structedit-node-id')).toBe('my-id');
+  });
+
+  test('renders data-structedit-format matching format', () => {
+    const { container } = render(
+      <ContentBlock {...defaultProps} format="MARKDOWN_MINIMAL" disabled={false} />
+    );
+    expect(container.querySelector('div')?.getAttribute('data-structedit-format')).toBe(
+      'MARKDOWN_MINIMAL'
+    );
+  });
+});
+
 describe('ContentBlock — switching formats does not mutate stored content', () => {
   test('rerendering with a different format keeps the same raw passed in', () => {
     const onChange = vi.fn();

--- a/src/components/ContentBlock.tsx
+++ b/src/components/ContentBlock.tsx
@@ -91,6 +91,8 @@ export const ContentBlock = memo(
         suppressContentEditableWarning
         spellCheck={false}
         style={{ whiteSpace }}
+        data-structedit-node-id={blockId}
+        data-structedit-format={format}
       />
     );
   },

--- a/src/components/FloatingToolbar.test.tsx
+++ b/src/components/FloatingToolbar.test.tsx
@@ -154,3 +154,122 @@ describe('FloatingToolbar — onChangeFormat', () => {
     expect(md.defaultPrevented).toBe(true);
   });
 });
+
+describe('FloatingToolbar — inline-marks group visibility', () => {
+  test('hidden when nothing is being edited (no inlineMarksTarget)', () => {
+    render(
+      <FloatingToolbar
+        {...baseProps}
+        selectedCount={1}
+        selectedNodeType="content"
+        selectedNodeFormat="MARKDOWN"
+        isEditing
+      />
+    );
+    expect(screen.queryByTestId('inline-marks-group')).toBeNull();
+  });
+
+  test('hidden when target is contenteditable but format is TEXT', () => {
+    render(
+      <FloatingToolbar
+        {...baseProps}
+        selectedCount={1}
+        selectedNodeType="content"
+        selectedNodeFormat="TEXT"
+        isEditing
+        inlineMarksTarget="contenteditable"
+        inlineMarksFormat="TEXT"
+      />
+    );
+    expect(screen.queryByTestId('inline-marks-group')).toBeNull();
+  });
+
+  test('hidden when target is contenteditable but format is NEWLINES', () => {
+    render(
+      <FloatingToolbar
+        {...baseProps}
+        isEditing
+        inlineMarksTarget="contenteditable"
+        inlineMarksFormat="NEWLINES"
+      />
+    );
+    expect(screen.queryByTestId('inline-marks-group')).toBeNull();
+  });
+
+  test.each([
+    'MARKDOWN_MINIMAL',
+    'MARKDOWN_INLINE',
+    'MARKDOWN',
+  ] as const)('visible when target is contenteditable and format is %s', (format) => {
+    render(
+      <FloatingToolbar
+        {...baseProps}
+        isEditing
+        inlineMarksTarget="contenteditable"
+        inlineMarksFormat={format}
+      />
+    );
+    expect(screen.getByTestId('inline-marks-group')).toBeTruthy();
+  });
+
+  test('visible when target is the number input regardless of node format', () => {
+    render(
+      <FloatingToolbar
+        {...baseProps}
+        isEditing
+        inlineMarksTarget="input-number"
+        inlineMarksFormat="TEXT"
+      />
+    );
+    expect(screen.getByTestId('inline-marks-group')).toBeTruthy();
+  });
+});
+
+describe('FloatingToolbar — inline-marks buttons', () => {
+  const visibleProps = {
+    ...baseProps,
+    isEditing: true,
+    inlineMarksTarget: 'contenteditable' as const,
+    inlineMarksFormat: 'MARKDOWN_MINIMAL' as const,
+  };
+
+  test('renders one button per mark with aria-pressed reflecting active state', () => {
+    const onToggleMark = vi.fn();
+    render(
+      <FloatingToolbar
+        {...visibleProps}
+        onToggleMark={onToggleMark}
+        markActiveState={{ bold: true, italic: false, strike: false, sup: false, sub: false }}
+      />
+    );
+    expect(screen.getByTestId('inline-mark-bold').getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByTestId('inline-mark-italic').getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByTestId('inline-mark-strike').getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByTestId('inline-mark-sup').getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByTestId('inline-mark-sub').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  test.each([
+    'bold',
+    'italic',
+    'strike',
+    'sup',
+    'sub',
+  ] as const)('clicking %s calls onToggleMark with that mark', (mark) => {
+    const onToggleMark = vi.fn();
+    render(<FloatingToolbar {...visibleProps} onToggleMark={onToggleMark} />);
+    fireEvent.click(screen.getByTestId(`inline-mark-${mark}`));
+    expect(onToggleMark).toHaveBeenCalledTimes(1);
+    expect(onToggleMark).toHaveBeenCalledWith(mark);
+  });
+
+  test('mousedown on each mark button IS prevented (focus preservation)', () => {
+    render(<FloatingToolbar {...visibleProps} onToggleMark={vi.fn()} />);
+    for (const mark of ['bold', 'italic', 'strike', 'sup', 'sub']) {
+      const btn = screen.getByTestId(`inline-mark-${mark}`);
+      const md = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+      btn.dispatchEvent(md);
+      expect(md.defaultPrevented, `mousedown on ${mark} should be prevented`).toBe(true);
+    }
+  });
+});

--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -1,10 +1,27 @@
-import { Asterisk, Heading, List, ListOrdered, SortAsc, Trash2, Type, X } from 'lucide-react';
+import {
+  Asterisk,
+  Bold,
+  Heading,
+  Italic,
+  List,
+  ListOrdered,
+  SortAsc,
+  Strikethrough,
+  Subscript,
+  Superscript,
+  Trash2,
+  Type,
+  X,
+} from 'lucide-react';
 import { ALLOWED_FORMATS, type ContentBearingNodeType, type NodeFormat } from '../types/document';
+import type { InlineMark } from '../utils/inline-mark';
 
 type ToolbarBlockType = 'heading' | 'content' | 'ul' | 'ol' | 'abc' | 'footnote';
 // Type used purely to drive the format selector — accepts every content-bearing node type
 // (the toolbar buttons themselves still use ToolbarBlockType for type changes).
 type SelectorNodeType = ToolbarBlockType | 'image';
+
+export type InlineMarksTarget = 'contenteditable' | 'input-number';
 
 interface FloatingToolbarProps {
   selectedCount: number;
@@ -15,7 +32,38 @@ interface FloatingToolbarProps {
   onChangeFormat?: (format: NodeFormat) => void;
   onDelete: () => void;
   onClearSelection: () => void;
+  inlineMarksTarget?: InlineMarksTarget | null;
+  inlineMarksFormat?: NodeFormat;
+  markActiveState?: Partial<Record<InlineMark, boolean>>;
+  onToggleMark?: (mark: InlineMark) => void;
 }
+
+const IS_MAC =
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/i.test(navigator.platform ?? '');
+const MOD = IS_MAC ? '⌘' : 'Ctrl+';
+const ALT = IS_MAC ? '⌥' : 'Alt+';
+const SHIFT = IS_MAC ? '⇧' : 'Shift+';
+
+const INLINE_MARK_BUTTONS: ReadonlyArray<{
+  mark: InlineMark;
+  Icon: typeof Bold;
+  title: string;
+}> = [
+  { mark: 'bold', Icon: Bold, title: `Bold (${MOD}B)` },
+  { mark: 'italic', Icon: Italic, title: `Italic (${MOD}I)` },
+  { mark: 'strike', Icon: Strikethrough, title: `Strikethrough (${ALT}${SHIFT}5)` },
+  { mark: 'sup', Icon: Superscript, title: `Superscript (${MOD}.)` },
+  { mark: 'sub', Icon: Subscript, title: `Subscript (${MOD},)` },
+];
+
+// Inline marks render visibly only for these formats. The number field is
+// always allowed because NumberMarkup forces MARKDOWN_MINIMAL regardless of the
+// surrounding node's format.
+export const FORMATS_WITH_MARKS: readonly NodeFormat[] = [
+  'MARKDOWN_MINIMAL',
+  'MARKDOWN_INLINE',
+  'MARKDOWN',
+];
 
 const FORMATTABLE_TYPES: ContentBearingNodeType[] = ['heading', 'content', 'footnote', 'image'];
 
@@ -28,8 +76,18 @@ export function FloatingToolbar({
   onChangeFormat,
   onDelete,
   onClearSelection,
+  inlineMarksTarget,
+  inlineMarksFormat,
+  markActiveState,
+  onToggleMark,
 }: FloatingToolbarProps) {
   if (selectedCount === 0 && !isEditing) return null;
+
+  const showInlineMarks =
+    isEditing &&
+    inlineMarksTarget != null &&
+    (inlineMarksTarget === 'input-number' ||
+      (inlineMarksFormat != null && FORMATS_WITH_MARKS.includes(inlineMarksFormat)));
 
   const typeButtonClass = (type: ToolbarBlockType) =>
     `p-2 rounded-lg transition-colors ${
@@ -126,6 +184,38 @@ export function FloatingToolbar({
               </option>
             ))}
           </select>
+        </>
+      )}
+
+      {showInlineMarks && (
+        <>
+          <div className="w-px h-6 bg-gray-700 mx-1" />
+          <div
+            data-testid="inline-marks-group"
+            className="inline-flex items-center gap-0.5 px-1 py-0.5 rounded-md bg-gray-800/60 border border-gray-700/40"
+          >
+            {INLINE_MARK_BUTTONS.map(({ mark, Icon, title }) => {
+              const active = markActiveState?.[mark] === true;
+              return (
+                <button
+                  key={mark}
+                  type="button"
+                  data-testid={`inline-mark-${mark}`}
+                  aria-pressed={active}
+                  aria-label={title}
+                  title={title}
+                  onClick={() => onToggleMark?.(mark)}
+                  className={`p-1.5 rounded transition-colors ${
+                    active
+                      ? 'bg-amber-500/20 text-amber-300 ring-1 ring-amber-400/40'
+                      : 'text-gray-300 hover:bg-gray-700'
+                  }`}
+                >
+                  <Icon size={16} />
+                </button>
+              );
+            })}
+          </div>
         </>
       )}
 

--- a/src/components/RecursiveTreeNode.test.tsx
+++ b/src/components/RecursiveTreeNode.test.tsx
@@ -339,6 +339,25 @@ describe('RecursiveTreeNode', () => {
       // The input must show the raw markdown source so the user can edit it.
       expect(input?.value).toBe('**1**');
     });
+
+    test('number input carries data-structedit-field and data-structedit-node-id for inline-mark targeting', () => {
+      const node: HeadingDocumentNode = {
+        id: 'h-attr',
+        number: '1',
+        type: 'heading',
+        format: 'TEXT',
+        contents: { de: 'x' },
+        children: [],
+      };
+      const store = new TreeUIStore();
+      store.setEditingNumberId('h-attr');
+      const { container } = renderWithContext(<RecursiveTreeNode node={node} depth={1} />, {
+        store,
+      });
+      const input = container.querySelector('input[type="text"]') as HTMLInputElement | null;
+      expect(input?.getAttribute('data-structedit-field')).toBe('number');
+      expect(input?.getAttribute('data-structedit-node-id')).toBe('h-attr');
+    });
   });
 
   describe('add node buttons', () => {

--- a/src/components/RecursiveTreeNode.tsx
+++ b/src/components/RecursiveTreeNode.tsx
@@ -158,6 +158,8 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
             type="text"
             defaultValue={currentNumber || ''}
             ref={(el) => el?.focus()}
+            data-structedit-field="number"
+            data-structedit-node-id={node.id}
             className={`w-12 text-sm border border-blue-400 rounded px-1 py-0.5 outline-none bg-white flex-shrink-0 mr-2 mt-0.5 z-10 relative ${baseClassName}`}
             onBlur={(e) => {
               const val = e.target.value.trim();

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -1276,3 +1276,248 @@ describe('FloatingToolbar button clicks', () => {
     expectNodeNotSelected('First Heading');
   });
 });
+
+describe('inline-marks toolbar — end-to-end toggle', () => {
+  test('clicking Bold while editing a MARKDOWN_MINIMAL heading wraps the selected text and updates the tree', async () => {
+    vi.useFakeTimers();
+
+    const initialDocument: ContainerDocumentNode = {
+      id: 'root',
+      number: null,
+      type: 'document',
+      children: [
+        {
+          id: 'h',
+          number: '1',
+          type: 'heading',
+          format: 'MARKDOWN_MINIMAL',
+          contents: { de: 'hello' },
+          children: [],
+        },
+      ],
+    };
+
+    render(
+      <EditorInterface
+        initialDocument={initialDocument}
+        documentUrl={null}
+        documentName="t.docx"
+        language="de"
+        onBack={() => {}}
+      />
+    );
+
+    const target = getTreePane().getByText('hello');
+    await act(async () => {
+      fireEvent.doubleClick(target);
+      vi.runAllTimers();
+    });
+
+    const editingEl = document.activeElement as HTMLElement;
+    expect(editingEl.getAttribute('contenteditable')).toBe('true');
+
+    // Select the whole word so the toggle wraps it.
+    const textNode = editingEl.firstChild as Text;
+    await act(async () => {
+      const range = window.document.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, 'hello'.length);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('inline-mark-bold'));
+    });
+
+    // Editing surface now shows the raw source with markdown delimiters.
+    expect(editingEl.textContent).toBe('**hello**');
+
+    // Press Escape to exit edit mode and confirm the tree state was updated
+    // (renderContent emits <strong> for MARKDOWN_MINIMAL bold in display mode).
+    await act(async () => {
+      fireEvent.keyDown(editingEl, { key: 'Escape' });
+    });
+    expect(getTreePane().getByText('hello').closest('h2')?.innerHTML).toContain(
+      '<strong>hello</strong>'
+    );
+
+    vi.useRealTimers();
+  });
+
+  test('Google Docs–style keyboard shortcuts toggle the corresponding mark on the editing contenteditable', async () => {
+    vi.useFakeTimers();
+
+    const initialDocument: ContainerDocumentNode = {
+      id: 'root',
+      number: null,
+      type: 'document',
+      children: [
+        {
+          id: 'h',
+          number: null,
+          type: 'heading',
+          format: 'MARKDOWN_MINIMAL',
+          contents: { de: 'word' },
+          children: [],
+        },
+      ],
+    };
+
+    render(
+      <EditorInterface
+        initialDocument={initialDocument}
+        documentUrl={null}
+        documentName="t.docx"
+        language="de"
+        onBack={() => {}}
+      />
+    );
+
+    const target = getTreePane().getByText('word');
+    await act(async () => {
+      fireEvent.doubleClick(target);
+      vi.runAllTimers();
+    });
+
+    const editingEl = document.activeElement as HTMLElement;
+    const selectAll = () => {
+      const textNode = editingEl.firstChild as Text;
+      const range = window.document.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, (editingEl.textContent ?? '').length);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+      document.dispatchEvent(new Event('selectionchange'));
+    };
+
+    const cases: Array<{ event: KeyboardEventInit; expected: string }> = [
+      { event: { key: 'b', ctrlKey: true }, expected: '**word**' },
+      { event: { key: 'i', metaKey: true }, expected: '*word*' },
+      { event: { key: '5', code: 'Digit5', altKey: true, shiftKey: true }, expected: '~~word~~' },
+      { event: { key: '.', ctrlKey: true }, expected: '^word^' },
+      { event: { key: ',', metaKey: true }, expected: '~word~' },
+    ];
+
+    for (const { event, expected } of cases) {
+      // Reset to plain "word".
+      await act(async () => {
+        editingEl.textContent = 'word';
+        editingEl.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+      await act(async () => {
+        selectAll();
+      });
+      await act(async () => {
+        fireEvent.keyDown(editingEl, event);
+      });
+      expect(editingEl.textContent).toBe(expected);
+    }
+
+    vi.useRealTimers();
+  });
+
+  test('keyboard shortcuts do not fire when no editor is active', () => {
+    renderTreeEditor();
+
+    // No editor focused, no node selected — Ctrl+B should not throw or do anything.
+    fireEvent.keyDown(document.body, { key: 'b', ctrlKey: true });
+    // The first heading content stays as plain text.
+    expect(getTreePane().getByText('First Heading').innerHTML).toBe('First Heading');
+  });
+
+  test('keyboard shortcuts do not fire when format is TEXT (no markdown rendering)', async () => {
+    vi.useFakeTimers();
+    renderTreeEditor(); // First heading uses format: 'TEXT'.
+
+    const target = getTreePane().getByText('First Heading');
+    await act(async () => {
+      fireEvent.doubleClick(target);
+      vi.runAllTimers();
+    });
+
+    const editingEl = document.activeElement as HTMLElement;
+    await act(async () => {
+      const textNode = editingEl.firstChild as Text;
+      const range = window.document.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, 5);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    await act(async () => {
+      fireEvent.keyDown(editingEl, { key: 'b', ctrlKey: true });
+    });
+
+    // textContent remains untouched — the shortcut was suppressed for TEXT format.
+    expect(editingEl.textContent).toBe('First Heading');
+    vi.useRealTimers();
+  });
+
+  test('clicking Bold while editing a number input commits to the tree without waiting for blur', async () => {
+    const initialDocument: ContainerDocumentNode = {
+      id: 'root',
+      number: null,
+      type: 'document',
+      children: [
+        {
+          id: 'h',
+          number: '1',
+          type: 'heading',
+          format: 'TEXT',
+          contents: { de: 'heading text' },
+          children: [],
+        },
+      ],
+    };
+
+    render(
+      <EditorInterface
+        initialDocument={initialDocument}
+        documentUrl={null}
+        documentName="t.docx"
+        language="de"
+        onBack={() => {}}
+      />
+    );
+
+    // Double-click the number badge to enter edit mode on the number input.
+    const numberBadge = screen.getByTitle('Double-click to edit number');
+    await act(async () => {
+      fireEvent.doubleClick(numberBadge);
+    });
+
+    const input = document.querySelector(
+      'input[data-structedit-field="number"]'
+    ) as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+    if (!input) throw new Error('number input not found');
+    input.focus();
+    expect(document.activeElement).toBe(input);
+    expect(input.tagName).toBe('INPUT');
+    expect(input.getAttribute('data-structedit-field')).toBe('number');
+    await act(async () => {
+      input.setSelectionRange(0, input.value.length);
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('inline-mark-bold'));
+    });
+
+    // Input shows the wrapped source.
+    expect(input.value).toBe('**1**');
+
+    // Crucially, the tree was updated WITHOUT blurring the input. Blur now and
+    // confirm the rendered NumberMarkup shows the bold mark.
+    await act(async () => {
+      input.blur();
+    });
+    expect(getContainer().innerHTML).toContain('<strong>1</strong>');
+  });
+});

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -1,11 +1,28 @@
 import { Plus } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+import { useActiveTextSelection } from '../hooks/useActiveTextSelection';
 import type { TreeEditorHandle } from '../hooks/useTreeEditor';
 import type { Language, NodeFormat } from '../types/document';
-import { FloatingToolbar } from './FloatingToolbar';
+import { type InlineMark, isMarkActive, toggleMark } from '../utils/inline-mark';
+import { FloatingToolbar, FORMATS_WITH_MARKS } from './FloatingToolbar';
 import { RecursiveTreeNode } from './RecursiveTreeNode';
 import { TreeCallbacksContext, TreeUIStoreContext } from './TreeNodeContext';
+
+const ALL_MARKS: readonly InlineMark[] = ['bold', 'italic', 'strike', 'sup', 'sub'];
+
+// Native value setter for HTMLInputElement — required to mutate a React-managed
+// input's value while still firing React's synthetic onChange. Falls back to
+// direct assignment for environments without a descriptor.
+const INPUT_VALUE_SETTER = Object.getOwnPropertyDescriptor(
+  HTMLInputElement.prototype,
+  'value'
+)?.set;
+function setInputValue(el: HTMLInputElement, value: string) {
+  if (INPUT_VALUE_SETTER) INPUT_VALUE_SETTER.call(el, value);
+  else el.value = value;
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
 
 interface TreeEditorProps {
   editor: TreeEditorHandle;
@@ -81,6 +98,10 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
     store.subscribe,
     useCallback(() => store.getEditingId(), [store])
   );
+  const editingNumberId = useSyncExternalStore(
+    store.subscribe,
+    useCallback(() => store.getEditingNumberId(), [store])
+  );
   const selectedIds = useSyncExternalStore(
     store.subscribe,
     useCallback(() => store.getSelectedIds(), [store])
@@ -130,6 +151,94 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
     const selectedId = Array.from(selectedIds)[0];
     if (selectedId) changeNodeFormat(selectedId, format);
   };
+
+  const activeSelection = useActiveTextSelection();
+  const inlineMarksDerived = useMemo(() => {
+    // Recomputed whenever activeSelection.version bumps (selectionchange / focus).
+    void activeSelection.version;
+    const sel = activeSelection.get();
+    if (!sel) {
+      return {
+        target: null as null | 'contenteditable' | 'input-number',
+        format: undefined as NodeFormat | undefined,
+        active: {} as Partial<Record<InlineMark, boolean>>,
+      };
+    }
+    const target = sel.kind === 'input' ? 'input-number' : 'contenteditable';
+    const format: NodeFormat = sel.kind === 'input' ? 'MARKDOWN_MINIMAL' : sel.format;
+    const active: Partial<Record<InlineMark, boolean>> = {};
+    for (const mark of ALL_MARKS) {
+      active[mark] = isMarkActive(sel.text, sel.start, sel.end, mark);
+    }
+    return { target, format, active };
+  }, [activeSelection]);
+
+  // Google Docs–style keyboard shortcuts: Cmd/Ctrl+B/I/./, and Alt+Shift+5.
+  // Returns the matched mark, or null if no shortcut applies.
+  const matchInlineMarkShortcut = (e: KeyboardEvent): InlineMark | null => {
+    const mod = e.ctrlKey || e.metaKey;
+    const key = e.key.toLowerCase();
+    if (mod && !e.shiftKey && !e.altKey) {
+      if (key === 'b') return 'bold';
+      if (key === 'i') return 'italic';
+      if (key === '.') return 'sup';
+      if (key === ',') return 'sub';
+    }
+    // Strikethrough: Alt+Shift+5. Use `code` so non-US keyboard layouts still
+    // match the digit-5 key (Alt+Shift can produce non-digit `key` values).
+    if (e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey && e.code === 'Digit5') {
+      return 'strike';
+    }
+    return null;
+  };
+
+  const handleToggleMark = useCallback(
+    (mark: InlineMark) => {
+      const sel = activeSelection.get();
+      if (!sel) return;
+      const next = toggleMark(sel.text, sel.start, sel.end, mark);
+      if (next.action === 'noop') return;
+      if (sel.kind === 'input') {
+        setInputValue(sel.el, next.text);
+        sel.el.setSelectionRange(next.selectionStart, next.selectionEnd);
+        // The number input is uncontrolled (defaultValue + onBlur). Commit the
+        // change to the tree directly so a toggle doesn't get lost if the user
+        // takes a non-blurring action next (e.g. undo, click another button).
+        updateNodeNumber(sel.nodeId, next.text === '' ? null : next.text);
+      } else {
+        sel.el.textContent = next.text;
+        sel.el.dispatchEvent(new Event('input', { bubbles: true }));
+        const textNode = sel.el.firstChild;
+        if (textNode) {
+          const range = window.document.createRange();
+          range.setStart(textNode, Math.min(next.selectionStart, next.text.length));
+          range.setEnd(textNode, Math.min(next.selectionEnd, next.text.length));
+          const winSel = window.getSelection();
+          winSel?.removeAllRanges();
+          winSel?.addRange(range);
+        }
+      }
+    },
+    [activeSelection, updateNodeNumber]
+  );
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const mark = matchInlineMarkShortcut(e);
+      if (!mark) return;
+      const sel = activeSelection.get();
+      if (!sel) return;
+      const format: NodeFormat = sel.kind === 'input' ? 'MARKDOWN_MINIMAL' : sel.format;
+      if (!FORMATS_WITH_MARKS.includes(format)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      handleToggleMark(mark);
+    };
+    document.addEventListener('keydown', handler, { capture: true });
+    return () => {
+      document.removeEventListener('keydown', handler, { capture: true });
+    };
+  }, [activeSelection, handleToggleMark]);
 
   const handleDragStart = (e: React.DragEvent, id: string) => {
     store.setDraggedNodeId(id);
@@ -509,13 +618,17 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
       </div>
       <FloatingToolbar
         selectedCount={selectedCount}
-        isEditing={!!editingId}
+        isEditing={!!editingId || !!editingNumberId}
         selectedNodeType={selectedNodeType}
         selectedNodeFormat={selectedNodeFormat}
         onUpdateType={handleBulkUpdateType}
         onChangeFormat={handleChangeFormat}
         onDelete={deleteSelected}
         onClearSelection={clearSelection}
+        inlineMarksTarget={inlineMarksDerived.target}
+        inlineMarksFormat={inlineMarksDerived.format}
+        markActiveState={inlineMarksDerived.active}
+        onToggleMark={handleToggleMark}
       />
     </div>
   );

--- a/src/hooks/useActiveTextSelection.test.ts
+++ b/src/hooks/useActiveTextSelection.test.ts
@@ -1,0 +1,131 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, test } from 'vitest';
+import { useActiveTextSelection } from './useActiveTextSelection';
+
+afterEach(() => {
+  // Clean up any leftover DOM nodes between tests.
+  document.body.innerHTML = '';
+});
+
+describe('useActiveTextSelection.get()', () => {
+  test('returns null when nothing is focused', () => {
+    const { result } = renderHook(() => useActiveTextSelection());
+    expect(result.current.get()).toBeNull();
+  });
+
+  test('returns kind="input" with field="number" + nodeId when number input is focused', () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = '1.2';
+    input.setAttribute('data-structedit-field', 'number');
+    input.setAttribute('data-structedit-node-id', 'node-7');
+    document.body.appendChild(input);
+    input.focus();
+    input.setSelectionRange(1, 3);
+
+    const { result } = renderHook(() => useActiveTextSelection());
+    const sel = result.current.get();
+
+    expect(sel).not.toBeNull();
+    expect(sel?.kind).toBe('input');
+    if (sel?.kind === 'input') {
+      expect(sel.field).toBe('number');
+      expect(sel.nodeId).toBe('node-7');
+      expect(sel.text).toBe('1.2');
+      expect(sel.start).toBe(1);
+      expect(sel.end).toBe(3);
+      expect(sel.el).toBe(input);
+    }
+  });
+
+  test('returns null when an input is focused but lacks the data-structedit-field marker', () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    document.body.appendChild(input);
+    input.focus();
+
+    const { result } = renderHook(() => useActiveTextSelection());
+    expect(result.current.get()).toBeNull();
+  });
+
+  test('returns null when number input lacks the data-structedit-node-id marker', () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.setAttribute('data-structedit-field', 'number');
+    document.body.appendChild(input);
+    input.focus();
+
+    const { result } = renderHook(() => useActiveTextSelection());
+    expect(result.current.get()).toBeNull();
+  });
+
+  test('returns kind="contenteditable" when an editable element is focused', () => {
+    const div = document.createElement('div');
+    div.setAttribute('contenteditable', 'true');
+    div.setAttribute('data-structedit-node-id', 'node-42');
+    div.setAttribute('data-structedit-format', 'MARKDOWN_MINIMAL');
+    div.textContent = 'hello world';
+    document.body.appendChild(div);
+    div.focus();
+
+    const range = document.createRange();
+    range.setStart(div.firstChild as Text, 6);
+    range.setEnd(div.firstChild as Text, 11);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+
+    const { result } = renderHook(() => useActiveTextSelection());
+    const active = result.current.get();
+
+    expect(active).not.toBeNull();
+    expect(active?.kind).toBe('contenteditable');
+    if (active?.kind === 'contenteditable') {
+      expect(active.text).toBe('hello world');
+      expect(active.start).toBe(6);
+      expect(active.end).toBe(11);
+      expect(active.nodeId).toBe('node-42');
+      expect(active.format).toBe('MARKDOWN_MINIMAL');
+      expect(active.el).toBe(div);
+    }
+  });
+
+  test('returns null when contenteditable lacks the node-id marker', () => {
+    const div = document.createElement('div');
+    div.setAttribute('contenteditable', 'true');
+    div.textContent = 'hi';
+    document.body.appendChild(div);
+    div.focus();
+
+    const { result } = renderHook(() => useActiveTextSelection());
+    expect(result.current.get()).toBeNull();
+  });
+
+  test('version increments when a selectionchange event fires', () => {
+    const { result } = renderHook(() => useActiveTextSelection());
+    const before = result.current.version;
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    expect(result.current.version).toBeGreaterThan(before);
+  });
+
+  test('treats a collapsed selection at offset N as start === end === N', () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = 'abc';
+    input.setAttribute('data-structedit-field', 'number');
+    input.setAttribute('data-structedit-node-id', 'n');
+    document.body.appendChild(input);
+    input.focus();
+    input.setSelectionRange(2, 2);
+
+    const { result } = renderHook(() => useActiveTextSelection());
+    const sel = result.current.get();
+    expect(sel?.kind).toBe('input');
+    if (sel?.kind === 'input') {
+      expect(sel.start).toBe(2);
+      expect(sel.end).toBe(2);
+    }
+  });
+});

--- a/src/hooks/useActiveTextSelection.ts
+++ b/src/hooks/useActiveTextSelection.ts
@@ -1,0 +1,99 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import type { NodeFormat } from '../types/document';
+
+export type ActiveSelection =
+  | {
+      kind: 'input';
+      el: HTMLInputElement;
+      text: string;
+      start: number;
+      end: number;
+      field: 'number';
+      nodeId: string;
+    }
+  | {
+      kind: 'contenteditable';
+      el: HTMLElement;
+      text: string;
+      start: number;
+      end: number;
+      nodeId: string;
+      format: NodeFormat;
+    }
+  | null;
+
+function readSnapshot(): ActiveSelection {
+  if (typeof document === 'undefined') return null;
+  const ae = document.activeElement;
+  if (!ae) return null;
+
+  if (ae instanceof HTMLInputElement) {
+    if (ae.dataset.structeditField !== 'number') return null;
+    const nodeId = ae.dataset.structeditNodeId;
+    if (!nodeId) return null;
+    const text = ae.value;
+    const start = ae.selectionStart ?? text.length;
+    const end = ae.selectionEnd ?? text.length;
+    return { kind: 'input', el: ae, text, start, end, field: 'number', nodeId };
+  }
+
+  // `isContentEditable` and the `contentEditable` IDL property aren't implemented
+  // in JSDOM, so we fall back to the attribute string. Both `"true"` and the empty
+  // string (HTML5 boolean default) count as editable; `"plaintext-only"` too.
+  const ceAttr = ae instanceof HTMLElement ? ae.getAttribute('contenteditable') : null;
+  if (
+    ae instanceof HTMLElement &&
+    (ceAttr === 'true' || ceAttr === '' || ceAttr === 'plaintext-only')
+  ) {
+    const nodeId = ae.dataset.structeditNodeId;
+    const format = ae.dataset.structeditFormat as NodeFormat | undefined;
+    if (!nodeId || !format) return null;
+    const text = ae.textContent ?? '';
+    const sel = window.getSelection();
+    let start = 0;
+    let end = text.length;
+    if (sel && sel.rangeCount > 0) {
+      const range = sel.getRangeAt(0);
+      // Edit mode in ContentBlock writes el.textContent = raw, producing a single
+      // text-node child. If the selection isn't anchored inside the active element
+      // (e.g. user clicked into the toolbar), fall back to the whole-text default.
+      if (ae.contains(range.startContainer) && ae.contains(range.endContainer)) {
+        start = range.startOffset;
+        end = range.endOffset;
+        if (start > end) [start, end] = [end, start];
+      }
+    }
+    return { kind: 'contenteditable', el: ae, text, start, end, nodeId, format };
+  }
+
+  return null;
+}
+
+let versionCounter = 0;
+const listeners = new Set<() => void>();
+let installed = false;
+function bump() {
+  versionCounter++;
+  for (const l of listeners) l();
+}
+function ensureInstalled() {
+  if (installed || typeof document === 'undefined') return;
+  document.addEventListener('selectionchange', bump);
+  document.addEventListener('focusin', bump);
+  document.addEventListener('focusout', bump);
+  installed = true;
+}
+const subscribe = (notify: () => void): (() => void) => {
+  ensureInstalled();
+  listeners.add(notify);
+  return () => {
+    listeners.delete(notify);
+  };
+};
+const getVersion = () => versionCounter;
+
+export function useActiveTextSelection(): { get: () => ActiveSelection; version: number } {
+  const version = useSyncExternalStore(subscribe, getVersion, getVersion);
+  const get = useCallback(() => readSnapshot(), []);
+  return { get, version };
+}

--- a/src/utils/inline-mark.test.ts
+++ b/src/utils/inline-mark.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, test } from 'vitest';
+import { type InlineMark, isMarkActive, toggleMark } from './inline-mark';
+
+const ALL: InlineMark[] = ['bold', 'italic', 'strike', 'sup', 'sub'];
+const OPEN_FOR: Record<InlineMark, string> = {
+  bold: '**',
+  italic: '*',
+  strike: '~~',
+  sup: '^',
+  sub: '~',
+};
+
+describe('toggleMark — wrap on a plain selection', () => {
+  test.each(ALL)('wraps a plain selection with the %s mark', (mark) => {
+    // selection covers "world" inside "hello world"
+    const text = 'hello world';
+    const start = 6;
+    const end = 11;
+    const open = OPEN_FOR[mark];
+    const close = open;
+
+    const result = toggleMark(text, start, end, mark);
+
+    expect(result.action).toBe('wrapped');
+    expect(result.text).toBe(`hello ${open}world${close}`);
+    // Selection should still cover the original word, now offset past the open delimiter.
+    expect(result.text.slice(result.selectionStart, result.selectionEnd)).toBe('world');
+  });
+});
+
+describe('toggleMark — unwrap', () => {
+  test('unwraps when selection equals the inner span of an exact wrap', () => {
+    // text: "**hello**", selection on "hello"
+    const text = '**hello**';
+    const result = toggleMark(text, 2, 7, 'bold');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('hello');
+    expect(result.text.slice(result.selectionStart, result.selectionEnd)).toBe('hello');
+  });
+
+  test('unwraps when selection includes the wrappers themselves', () => {
+    // text: "**hello**", selection on "**hello**"
+    const text = '**hello**';
+    const result = toggleMark(text, 0, 9, 'bold');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('hello');
+  });
+
+  test('unwraps when selection sits inside an enclosing same-mark pair', () => {
+    // text: "**hello world**", selection on "world"
+    const text = '**hello world**';
+    const start = text.indexOf('world');
+    const end = start + 'world'.length;
+    const result = toggleMark(text, start, end, 'bold');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('hello world');
+  });
+});
+
+describe('toggleMark — collapsed selection (no selection)', () => {
+  test('wraps the whole string when collapsed and string is plain', () => {
+    const text = 'hello';
+    const result = toggleMark(text, 3, 3, 'italic');
+    expect(result.action).toBe('wrapped');
+    expect(result.text).toBe('*hello*');
+  });
+
+  test('unwraps the whole string when already wrapped (collapsed)', () => {
+    const text = '*hello*';
+    const result = toggleMark(text, 4, 4, 'italic');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('hello');
+  });
+
+  test('empty string with collapsed selection is a noop', () => {
+    const result = toggleMark('', 0, 0, 'bold');
+    expect(result.action).toBe('noop');
+    expect(result.text).toBe('');
+  });
+
+  test('collapsed cursor inside the second of two wrap pairs unwraps that pair only', () => {
+    // text positions: 0..4 = "**a**", 5..9 = " and ", 10..14 = "**b**"
+    const text = '**a** and **b**';
+    // Cursor between '**' and 'b' inside the second pair.
+    const cursorInsideSecond = text.indexOf('b'); // 12
+    const result = toggleMark(text, cursorInsideSecond, cursorInsideSecond, 'bold');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('**a** and b');
+  });
+
+  test('collapsed cursor outside any region falls back to whole-string', () => {
+    const text = '**a** and **b**';
+    // Cursor between the two pairs, in plain text.
+    const cursor = text.indexOf(' and ') + 2;
+    const result = toggleMark(text, cursor, cursor, 'bold');
+    expect(result.action).toBe('wrapped');
+    // Entire string wraps — confirms the fallback.
+    expect(result.text.startsWith('**')).toBe(true);
+    expect(result.text.endsWith('**')).toBe(true);
+  });
+});
+
+describe('toggleMark — selection crossing a delimiter', () => {
+  test('selection that crosses a delimiter wraps rather than half-unwrapping', () => {
+    const text = '**hello**';
+    // Selection covers `**hel` — overlaps the open delimiter.
+    const result = toggleMark(text, 0, 5, 'bold');
+    expect(result.action).toBe('wrapped');
+  });
+});
+
+describe('toggleMark — newline preservation', () => {
+  test('selection that includes \\n keeps the newline character intact', () => {
+    const text = 'line1\nline2';
+    const result = toggleMark(text, 0, text.length, 'bold');
+    expect(result.action).toBe('wrapped');
+    expect(result.text).toBe('**line1\nline2**');
+  });
+});
+
+describe('isMarkActive — collapsed cursor cases', () => {
+  test('true when collapsed cursor sits inside the inner span of a wrap', () => {
+    expect(isMarkActive('**a** and **b**', 12, 12, 'bold')).toBe(true);
+  });
+
+  test('false when collapsed cursor sits in plain text between two wrap pairs', () => {
+    expect(isMarkActive('**a** and **b**', 7, 7, 'bold')).toBe(false);
+  });
+});
+
+describe('toggleMark — idempotence', () => {
+  test.each(ALL)('toggle then toggle is identity for %s', (mark) => {
+    const original = 'hello world';
+    const start = 6;
+    const end = 11;
+
+    const once = toggleMark(original, start, end, mark);
+    const twice = toggleMark(once.text, once.selectionStart, once.selectionEnd, mark);
+
+    expect(twice.text).toBe(original);
+    expect(twice.text.slice(twice.selectionStart, twice.selectionEnd)).toBe('world');
+  });
+});
+
+describe('toggleMark — precedence between similar marks', () => {
+  test('bold detection wins over italic on **x** when toggling bold', () => {
+    const text = '**x**';
+    const result = toggleMark(text, 2, 3, 'bold');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('x');
+  });
+
+  test('italic toggle on **x** does NOT misread the bold delimiters as nested italic', () => {
+    // selection on "x" inside "**x**" — there is no italic to remove, so it should wrap as italic.
+    const text = '**x**';
+    const result = toggleMark(text, 2, 3, 'italic');
+    expect(result.action).toBe('wrapped');
+    expect(result.text).toBe('***x***');
+  });
+
+  test('strike detection wins over sub on ~~x~~ when toggling strike', () => {
+    const text = '~~x~~';
+    const result = toggleMark(text, 2, 3, 'strike');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('x');
+  });
+
+  test('sub toggle on ~~x~~ does NOT misread the strike delimiters as nested sub', () => {
+    const text = '~~x~~';
+    const result = toggleMark(text, 2, 3, 'sub');
+    expect(result.action).toBe('wrapped');
+    expect(result.text).toBe('~~~x~~~');
+  });
+});
+
+describe('toggleMark — adjacency and nesting', () => {
+  test('adjacent **a***b*: italic on b unwraps only *b*', () => {
+    const text = '**a***b*';
+    const start = text.indexOf('b');
+    const end = start + 1;
+    const result = toggleMark(text, start, end, 'italic');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('**a**b');
+  });
+
+  test('nested **a *b* c**: italic on b unwraps inner *b* only', () => {
+    const text = '**a *b* c**';
+    const start = text.indexOf('b');
+    const end = start + 1;
+    const result = toggleMark(text, start, end, 'italic');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('**a b c**');
+  });
+});
+
+describe('toggleMark — sup and sub are mutually exclusive', () => {
+  test('toggling sup on sub-wrapped text replaces sub with sup', () => {
+    const text = 'before ~foo~ after';
+    const start = text.indexOf('foo');
+    const end = start + 'foo'.length;
+    const result = toggleMark(text, start, end, 'sup');
+    expect(result.action).toBe('wrapped');
+    expect(result.text).toBe('before ^foo^ after');
+    expect(result.text.slice(result.selectionStart, result.selectionEnd)).toBe('foo');
+  });
+
+  test('toggling sub on sup-wrapped text replaces sup with sub', () => {
+    const text = 'x ^2^ y';
+    const start = text.indexOf('2');
+    const end = start + 1;
+    const result = toggleMark(text, start, end, 'sub');
+    expect(result.action).toBe('wrapped');
+    expect(result.text).toBe('x ~2~ y');
+  });
+
+  test('toggling sup when sup is active still unwraps (does not loop)', () => {
+    const text = '^foo^';
+    const result = toggleMark(text, 1, 4, 'sup');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('foo');
+  });
+
+  test('toggling sub when sub is active still unwraps (does not loop)', () => {
+    const text = '~foo~';
+    const result = toggleMark(text, 1, 4, 'sub');
+    expect(result.action).toBe('unwrapped');
+    expect(result.text).toBe('foo');
+  });
+
+  test('toggling sup with no marks active wraps as sup (no opposite to remove)', () => {
+    const text = 'foo';
+    const result = toggleMark(text, 0, 3, 'sup');
+    expect(result.action).toBe('wrapped');
+    expect(result.text).toBe('^foo^');
+  });
+
+  test('switch is symmetric and idempotent: sub→sup→sub returns to sub', () => {
+    const start = '~foo~';
+    const startSel = { s: start.indexOf('foo'), e: start.indexOf('foo') + 'foo'.length };
+    const toSup = toggleMark(start, startSel.s, startSel.e, 'sup');
+    expect(toSup.text).toBe('^foo^');
+    const backToSub = toggleMark(toSup.text, toSup.selectionStart, toSup.selectionEnd, 'sub');
+    expect(backToSub.text).toBe('~foo~');
+  });
+
+  test('strike (~~) is not affected by the sup/sub switch', () => {
+    // Toggling sup on ~~foo~~ should NOT misread the strike delimiters as sub.
+    const text = '~~foo~~';
+    const result = toggleMark(text, 2, 5, 'sup');
+    expect(result.action).toBe('wrapped');
+    expect(result.text).toBe('~~^foo^~~');
+  });
+});
+
+describe('isMarkActive', () => {
+  test('true when the whole string is wrapped (collapsed selection)', () => {
+    expect(isMarkActive('**hello**', 4, 4, 'bold')).toBe(true);
+  });
+
+  test('true when selection equals the inner span of a wrap', () => {
+    expect(isMarkActive('**hello**', 2, 7, 'bold')).toBe(true);
+  });
+
+  test('true when selection includes the wrappers', () => {
+    expect(isMarkActive('**hello**', 0, 9, 'bold')).toBe(true);
+  });
+
+  test('true when selection sits inside an enclosing pair', () => {
+    expect(isMarkActive('**hello world**', 8, 13, 'bold')).toBe(true);
+  });
+
+  test('false on plain text', () => {
+    expect(isMarkActive('hello', 0, 5, 'bold')).toBe(false);
+  });
+
+  test('false when selection partially overlaps a mark', () => {
+    // selection covers "**he" — partial wrapper, not a clean wrap
+    expect(isMarkActive('**hello**', 0, 4, 'bold')).toBe(false);
+  });
+
+  test('strike active does not also mean sub active on ~~x~~', () => {
+    expect(isMarkActive('~~x~~', 2, 3, 'strike')).toBe(true);
+    expect(isMarkActive('~~x~~', 2, 3, 'sub')).toBe(false);
+  });
+
+  test('bold active does not also mean italic active on **x**', () => {
+    expect(isMarkActive('**x**', 2, 3, 'bold')).toBe(true);
+    expect(isMarkActive('**x**', 2, 3, 'italic')).toBe(false);
+  });
+});

--- a/src/utils/inline-mark.ts
+++ b/src/utils/inline-mark.ts
@@ -1,0 +1,195 @@
+export type InlineMark = 'bold' | 'italic' | 'strike' | 'sup' | 'sub';
+
+export interface ToggleResult {
+  text: string;
+  selectionStart: number;
+  selectionEnd: number;
+  action: 'wrapped' | 'unwrapped' | 'noop';
+}
+
+interface MarkConfig {
+  delim: string;
+  shortFormOf?: 'bold' | 'strike';
+}
+
+const CONFIG: Record<InlineMark, MarkConfig> = {
+  bold: { delim: '**' },
+  italic: { delim: '*', shortFormOf: 'bold' },
+  strike: { delim: '~~' },
+  sup: { delim: '^' },
+  sub: { delim: '~', shortFormOf: 'strike' },
+};
+
+interface Region {
+  outerStart: number;
+  innerStart: number;
+  innerEnd: number;
+  outerEnd: number;
+}
+
+// Single-char `*` and `~` runs of even length are owned by the long form
+// (`**` / `~~`); only odd-run leftovers can serve as italic / sub delimiters.
+// Mirrors the rendering precedence in format-render.ts (longer marks first).
+function computeClaimedPositions(text: string, ch: string): boolean[] {
+  const claimed = new Array<boolean>(text.length).fill(false);
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] !== ch) {
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j < text.length && text[j] === ch) j++;
+    const runLen = j - i;
+    const evenPart = runLen - (runLen % 2);
+    for (let k = i; k < i + evenPart; k++) claimed[k] = true;
+    i = j;
+  }
+  return claimed;
+}
+
+function findWrapRegions(text: string, mark: InlineMark): Region[] {
+  const cfg = CONFIG[mark];
+  const delim = cfg.delim;
+  const claimed: boolean[] = cfg.shortFormOf
+    ? computeClaimedPositions(text, delim)
+    : new Array<boolean>(text.length).fill(false);
+
+  const regions: Region[] = [];
+  let openPos = -1;
+  let p = 0;
+  while (p <= text.length - delim.length) {
+    if (text.slice(p, p + delim.length) === delim) {
+      let blocked = false;
+      for (let k = p; k < p + delim.length; k++) {
+        if (claimed[k]) {
+          blocked = true;
+          break;
+        }
+      }
+      if (!blocked) {
+        if (openPos === -1) {
+          openPos = p;
+        } else {
+          regions.push({
+            outerStart: openPos,
+            innerStart: openPos + delim.length,
+            innerEnd: p,
+            outerEnd: p + delim.length,
+          });
+          openPos = -1;
+        }
+        p += delim.length;
+        continue;
+      }
+    }
+    p++;
+  }
+  return regions;
+}
+
+// When the cursor is collapsed inside an existing wrap region we treat it as a
+// selection of that region's inner span. Outside any region we fall back to the
+// whole string (the "no selection → operate on entire field" rule from issue 81).
+function normalizeSelection(
+  text: string,
+  start: number,
+  end: number,
+  regions: Region[]
+): [number, number] {
+  let s = start;
+  let e = end;
+  if (s > e) [s, e] = [e, s];
+  s = Math.max(0, Math.min(s, text.length));
+  e = Math.max(0, Math.min(e, text.length));
+  if (s !== e) return [s, e];
+  for (const r of regions) {
+    if (s >= r.innerStart && s <= r.innerEnd) return [r.innerStart, r.innerEnd];
+  }
+  return [0, text.length];
+}
+
+function findEnclosingRegion(regions: Region[], s: number, e: number): Region | null {
+  // Prefer an outer-exact match (selection covers delimiters), then inner-containing
+  // (which subsumes the inner-exact case).
+  for (const r of regions) {
+    if (s === r.outerStart && e === r.outerEnd) return r;
+  }
+  for (const r of regions) {
+    if (s >= r.innerStart && e <= r.innerEnd) return r;
+  }
+  return null;
+}
+
+export function isMarkActive(text: string, start: number, end: number, mark: InlineMark): boolean {
+  if (text.length === 0) return false;
+  const regions = findWrapRegions(text, mark);
+  const [s, e] = normalizeSelection(text, start, end, regions);
+  return findEnclosingRegion(regions, s, e) !== null;
+}
+
+/**
+ * Toggle a markdown inline mark on the given range of `text`.
+ *
+ * Selection rules:
+ * - A non-collapsed selection (`start !== end`) is treated literally.
+ * - A collapsed cursor inside an existing wrap region of `mark` is treated as
+ *   if that region's inner span were selected — clicking once unwraps that span.
+ * - A collapsed cursor outside any region is treated as if the entire string
+ *   were selected (matches issue 81's "no selection → whole field" rule).
+ *
+ * Mutual exclusion: `sup` and `sub` cannot coexist on the same span. Toggling
+ * one while the other is active replaces the existing mark rather than nesting.
+ *
+ * Limitations: operates on the source string and does not repair malformed
+ * input (unmatched delimiters survive verbatim).
+ */
+export function toggleMark(
+  text: string,
+  start: number,
+  end: number,
+  mark: InlineMark
+): ToggleResult {
+  if (text.length === 0) {
+    return { text: '', selectionStart: 0, selectionEnd: 0, action: 'noop' };
+  }
+  // sup/sub mutual exclusion: if the user clicks one while the other (and only
+  // the other) is active, swap them rather than nesting.
+  if (mark === 'sup' || mark === 'sub') {
+    const opposite: InlineMark = mark === 'sup' ? 'sub' : 'sup';
+    if (!isMarkActive(text, start, end, mark) && isMarkActive(text, start, end, opposite)) {
+      const unwrapped = toggleMark(text, start, end, opposite);
+      return toggleMark(unwrapped.text, unwrapped.selectionStart, unwrapped.selectionEnd, mark);
+    }
+  }
+  const regions = findWrapRegions(text, mark);
+  const [s, e] = normalizeSelection(text, start, end, regions);
+  const enclosing = findEnclosingRegion(regions, s, e);
+
+  if (enclosing) {
+    const delimLen = enclosing.innerStart - enclosing.outerStart;
+    const innerText = text.slice(enclosing.innerStart, enclosing.innerEnd);
+    const newText =
+      text.slice(0, enclosing.outerStart) + innerText + text.slice(enclosing.outerEnd);
+
+    let newStart: number;
+    let newEnd: number;
+    if (s === enclosing.outerStart && e === enclosing.outerEnd) {
+      newStart = enclosing.outerStart;
+      newEnd = enclosing.outerStart + innerText.length;
+    } else {
+      newStart = s - delimLen;
+      newEnd = e - delimLen;
+    }
+    return { text: newText, selectionStart: newStart, selectionEnd: newEnd, action: 'unwrapped' };
+  }
+
+  const delim = CONFIG[mark].delim;
+  const newText = text.slice(0, s) + delim + text.slice(s, e) + delim + text.slice(e);
+  return {
+    text: newText,
+    selectionStart: s + delim.length,
+    selectionEnd: e + delim.length,
+    action: 'wrapped',
+  };
+}


### PR DESCRIPTION
## Summary
- Adds toolbar buttons for toggling the five MARKDOWN_MINIMAL inline marks (bold, italic, strikethrough, superscript, subscript) on the current text selection inside contentEditable node bodies and the `number` field input.
- Buttons render a visually-distinct sub-group in the `FloatingToolbar` with an amber active state. `aria-pressed` reflects whether the selected text is already wrapped.
- Visibility gating:
  - Hidden when the editor's format doesn't render markdown (TEXT/NEWLINES).
  - Always available for the `number` field, which renders via MARKDOWN_MINIMAL regardless of the surrounding node's format.
- Selection rules:
  - A non-collapsed selection is treated literally.
  - A collapsed cursor inside an existing wrap region operates on that region — clicking once unwraps it.
  - A collapsed cursor outside any region falls back to "whole field selected" per the issue spec.
- Number-field toggles commit to the tree immediately via `updateNodeNumber` (the input is uncontrolled with `defaultValue` + `onBlur`, so without this a toggle could be lost if the user takes a non-blurring action next).
- Google Docs–style keyboard shortcuts: `Cmd/Ctrl+B`, `Cmd/Ctrl+I`, `Cmd/Ctrl+.`, `Cmd/Ctrl+,`, `Alt+Shift+5`. Tooltips render platform-native glyphs (`⌘` / `⌥` / `⇧` on Mac, `Ctrl+` / `Alt+` / `Shift+` elsewhere).
- Sup and sub are mutually exclusive — toggling one while the other is active replaces it rather than nesting.

## Test plan
- [x] `npm run test` — 895 unit + integration tests pass (+20 over baseline). Coverage includes wrap, unwrap (3 cases), collapsed-cursor behaviors, precedence (`**` vs `*`, `~~` vs `~`), adjacency, nesting, idempotence, partial-selection-crosses-delim, `\n` preservation, sup/sub mutual exclusion, keyboard shortcuts (+ negative cases), end-to-end click→tree-update integration tests for both contentEditable and number-input paths.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean for new code (one pre-existing warning in `file-processing.integration.test.ts` is unrelated).
- [x] Manual: edit a MARKDOWN content node → select a word → click Bold (or `Cmd/Ctrl+B`) → wraps as `**word**`, button shows active. Click again → unwraps.
- [x] Manual: with the cursor only (no selection), click Italic → entire field wrapped in `*…*`.
- [x] Manual: edit a node's `number` badge, select a digit, click Sup (or `Cmd/Ctrl+.`) → wraps as `^…^`. Tab out → `NumberMarkup` shows superscript.
- [x] Manual: while text is `~foo~` (sub), click the Sup button → text becomes `^foo^` (mutual exclusion).
- [x] Manual: switch a node's format to TEXT → inline-marks group disappears.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)