### PR TITLE
Strip markdown markers before legal-pattern matching

### DIFF
--- a/src/utils/file-processing.integration.test.ts
+++ b/src/utils/file-processing.integration.test.ts
@@ -112,6 +112,7 @@ describe('file-processing integration', () => {
   describe('real DOCX: numbering_example (issue #63 — <sup> Absatznummern)', () => {
     let allNodes: DocumentNode[];
     let contentNodes: DocumentNode[];
+    let headings: DocumentNode[];
     let warnSpy: ReturnType<typeof vi.spyOn>;
 
     beforeAll(async () => {
@@ -119,6 +120,7 @@ describe('file-processing integration', () => {
       const result = await importFixture('numbering_example.docx');
       allNodes = flattenTree(result.doc);
       contentNodes = allNodes.filter((n) => n.type === 'content');
+      headings = allNodes.filter((n) => n.type === 'heading');
     });
 
     afterAll(() => {
@@ -188,6 +190,19 @@ describe('file-processing integration', () => {
       );
       expect(plainAbsatz).toBeDefined();
       expect('format' in plainAbsatz! && plainAbsatz.format).toBe('TEXT');
+    });
+
+    // Issue #89: the bold `**I.**` and italic `*Art. 1 Lorem ipsum*` paragraphs
+    // in the fixture must be promoted to headings by the legal transforms.
+    it('detects the top-level Roman numeral section `I.` as a heading', () => {
+      const romanSection = headings.find((h) => h.number === 'I.');
+      expect(romanSection).toBeDefined();
+    });
+
+    it('detects `Art. 1 Lorem ipsum` as an article heading', () => {
+      const article = headings.find((h) => h.number === 'Art. 1');
+      expect(article).toBeDefined();
+      expect(textOf(article!)).toBe('Lorem ipsum');
     });
   });
 });

--- a/src/utils/legal-transforms/article.test.ts
+++ b/src/utils/legal-transforms/article.test.ts
@@ -76,6 +76,19 @@ describe('articleTransform', () => {
     expect(art1.children[0].type).toBe('content');
   });
 
+  // Issue #89: italics wrapping the whole article line kept it from matching after PR #75.
+  it('promotes a content node with italic markdown wrapping the whole article line', () => {
+    const input = createDoc([content('*Art. 1 Lorem ipsum*'), content('Body')]);
+
+    const result = articleTransform(input, 'de');
+
+    expect(result.children).toHaveLength(1);
+    expect(result.children[0].type).toBe('heading');
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBe('Art. 1');
+    expect(h.contents.de).toBe('Lorem ipsum');
+  });
+
   it('handles § pattern', () => {
     const input = createDoc([content('§ 5 Some title'), content('Content')]);
 

--- a/src/utils/legal-transforms/lettered-items.test.ts
+++ b/src/utils/legal-transforms/lettered-items.test.ts
@@ -38,6 +38,25 @@ describe('letteredItemsTransform', () => {
     expect(contentNode.contents.de).toBe('First item text');
   });
 
+  // Issue #89: once extractCleanText strips markdown delimiters, the matcher
+  // accepts `**a. First**` — but the prefix-stripping step also needs to ignore
+  // wrapping marks, otherwise the produced list_item's content keeps both the
+  // duplicated letter and the literal markdown source.
+  it('strips letter prefix from content wrapped in markdown delimiters', () => {
+    const input = createDoc([content('**a. First item**'), content('*b. Second item*')]);
+
+    const result = letteredItemsTransform(input, 'de');
+
+    const listNode = result.children[0] as ContainerDocumentNode;
+    expect(listNode.type).toBe('list');
+    const first = (listNode.children[0] as ContainerDocumentNode)
+      .children[0] as ContentDocumentNode;
+    const second = (listNode.children[1] as ContainerDocumentNode)
+      .children[0] as ContentDocumentNode;
+    expect(first.contents.de).toBe('First item');
+    expect(second.contents.de).toBe('Second item');
+  });
+
   it('breaks list on non-lettered content', () => {
     const input = createDoc([
       content('a. First'),

--- a/src/utils/legal-transforms/lettered-items.ts
+++ b/src/utils/legal-transforms/lettered-items.ts
@@ -24,10 +24,13 @@ function getLetterMatch(node: DocumentNode): { letter: string; content: string }
 }
 
 /**
- * Strip the letter prefix from content, preserving HTML
+ * Strip the letter prefix from content. Inline markdown delimiters around the
+ * prefix (e.g. `**a. First**`) are stripped first so the produced list_item —
+ * whose content is stored as TEXT — doesn't keep both a duplicated letter and
+ * literal markdown source.
  */
 function stripLetterPrefix(htmlContent: string): string {
-  return htmlContent.replace(/^[a-z]\.\s+/, '');
+  return extractCleanText(htmlContent).replace(/^[a-z]\.\s+/, '');
 }
 
 /**

--- a/src/utils/legal-transforms/patterns.test.ts
+++ b/src/utils/legal-transforms/patterns.test.ts
@@ -180,5 +180,28 @@ describe('patterns', () => {
     ])('extracts clean text from %j → %j', (input, expected) => {
       expect(extractCleanText(input)).toBe(expected);
     });
+
+    // Issue #89: inline marks are now preserved as markdown source in content
+    // nodes (from PR #75). The legal-transform matchers feed text through this
+    // function, so well-formed markdown delimiters must be stripped here too —
+    // otherwise headings like `**I.**` and `*Art. 1 Lorem ipsum*` never match.
+    it.each([
+      ['**bold**', 'bold'],
+      ['*italic*', 'italic'],
+      ['~~strike~~', 'strike'],
+      ['~sub~', 'sub'],
+      ['^sup^', 'sup'],
+      ['**I.**', 'I.'],
+      ['*Art. 1 Lorem ipsum*', 'Art. 1 Lorem ipsum'],
+      ['**bold** and *italic*', 'bold and italic'],
+      ['[label](https://example.com)', 'label'],
+      ['<p><strong>**Mixed**</strong></p>', 'Mixed'],
+    ])('strips markdown inline marks from %j → %j', (input, expected) => {
+      expect(extractCleanText(input)).toBe(expected);
+    });
+
+    it('preserves unmatched delimiters (no false stripping)', () => {
+      expect(extractCleanText('**unclosed')).toBe('**unclosed');
+    });
   });
 });

--- a/src/utils/legal-transforms/patterns.ts
+++ b/src/utils/legal-transforms/patterns.ts
@@ -97,12 +97,30 @@ export function matchLetteredItem(text: string): LetteredItemMatchResult {
 }
 
 /**
- * Extract clean text from HTML content for pattern matching.
- * Strips HTML tags and converts &nbsp; to spaces.
+ * Strip well-formed pairs of inline markdown delimiters and link syntax.
+ * Long-form delimiters run first so `**bold**` is not mis-parsed as two italics.
+ *
+ * Assumes well-formed Mammoth-emitted markdown: backslash escapes are not honored
+ * and stray asterisks/tildes in math-like text (`5 * 3`) collapse. The legal
+ * matchers all anchor at `^`, so collapses mid-string can't introduce a false
+ * heading match.
+ */
+function stripInlineMarkdownMarks(text: string): string {
+  return text
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/~([^~]+)~/g, '$1')
+    .replace(/\^([^^]+)\^/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+}
+
+/**
+ * Extract clean text from HTML/markdown content for pattern matching.
+ * Strips HTML tags, well-formed inline markdown delimiters, and converts &nbsp; to spaces.
  */
 export function extractCleanText(htmlContent: string): string {
-  return htmlContent
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .trim();
+  return stripInlineMarkdownMarks(
+    htmlContent.replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ')
+  ).trim();
 }

--- a/src/utils/legal-transforms/roman-section.test.ts
+++ b/src/utils/legal-transforms/roman-section.test.ts
@@ -125,6 +125,40 @@ describe('romanSectionTransform', () => {
     expect(section.children[0].type).toBe('heading');
   });
 
+  // Issue #89: bold/italic wrapping of the numeral kept it from matching after PR #75.
+  it('promotes a content node with bold markdown around the numeral and title', () => {
+    const input = createDoc([content('**I.** First Section'), content('Body')]);
+
+    const result = romanSectionTransform(input, 'de');
+
+    expect(result.children).toHaveLength(1);
+    expect(result.children[0].type).toBe('heading');
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBe('I.');
+    expect(h.contents.de).toBe('First Section');
+  });
+
+  it('still anchors at start: a bold Roman numeral mid-sentence is not promoted', () => {
+    const input = createDoc([content('Siehe **I.** weiter unten')]);
+
+    const result = romanSectionTransform(input, 'de');
+
+    expect(result.children).toHaveLength(1);
+    expect(result.children[0].type).toBe('content');
+  });
+
+  it('promotes a content node that is just a bold Roman numeral', () => {
+    const input = createDoc([content('**I.**'), content('Body')]);
+
+    const result = romanSectionTransform(input, 'de');
+
+    expect(result.children).toHaveLength(1);
+    expect(result.children[0].type).toBe('heading');
+    const h = result.children[0] as HeadingDocumentNode;
+    expect(h.number).toBe('I.');
+    expect(h.contents.de).toBe('');
+  });
+
   it('handles empty document', () => {
     const input = createDoc([]);
 


### PR DESCRIPTION
## Summary
- Heading autodetection regressed after #75: bold/italic DOCX paragraphs like `**I.**` and `*Art. 1 Lorem ipsum*` were no longer promoted to headings because the legal-transform matchers fed those strings through `extractCleanText`, which stripped HTML but not the new markdown delimiters.
- Extend `extractCleanText` (single chokepoint for all four legal transforms) to also strip well-formed pairs of inline markdown delimiters (`**`, `*`, `~~`, `~`, `^`) and link syntax `[label](url)`.
- Update `stripLetterPrefix` in `lettered-items` to peel markdown delimiters before the prefix regex, preventing a duplicated-letter list-item rendering once the matcher accepts `**a. First**` (caught in code review — the new `extractCleanText` would otherwise create an asymmetry).

The third "in-between" heading mentioned in the issue (`I. Lorem ipsum`) is a separate class of problem and intentionally out of scope; rationale and options posted as a [follow-up comment on the issue](https://github.com/Demokratis-ch/structedit/issues/89#issuecomment-4438245170).

## Test plan
- [x] `npm run test` — 964 passed (up from 962), 1 pre-existing skip
- [x] `npm run build` — clean
- [x] New unit tests cover `extractCleanText` markdown stripping (including an unmatched-delimiter survival case)
- [x] New transform tests cover bold Roman-numeral promotion, italic article-line promotion, markdown-wrapped lettered item, and a start-anchor negative case
- [x] New integration assertions on the `numbering_example.docx` fixture confirm `I.` is now a heading and `Art. 1 Lorem ipsum` is an article heading

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)