### PR TITLE
Merge page-split lists during DOCX import

### DIFF
--- a/src/utils/legal-transforms/index.test.ts
+++ b/src/utils/legal-transforms/index.test.ts
@@ -5,7 +5,7 @@ import type {
   HeadingDocumentNode,
 } from '../../types/document';
 import { applySwissLegalTransforms, composeTransforms } from './index';
-import { content, createDoc, heading } from './test-helpers';
+import { content, createDoc, heading, list } from './test-helpers';
 
 describe('composeTransforms', () => {
   it('applies transforms left to right', () => {
@@ -123,6 +123,55 @@ describe('applySwissLegalTransforms', () => {
     expect(result.children).toHaveLength(2);
     expect(result.children[0].type).toBe('content');
     expect(result.children[1].type).toBe('content');
+  });
+
+  it('merges adjacent lists by default', () => {
+    const input = createDoc([
+      list([{ number: '1.', content: 'A' }]),
+      list([{ number: '1.', content: 'B' }]),
+    ]);
+
+    const result = applySwissLegalTransforms(input, 'de');
+
+    expect(result.children).toHaveLength(1);
+    expect(result.children[0].type).toBe('list');
+    const merged = result.children[0] as ContainerDocumentNode;
+    expect(merged.children).toHaveLength(2);
+  });
+
+  it('respects config to disable mergeAdjacentLists', () => {
+    const input = createDoc([
+      list([{ number: '1.', content: 'A' }]),
+      list([{ number: '1.', content: 'B' }]),
+    ]);
+
+    const result = applySwissLegalTransforms(input, 'de', { mergeAdjacentLists: false });
+
+    expect(result.children).toHaveLength(2);
+    expect(result.children[0].type).toBe('list');
+    expect(result.children[1].type).toBe('list');
+  });
+
+  it('preserves lettered list_item numbers verbatim through the full pipeline', () => {
+    // Whole-pipeline assertion of the user's "no auto-renumber" requirement:
+    // when two adjacent lettered lists are merged, the original markers from
+    // both lists survive — even if the apparent sequence restarts.
+    const input = createDoc([
+      list([
+        { number: 'a)', content: 'A' },
+        { number: 'b)', content: 'B' },
+      ]),
+      list([
+        { number: 'a)', content: 'C' },
+        { number: 'b)', content: 'D' },
+      ]),
+    ]);
+
+    const result = applySwissLegalTransforms(input, 'de');
+
+    expect(result.children).toHaveLength(1);
+    const merged = result.children[0] as ContainerDocumentNode;
+    expect(merged.children.map((c) => c.number)).toEqual(['a)', 'b)', 'a)', 'b)']);
   });
 
   it('handles complex nested structure', () => {

--- a/src/utils/legal-transforms/index.ts
+++ b/src/utils/legal-transforms/index.ts
@@ -3,6 +3,7 @@ import { articleTransform } from './article';
 import { headingNumberExtractTransform } from './heading-number-extract';
 import { letteredItemsTransform } from './lettered-items';
 import { listNumberDedupTransform } from './list-number-dedup';
+import { mergeAdjacentListsTransform } from './merge-adjacent-lists';
 import { romanSectionTransform } from './roman-section';
 import type { TreeTransform } from './types';
 
@@ -10,6 +11,7 @@ export { articleTransform } from './article';
 export { headingNumberExtractTransform } from './heading-number-extract';
 export { letteredItemsTransform } from './lettered-items';
 export { listNumberDedupTransform } from './list-number-dedup';
+export { mergeAdjacentListsTransform } from './merge-adjacent-lists';
 export { LEGAL_PATTERNS } from './patterns';
 export { romanSectionTransform } from './roman-section';
 // Re-export types
@@ -19,6 +21,8 @@ export type { TreeTransform } from './types';
  * Configuration for the legal transform pipeline
  */
 export interface LegalTransformConfig {
+  /** Merge adjacent list siblings into one list (fixes Mammoth's page-split lists). Default: true */
+  mergeAdjacentLists?: boolean;
   /** Enable heading number extraction from existing headings. Default: true */
   headingNumberExtract?: boolean;
   /** Enable roman numeral section detection (I., II., etc.). Default: true */
@@ -44,11 +48,13 @@ export function composeTransforms(...transforms: TreeTransform[]): TreeTransform
  * Apply Swiss legal document transforms to a tree.
  *
  * Transform order matters:
- * 1. Heading number extract - Populates number field on existing headings
- * 2. List number dedup - Fixes duplicate numbering from Mammoth's ol/sup output
- * 3. Roman sections - Creates top-level structure (I., II., III.)
- * 4. Articles - Creates nested structure within sections (Art. 1, Art. 2)
- * 5. Lettered items last - Groups items within articles (a., b., c.)
+ * 1. Merge adjacent lists - Fixes page-split lists from Mammoth (must run before dedup so
+ *    list items end up in one container before number extraction)
+ * 2. Heading number extract - Populates number field on existing headings
+ * 3. List number dedup - Fixes duplicate numbering from Mammoth's ol/sup output
+ * 4. Roman sections - Creates top-level structure (I., II., III.)
+ * 5. Articles - Creates nested structure within sections (Art. 1, Art. 2)
+ * 6. Lettered items last - Groups items within articles (a., b., c.)
  *
  * @param root - The document tree to transform
  * @param language - The language of the document content
@@ -61,6 +67,7 @@ export function applySwissLegalTransforms(
   config: LegalTransformConfig = {}
 ): ContainerDocumentNode {
   const {
+    mergeAdjacentLists = true,
     headingNumberExtract = true,
     romanSections = true,
     articles = true,
@@ -70,6 +77,9 @@ export function applySwissLegalTransforms(
 
   const transforms: TreeTransform[] = [];
 
+  if (mergeAdjacentLists) {
+    transforms.push(mergeAdjacentListsTransform);
+  }
   if (headingNumberExtract) {
     transforms.push(headingNumberExtractTransform);
   }

--- a/src/utils/legal-transforms/merge-adjacent-lists.test.ts
+++ b/src/utils/legal-transforms/merge-adjacent-lists.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ContainerDocumentNode,
+  ContentDocumentNode,
+  HeadingDocumentNode,
+} from '../../types/document';
+import { parseHtmlLegalToTree, parseHtmlToTree } from '../document-utils';
+import { mergeAdjacentListsTransform } from './merge-adjacent-lists';
+import { content, createDoc, heading, list } from './test-helpers';
+
+describe('mergeAdjacentListsTransform', () => {
+  describe('core merge behaviour', () => {
+    it('merges two adjacent list siblings at root level into one list', () => {
+      const input = createDoc([
+        list([{ number: '1.', content: 'A' }]),
+        list([{ number: '1.', content: 'B' }]),
+      ]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      expect(result.children).toHaveLength(1);
+      expect(result.children[0].type).toBe('list');
+      const merged = result.children[0] as ContainerDocumentNode;
+      expect(merged.children).toHaveLength(2);
+      const item0 = merged.children[0] as ContainerDocumentNode;
+      const item1 = merged.children[1] as ContainerDocumentNode;
+      expect((item0.children[0] as ContentDocumentNode).contents.de).toBe('A');
+      expect((item1.children[0] as ContentDocumentNode).contents.de).toBe('B');
+    });
+
+    it('preserves the first list id when merging', () => {
+      const first = list([{ number: '1.', content: 'A' }]);
+      const second = list([{ number: '1.', content: 'B' }]);
+      const input = createDoc([first, second]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      expect(result.children[0].id).toBe(first.id);
+    });
+
+    it('leaves a single list untouched', () => {
+      const input = createDoc([list([{ number: '1.', content: 'A' }])]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      expect(result).toBe(input);
+    });
+
+    it('leaves non-adjacent lists separate', () => {
+      const input = createDoc([
+        list([{ number: '1.', content: 'A' }]),
+        content('Separator paragraph'),
+        list([{ number: '1.', content: 'B' }]),
+      ]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      expect(result.children).toHaveLength(3);
+      expect(result.children[0].type).toBe('list');
+      expect(result.children[1].type).toBe('content');
+      expect(result.children[2].type).toBe('list');
+    });
+
+    it('merges three or more consecutive lists into one', () => {
+      const input = createDoc([
+        list([{ number: '1.', content: 'A' }]),
+        list([{ number: '1.', content: 'B' }]),
+        list([{ number: '1.', content: 'C' }]),
+      ]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      expect(result.children).toHaveLength(1);
+      const merged = result.children[0] as ContainerDocumentNode;
+      expect(merged.children).toHaveLength(3);
+    });
+
+    it('merges adjacent lists nested inside a heading container', () => {
+      const input = createDoc([
+        heading('Section', [
+          list([{ number: '1.', content: 'A' }]),
+          list([{ number: '1.', content: 'B' }]),
+        ]),
+      ]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      const h = result.children[0] as HeadingDocumentNode;
+      expect(h.children).toHaveLength(1);
+      const merged = h.children[0] as ContainerDocumentNode;
+      expect(merged.children).toHaveLength(2);
+    });
+
+    it('merges adjacent lists at multiple nesting levels in one pass', () => {
+      const input = createDoc([
+        list([{ number: '1.', content: 'root A' }]),
+        list([{ number: '1.', content: 'root B' }]),
+        heading('Section', [
+          list([{ number: '1.', content: 'nested A' }]),
+          list([{ number: '1.', content: 'nested B' }]),
+        ]),
+      ]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      expect(result.children).toHaveLength(2);
+      const rootList = result.children[0] as ContainerDocumentNode;
+      expect(rootList.children).toHaveLength(2);
+
+      const h = result.children[1] as HeadingDocumentNode;
+      const nestedList = h.children[0] as ContainerDocumentNode;
+      expect(h.children).toHaveLength(1);
+      expect(nestedList.children).toHaveLength(2);
+    });
+
+    it('does not merge sibling list_items as if they were lists', () => {
+      // The transform recurses into every container, but list_items have
+      // type 'list_item' so they never match the merge condition (which
+      // requires recursed.type === 'list').
+      const input = createDoc([
+        list([
+          { number: '1.', content: 'A' },
+          { number: '2.', content: 'B' },
+        ]),
+      ]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      const merged = result.children[0] as ContainerDocumentNode;
+      expect(merged.children).toHaveLength(2);
+      expect(merged.children[0].type).toBe('list_item');
+      expect(merged.children[1].type).toBe('list_item');
+    });
+
+    it('merges adjacent nested lists inside a list_item', () => {
+      // processListElement (document-utils.ts) appends every nested <ol>/<ul>
+      // child of a <li> as a separate list. If Mammoth splits a sub-list
+      // across a page, these adjacent sub-lists must also merge.
+      const outerListItem: ContainerDocumentNode = {
+        id: 'outer-item',
+        number: '1.',
+        type: 'list_item',
+        children: [
+          content('Outer item'),
+          list([{ number: '1.', content: 'nested A' }]),
+          list([{ number: '1.', content: 'nested B' }]),
+        ],
+      };
+      const input = createDoc([
+        {
+          id: 'outer-list',
+          number: null,
+          type: 'list',
+          children: [outerListItem],
+        },
+      ]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      const outerList = result.children[0] as ContainerDocumentNode;
+      const item = outerList.children[0] as ContainerDocumentNode;
+      // Outer item content + ONE merged nested list (was two).
+      expect(item.children).toHaveLength(2);
+      const nestedList = item.children[1] as ContainerDocumentNode;
+      expect(nestedList.type).toBe('list');
+      expect(nestedList.children).toHaveLength(2);
+    });
+
+    it('returns same reference at every level when nothing changes', () => {
+      const onlyList = list([{ number: '1.', content: 'A' }]);
+      const innerHeading = heading('Inner', [onlyList]);
+      const input = createDoc([innerHeading]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      // No merges anywhere → root, heading, and list references are all preserved.
+      expect(result).toBe(input);
+      expect(result.children[0]).toBe(innerHeading);
+      expect((result.children[0] as HeadingDocumentNode).children[0]).toBe(onlyList);
+    });
+  });
+
+  describe('marker preservation (no auto-renumber)', () => {
+    it('preserves each list_item number exactly across the boundary (lettered)', () => {
+      const input = createDoc([
+        list([
+          { number: 'a)', content: 'A' },
+          { number: 'b)', content: 'B' },
+          { number: 'c)', content: 'C' },
+          { number: 'd)', content: 'D' },
+        ]),
+        list([
+          { number: 'a)', content: 'E' },
+          { number: 'b)', content: 'F' },
+          { number: 'c)', content: 'G' },
+        ]),
+      ]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      const merged = result.children[0] as ContainerDocumentNode;
+      const numbers = merged.children.map((c) => c.number);
+      expect(numbers).toEqual(['a)', 'b)', 'c)', 'd)', 'a)', 'b)', 'c)']);
+    });
+
+    it('preserves each list_item number exactly across the boundary (arabic)', () => {
+      const input = createDoc([
+        list([
+          { number: '1.', content: 'A' },
+          { number: '2.', content: 'B' },
+          { number: '3.', content: 'C' },
+        ]),
+        list([
+          { number: '1.', content: 'D' },
+          { number: '2.', content: 'E' },
+        ]),
+      ]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      const merged = result.children[0] as ContainerDocumentNode;
+      const numbers = merged.children.map((c) => c.number);
+      expect(numbers).toEqual(['1.', '2.', '3.', '1.', '2.']);
+    });
+
+    it('preserves null markers for unordered lists', () => {
+      const input = createDoc([
+        list([
+          { number: null, content: 'A' },
+          { number: null, content: 'B' },
+        ]),
+        list([{ number: null, content: 'C' }]),
+      ]);
+
+      const result = mergeAdjacentListsTransform(input, 'de');
+
+      const merged = result.children[0] as ContainerDocumentNode;
+      const numbers = merged.children.map((c) => c.number);
+      expect(numbers).toEqual([null, null, null]);
+    });
+  });
+
+  describe('end-to-end parsing', () => {
+    it('merges adjacent <ol> elements produced by parseHtmlToTree', () => {
+      const html = `<ol><li>A</li></ol><ol><li>B</li></ol>`;
+
+      const tree = parseHtmlToTree(html, 'de');
+      const result = mergeAdjacentListsTransform(tree, 'de');
+
+      expect(result.children).toHaveLength(1);
+      const merged = result.children[0] as ContainerDocumentNode;
+      expect(merged.children).toHaveLength(2);
+      // position-derived numbers are preserved as-is (no renumbering)
+      expect(merged.children.map((c) => c.number)).toEqual(['1.', '1.']);
+    });
+
+    it('issue #67 scenario: merge + dedup yields continuous arabic numbers via <sup>', () => {
+      // Mammoth-style page-split: two adjacent <ol>. The first has two items
+      // (positional 1., 2.) — the second restarts positionally at 1. but its
+      // <sup> tag carries the actual Word number 3. Without the merge running
+      // BEFORE dedup, the result would be two distinct lists; with the merge,
+      // dedup operates on one list and rewrites all positional numbers from
+      // the <sup> text, yielding a single continuous list of three items.
+      const html =
+        `<ol><li><sup>1</sup> Page-1 item one</li><li><sup>2</sup> Page-1 item two</li></ol>` +
+        `<ol><li><sup>3</sup> Page-2 item one</li></ol>`;
+
+      const tree = parseHtmlLegalToTree(html, 'de');
+
+      expect(tree.children).toHaveLength(1);
+      const merged = tree.children[0] as ContainerDocumentNode;
+      expect(merged.children).toHaveLength(3);
+      expect(merged.children.map((c) => c.number)).toEqual(['1', '2', '3']);
+    });
+
+    it('preserves data-list-style-type markers across the merge (no overwrite)', () => {
+      const html = `<ol><li style="list-style-type: 'a) ';">A</li></ol><ol><li style="list-style-type: 'a) ';">B</li></ol>`;
+
+      const tree = parseHtmlLegalToTree(html, 'de');
+
+      expect(tree.children).toHaveLength(1);
+      const merged = tree.children[0] as ContainerDocumentNode;
+      expect(merged.children).toHaveLength(2);
+      // Explicit list-style-type markers preserved exactly — restart kept.
+      expect(merged.children.map((c) => c.number)).toEqual(['a)', 'a)']);
+    });
+  });
+});

--- a/src/utils/legal-transforms/merge-adjacent-lists.ts
+++ b/src/utils/legal-transforms/merge-adjacent-lists.ts
@@ -1,0 +1,52 @@
+import type { ContainerDocumentNode, DocumentNode, Language } from '../../types/document';
+import type { TreeTransform } from './types';
+
+/**
+ * Recurse into a container, merging adjacent `list` siblings at each level.
+ * Returns the original node reference if nothing changed (memo-friendly).
+ *
+ * Merge contract: when two adjacent `list` nodes are merged, the first list's
+ * identity (`id`, `number`, and any other top-level fields) wins; the second
+ * list's list_item children are appended to the first's children. Every
+ * merged `list_item`'s `number` field is preserved exactly — no
+ * auto-renumbering. Restarted sequences (e.g., Mammoth page-splits) survive
+ * as-is; downstream transforms (notably listNumberDedupTransform) handle the
+ * arabic-with-<sup> page-split case via text content. Explicit markers from
+ * `data-list-style-type` are never overwritten.
+ *
+ * The recursion descends through every container including `list_item`, so
+ * adjacent lists nested inside a list item are merged too.
+ */
+function recurseIntoContainer(node: DocumentNode): DocumentNode {
+  if (!('children' in node) || !node.children || node.children.length === 0) return node;
+
+  const out: DocumentNode[] = [];
+  let changed = false;
+
+  for (const child of node.children) {
+    const recursed = recurseIntoContainer(child);
+    if (recursed !== child) changed = true;
+
+    const last = out[out.length - 1];
+    if (recursed.type === 'list' && last?.type === 'list') {
+      const prev = last as ContainerDocumentNode;
+      const curr = recursed as ContainerDocumentNode;
+      out[out.length - 1] = {
+        ...prev,
+        children: [...prev.children, ...curr.children],
+      };
+      changed = true;
+    } else {
+      out.push(recursed);
+    }
+  }
+
+  return changed ? { ...node, children: out } : node;
+}
+
+export const mergeAdjacentListsTransform: TreeTransform = (
+  root: ContainerDocumentNode,
+  _language: Language
+): ContainerDocumentNode => {
+  return recurseIntoContainer(root) as ContainerDocumentNode;
+};


### PR DESCRIPTION
## Summary
- Adds `mergeAdjacentListsTransform` as the first stage of the Swiss-legal pipeline. Mammoth emits two adjacent `<ol>`/`<ul>` elements when a DOCX list spans a page break (e.g. the `§8 Einsatz von KI-Systemen` example in the issue); the transform joins consecutive `type: 'list'` siblings into one list at every level of the tree.
- **Markers are preserved verbatim** — no auto-renumber. `list_item.number` is copied across the merge boundary unchanged, including explicit `data-list-style-type` markers (`a)`, `b)`, …) and position-derived defaults (`1.`, `2.`, …). The canonical issue-67 case (arabic with `<sup>N</sup>`) is fixed end-to-end because the existing `listNumberDedupTransform` runs after the merge and rewrites positional numbers from the item text.
- Config flag `mergeAdjacentLists: false` disables the transform.

## Test plan
- [x] 16 unit + e2e tests in `merge-adjacent-lists.test.ts` covering core merge (adjacent / non-adjacent / nested / multi-level / nested inside `list_item`), same-reference memo behaviour, marker preservation (lettered / arabic / null), and end-to-end via `parseHtmlToTree` and `parseHtmlLegalToTree`.
- [x] 3 integration tests in `index.test.ts` proving default-on, config-disable, and full-pipeline marker preservation.
- [x] `npm run test` — 914 passing, 1 pre-existing skipped.
- [x] `npm run build` clean.
- [x] Manually verify against the referenced DOCX so `§8 Einsatz von KI-Systemen` renders as one list.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)