### PR TITLE
Render markdown marks in the Preview pane

### DIFF
--- a/src/components/DocumentPreview.test.tsx
+++ b/src/components/DocumentPreview.test.tsx
@@ -781,4 +781,239 @@ describe('DocumentPreview', () => {
       expect(container.textContent).toContain('<script>alert(1)</script>');
     });
   });
+
+  describe('body rendering — markdown marks', () => {
+    test('renders MARKDOWN_MINIMAL bold inside heading', () => {
+      const doc = makeDoc({
+        id: 'h1',
+        number: null,
+        type: 'heading',
+        format: 'MARKDOWN_MINIMAL',
+        contents: { de: '**Important** topic' },
+        children: [],
+      });
+
+      render(<DocumentPreview document={doc} language="de" />);
+      const heading = screen.getByRole('heading', { level: 1 });
+      const strong = heading.querySelector('strong');
+      expect(strong).not.toBeNull();
+      expect(strong?.textContent).toBe('Important');
+    });
+
+    test('renders MARKDOWN_MINIMAL sup inside heading', () => {
+      const doc = makeDoc({
+        id: 'h1',
+        number: null,
+        type: 'heading',
+        format: 'MARKDOWN_MINIMAL',
+        contents: { de: 'Note^*^' },
+        children: [],
+      });
+
+      render(<DocumentPreview document={doc} language="de" />);
+      const heading = screen.getByRole('heading', { level: 1 });
+      const sup = heading.querySelector('sup');
+      expect(sup).not.toBeNull();
+      expect(sup?.textContent).toBe('*');
+    });
+
+    test('does not show raw asterisks for MARKDOWN_MINIMAL heading', () => {
+      const doc = makeDoc({
+        id: 'h1',
+        number: null,
+        type: 'heading',
+        format: 'MARKDOWN_MINIMAL',
+        contents: { de: '**Important**' },
+        children: [],
+      });
+
+      render(<DocumentPreview document={doc} language="de" />);
+      const heading = screen.getByRole('heading', { level: 1 });
+      expect(heading.textContent).not.toContain('**');
+    });
+
+    test('renders MARKDOWN content with bold mark', () => {
+      const doc = makeDoc({
+        id: 'c1',
+        number: null,
+        type: 'content',
+        format: 'MARKDOWN',
+        contents: { de: '**bold body** rest' },
+        children: [],
+      });
+
+      const { container } = render(<DocumentPreview document={doc} language="de" />);
+      const strong = container.querySelector('strong');
+      expect(strong).not.toBeNull();
+      expect(strong?.textContent).toBe('bold body');
+      expect(container.textContent).not.toContain('**');
+    });
+
+    test('renders MARKDOWN content with paragraph breaks', () => {
+      const doc = makeDoc({
+        id: 'c1',
+        number: null,
+        type: 'content',
+        format: 'MARKDOWN',
+        contents: { de: 'first para\n\nsecond para' },
+        children: [],
+      });
+
+      render(<DocumentPreview document={doc} language="de" />);
+      expect(screen.getByText('first para')).toBeInTheDocument();
+      expect(screen.getByText('second para')).toBeInTheDocument();
+    });
+
+    test('renders MARKDOWN content with bulleted list', () => {
+      const doc = makeDoc({
+        id: 'c1',
+        number: null,
+        type: 'content',
+        format: 'MARKDOWN',
+        contents: { de: '- alpha\n- beta\n- gamma' },
+        children: [],
+      });
+
+      const { container } = render(<DocumentPreview document={doc} language="de" />);
+      const ul = container.querySelector('ul');
+      expect(ul).not.toBeNull();
+      const items = ul?.querySelectorAll('li') ?? [];
+      expect(items).toHaveLength(3);
+      expect(items[0].textContent).toBe('alpha');
+      expect(items[1].textContent).toBe('beta');
+      expect(items[2].textContent).toBe('gamma');
+    });
+
+    test('renders NEWLINES content with <br>', () => {
+      const doc = makeDoc({
+        id: 'c1',
+        number: null,
+        type: 'content',
+        format: 'NEWLINES',
+        contents: { de: 'line one\nline two' },
+        children: [],
+      });
+
+      const { container } = render(<DocumentPreview document={doc} language="de" />);
+      expect(container.querySelector('br')).not.toBeNull();
+    });
+
+    test('renders MARKDOWN inline mark inside list_item first content', () => {
+      const doc = makeDoc({
+        id: 'l1',
+        number: null,
+        type: 'list',
+        children: [
+          {
+            id: 'li1',
+            number: 'a)',
+            type: 'list_item',
+            children: [
+              {
+                id: 'c1',
+                number: null,
+                type: 'content',
+                format: 'MARKDOWN',
+                contents: { de: '**bold** item body' },
+                children: [],
+              },
+            ],
+          },
+        ],
+      });
+
+      const { container } = render(<DocumentPreview document={doc} language="de" />);
+      const strong = container.querySelector('strong');
+      expect(strong).not.toBeNull();
+      expect(strong?.textContent).toBe('bold');
+      expect(container.textContent).not.toContain('**');
+    });
+
+    test('renders MARKDOWN inline mark inside footnote', () => {
+      const doc = makeDoc({
+        id: 'h1',
+        number: null,
+        type: 'heading',
+        format: 'TEXT',
+        contents: { de: 'Title' },
+        children: [
+          {
+            id: 'c1',
+            number: null,
+            type: 'content',
+            format: 'TEXT',
+            contents: { de: 'Body' },
+            children: [
+              {
+                id: 'fn1',
+                number: '1',
+                type: 'footnote',
+                format: 'MARKDOWN',
+                contents: { de: '**bold note** body' },
+              },
+            ],
+          },
+        ],
+      });
+
+      const { container } = render(<DocumentPreview document={doc} language="de" />);
+      const details = container.querySelector('details');
+      expect(details).not.toBeNull();
+      const strong = details?.querySelector('strong');
+      expect(strong).not.toBeNull();
+      expect(strong?.textContent).toBe('bold note');
+    });
+
+    test('escapes raw HTML in TEXT content', () => {
+      const doc = makeDoc({
+        id: 'c1',
+        number: null,
+        type: 'content',
+        format: 'TEXT',
+        contents: { de: '<script>alert(1)</script>' },
+        children: [],
+      });
+
+      const { container } = render(<DocumentPreview document={doc} language="de" />);
+      expect(container.querySelector('script')).toBeNull();
+      expect(container.textContent).toContain('<script>alert(1)</script>');
+    });
+
+    test('strips XSS payloads in MARKDOWN content', () => {
+      const doc = makeDoc({
+        id: 'c1',
+        number: null,
+        type: 'content',
+        format: 'MARKDOWN',
+        contents: { de: '<img src=x onerror=alert(1)>' },
+        children: [],
+      });
+
+      const { container } = render(<DocumentPreview document={doc} language="de" />);
+      expect(container.querySelector('img')).toBeNull();
+      expect(container.querySelector('script')).toBeNull();
+      for (const el of Array.from(container.querySelectorAll('*'))) {
+        for (const attr of Array.from(el.attributes)) {
+          expect(attr.name.startsWith('on')).toBe(false);
+        }
+      }
+    });
+
+    test('rejects javascript: links in MARKDOWN content', () => {
+      const doc = makeDoc({
+        id: 'c1',
+        number: null,
+        type: 'content',
+        format: 'MARKDOWN',
+        contents: { de: '[click](javascript:alert(1))' },
+        children: [],
+      });
+
+      const { container } = render(<DocumentPreview document={doc} language="de" />);
+      for (const a of Array.from(container.querySelectorAll('a'))) {
+        const href = a.getAttribute('href') ?? '';
+        expect(href).not.toMatch(/^javascript:/i);
+      }
+    });
+  });
 });

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -1,10 +1,37 @@
 import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useResizable } from '../hooks/useResizable';
-import type { ContainerDocumentNode, DocumentNode, Language } from '../types/document';
+import type { ContainerDocumentNode, DocumentNode, Language, NodeFormat } from '../types/document';
+import { renderContent } from '../utils/format-render';
 import { getDocumentOutline, type OutlineEntry } from '../utils/outline-utils';
 import { DragHandle } from './DragHandle';
 import { NumberMarkup } from './NumberMarkup';
+
+/**
+ * MARKDOWN is the only format whose rendered output may contain block-level tags
+ * (<p>, <ul>, <blockquote>, …) — those can't legally nest inside a <p>, so any
+ * call site that would otherwise wrap in a <p> needs to switch to a <div>.
+ */
+const isBlockFormat = (format: NodeFormat): boolean => format === 'MARKDOWN';
+
+function MarkupSpan({ source, format }: { source: string; format: NodeFormat }) {
+  return (
+    <span
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: renderContent sanitizes via DOMPurify
+      dangerouslySetInnerHTML={{ __html: renderContent(source, format) }}
+    />
+  );
+}
+
+function MarkupBlock({ source, format }: { source: string; format: NodeFormat }) {
+  return (
+    <div
+      className="markdown-rendered"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: renderContent sanitizes via DOMPurify
+      dangerouslySetInnerHTML={{ __html: renderContent(source, format) }}
+    />
+  );
+}
 
 interface DocumentPreviewProps {
   document: ContainerDocumentNode;
@@ -256,8 +283,7 @@ function HeadingNode({
     <section id={node.id} className="mb-2">
       <Tag className={className}>
         {node.number && <NumberMarkup value={node.number} className="mr-2" />}
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: content from user-uploaded documents */}
-        <span dangerouslySetInnerHTML={{ __html: text }} />
+        <MarkupSpan source={text} format={node.format} />
       </Tag>
       {otherChildren.map((child) => (
         <PreviewNode key={child.id} node={child} language={language} headingDepth={depth + 1} />
@@ -276,14 +302,23 @@ function ContentNode({
 }) {
   const text = node.contents[language] ?? '';
   const footnotes = node.children.filter((c) => c.type === 'footnote');
+  const numberBadge = node.number && (
+    <NumberMarkup value={node.number} className="font-bold mr-1" />
+  );
 
   return (
     <div className="my-1">
-      <p className="leading-relaxed">
-        {node.number && <NumberMarkup value={node.number} className="font-bold mr-1" />}
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: content from user-uploaded documents */}
-        <span dangerouslySetInnerHTML={{ __html: text }} />
-      </p>
+      {isBlockFormat(node.format) ? (
+        <div className="leading-relaxed">
+          {numberBadge}
+          <MarkupBlock source={text} format={node.format} />
+        </div>
+      ) : (
+        <p className="leading-relaxed">
+          {numberBadge}
+          <MarkupSpan source={text} format={node.format} />
+        </p>
+      )}
       {footnotes.length > 0 && <FootnoteSection footnotes={footnotes} language={language} />}
     </div>
   );
@@ -327,6 +362,7 @@ function ListItemNode({
   const firstContentFootnotes = firstContent
     ? firstContent.children.filter((c) => c.type === 'footnote')
     : [];
+  const firstContentIsBlock = firstContent ? isBlockFormat(firstContent.format) : false;
 
   const marker = node.number ? (
     <NumberMarkup value={node.number} className="font-bold mr-1" />
@@ -336,11 +372,17 @@ function ListItemNode({
 
   return (
     <div className="my-1">
-      <p className="leading-relaxed">
-        {marker}
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: content from user-uploaded documents */}
-        {firstContent && <span dangerouslySetInnerHTML={{ __html: firstContentText }} />}
-      </p>
+      {firstContent && firstContentIsBlock ? (
+        <div className="leading-relaxed">
+          {marker}
+          <MarkupBlock source={firstContentText} format={firstContent.format} />
+        </div>
+      ) : (
+        <p className="leading-relaxed">
+          {marker}
+          {firstContent && <MarkupSpan source={firstContentText} format={firstContent.format} />}
+        </p>
+      )}
       {firstContentFootnotes.length > 0 && (
         <FootnoteSection footnotes={firstContentFootnotes} language={language} />
       )}
@@ -376,11 +418,21 @@ function FootnoteSection({
         {footnotes.map((fn) => {
           if (fn.type !== 'footnote') return null;
           const text = fn.contents[language] ?? '';
+          const numberBadge = fn.number && (
+            <NumberMarkup value={fn.number} className="font-bold mr-1" />
+          );
+          if (isBlockFormat(fn.format)) {
+            return (
+              <div key={fn.id} className="text-sm">
+                {numberBadge}
+                <MarkupBlock source={text} format={fn.format} />
+              </div>
+            );
+          }
           return (
             <p key={fn.id} className="text-sm">
-              {fn.number && <NumberMarkup value={fn.number} className="font-bold mr-1" />}
-              {/* biome-ignore lint/security/noDangerouslySetInnerHtml: content from user-uploaded documents */}
-              <span dangerouslySetInnerHTML={{ __html: text }} />
+              {numberBadge}
+              <MarkupSpan source={text} format={fn.format} />
             </p>
           );
         })}


### PR DESCRIPTION
## Summary
- Route every content-bearing render path in `DocumentPreview` through `renderContent`, so inline marks (`**bold**`, `*italic*`, `~~strike~~`, `^sup^`, `~sub~`) and block-level MARKDOWN (paragraphs, lists, etc.) display as formatted output instead of raw source.
- Switch to a `<div className="markdown-rendered">` wrapper for nodes whose format is MARKDOWN (block-level) to keep the rendered HTML valid; inline formats (TEXT / NEWLINES / MARKDOWN_MINIMAL) keep the existing `<p>` wrapper.
- New tests cover heading/content/list_item/footnote mark rendering plus XSS regressions (raw HTML in TEXT, `<img onerror>` in MARKDOWN, `javascript:` href) — the previous code path bypassed sanitization entirely.

## Test plan
- [x] `npm run test` — 946 pass
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] Manual: upload a DOCX with bold/italic/sup/sub in headings and content, open the Preview tab, confirm marks render and no `**` / `~~` literals remain visible

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)