### PR TITLE
Add "move to top" and "move to bottom" buttons to the floating toolbar

### DIFF
--- a/src/components/FloatingToolbar.test.tsx
+++ b/src/components/FloatingToolbar.test.tsx
@@ -11,6 +11,8 @@ const baseProps = {
   onDelete: vi.fn(),
   onClearSelection: vi.fn(),
   onChangeFormat: vi.fn(),
+  onMoveSelectedToTop: vi.fn(),
+  onMoveSelectedToBottom: vi.fn(),
 };
 
 describe('FloatingToolbar — format selector visibility', () => {
@@ -270,6 +272,52 @@ describe('FloatingToolbar — inline-marks buttons', () => {
       const md = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
       btn.dispatchEvent(md);
       expect(md.defaultPrevented, `mousedown on ${mark} should be prevented`).toBe(true);
+    }
+  });
+});
+
+describe('FloatingToolbar — move to top/bottom buttons', () => {
+  test('renders both buttons when something is selected', () => {
+    render(<FloatingToolbar {...baseProps} selectedCount={1} selectedNodeType="content" />);
+    expect(screen.getByTestId('move-to-top')).toBeTruthy();
+    expect(screen.getByTestId('move-to-bottom')).toBeTruthy();
+  });
+
+  test('clicking move-to-top calls onMoveSelectedToTop', () => {
+    const onMoveSelectedToTop = vi.fn();
+    render(
+      <FloatingToolbar
+        {...baseProps}
+        selectedCount={1}
+        selectedNodeType="content"
+        onMoveSelectedToTop={onMoveSelectedToTop}
+      />
+    );
+    fireEvent.click(screen.getByTestId('move-to-top'));
+    expect(onMoveSelectedToTop).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking move-to-bottom calls onMoveSelectedToBottom', () => {
+    const onMoveSelectedToBottom = vi.fn();
+    render(
+      <FloatingToolbar
+        {...baseProps}
+        selectedCount={1}
+        selectedNodeType="content"
+        onMoveSelectedToBottom={onMoveSelectedToBottom}
+      />
+    );
+    fireEvent.click(screen.getByTestId('move-to-bottom'));
+    expect(onMoveSelectedToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  test('mousedown on each button IS prevented (focus preservation)', () => {
+    render(<FloatingToolbar {...baseProps} selectedCount={1} selectedNodeType="content" />);
+    for (const id of ['move-to-top', 'move-to-bottom']) {
+      const btn = screen.getByTestId(id);
+      const md = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+      btn.dispatchEvent(md);
+      expect(md.defaultPrevented, `mousedown on ${id} should be prevented`).toBe(true);
     }
   });
 });

--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -1,4 +1,6 @@
 import {
+  ArrowDownToLine,
+  ArrowUpToLine,
   Asterisk,
   Bold,
   Heading,
@@ -32,6 +34,8 @@ interface FloatingToolbarProps {
   onChangeFormat?: (format: NodeFormat) => void;
   onDelete: () => void;
   onClearSelection: () => void;
+  onMoveSelectedToTop?: () => void;
+  onMoveSelectedToBottom?: () => void;
   inlineMarksTarget?: InlineMarksTarget | null;
   inlineMarksFormat?: NodeFormat;
   markActiveState?: Partial<Record<InlineMark, boolean>>;
@@ -76,6 +80,8 @@ export function FloatingToolbar({
   onChangeFormat,
   onDelete,
   onClearSelection,
+  onMoveSelectedToTop,
+  onMoveSelectedToBottom,
   inlineMarksTarget,
   inlineMarksFormat,
   markActiveState,
@@ -219,6 +225,27 @@ export function FloatingToolbar({
         </>
       )}
 
+      <div className="w-px h-6 bg-gray-700 mx-1" />
+      <button
+        type="button"
+        data-testid="move-to-top"
+        aria-label="Move to top of parent"
+        onClick={onMoveSelectedToTop}
+        className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
+        title="Move to top of parent"
+      >
+        <ArrowUpToLine size={18} />
+      </button>
+      <button
+        type="button"
+        data-testid="move-to-bottom"
+        aria-label="Move to bottom of parent"
+        onClick={onMoveSelectedToBottom}
+        className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
+        title="Move to bottom of parent"
+      >
+        <ArrowDownToLine size={18} />
+      </button>
       <div className="w-px h-6 bg-gray-700 mx-1" />
       <button
         onClick={onDelete}

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -83,6 +83,8 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
     indentSelected,
     outdentSelected,
     deleteSelected,
+    moveSelectedToTop,
+    moveSelectedToBottom,
     undo,
     redo,
     lastSelectedId,
@@ -625,6 +627,8 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
         onChangeFormat={handleChangeFormat}
         onDelete={deleteSelected}
         onClearSelection={clearSelection}
+        onMoveSelectedToTop={moveSelectedToTop}
+        onMoveSelectedToBottom={moveSelectedToBottom}
         inlineMarksTarget={inlineMarksDerived.target}
         inlineMarksFormat={inlineMarksDerived.format}
         markActiveState={inlineMarksDerived.active}

--- a/src/hooks/useTreeEditor.test.ts
+++ b/src/hooks/useTreeEditor.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 import type {
   ContainerDocumentNode,
+  ContentDocumentNode,
   HeadingDocumentNode,
   LeafDocumentNode,
 } from '../types/document';
@@ -393,5 +394,84 @@ describe('useTreeEditor', () => {
     expect(result.current.document.children[1].id).toBe('p1');
     expect(result.current.document.children[2].id).toBe('p2');
     expect(result.current.document.children[3].id).toBe('h2');
+  });
+
+  describe('moveSelectedToTop / moveSelectedToBottom', () => {
+    // Flat doc: root > [a, b, c, d]
+    const createFlatDoc = (): ContainerDocumentNode => ({
+      id: 'root',
+      number: null,
+      type: 'document',
+      children: ['a', 'b', 'c', 'd'].map(
+        (id) =>
+          ({
+            id,
+            number: null,
+            type: 'content',
+            format: 'TEXT',
+            contents: { de: id },
+            children: [],
+          }) as ContentDocumentNode
+      ),
+    });
+
+    test('moveSelectedToTop moves the single selected node to the top of its parent', () => {
+      const { result } = renderHook(() => useTreeEditor(createFlatDoc()));
+
+      act(() => {
+        result.current.handleNodeClick('c', { shiftKey: false, ctrlKey: false, metaKey: false });
+      });
+      act(() => {
+        result.current.moveSelectedToTop();
+      });
+
+      expect(result.current.document.children.map((c) => c.id)).toEqual(['c', 'a', 'b', 'd']);
+    });
+
+    test('moveSelectedToBottom moves the single selected node to the bottom of its parent', () => {
+      const { result } = renderHook(() => useTreeEditor(createFlatDoc()));
+
+      act(() => {
+        result.current.handleNodeClick('b', { shiftKey: false, ctrlKey: false, metaKey: false });
+      });
+      act(() => {
+        result.current.moveSelectedToBottom();
+      });
+
+      expect(result.current.document.children.map((c) => c.id)).toEqual(['a', 'c', 'd', 'b']);
+    });
+
+    test('multi-selection: moves all selected nodes to the top, preserving relative order', () => {
+      const { result } = renderHook(() => useTreeEditor(createFlatDoc()));
+
+      // Select b and c with ctrl-click for multi-select.
+      act(() => {
+        result.current.handleNodeClick('b', { shiftKey: false, ctrlKey: false, metaKey: false });
+      });
+      act(() => {
+        result.current.handleNodeClick('c', { shiftKey: false, ctrlKey: true, metaKey: false });
+      });
+      act(() => {
+        result.current.moveSelectedToTop();
+      });
+
+      expect(result.current.document.children.map((c) => c.id)).toEqual(['b', 'c', 'a', 'd']);
+    });
+
+    test('no-op when nothing is selected', () => {
+      const doc = createFlatDoc();
+      const { result } = renderHook(() => useTreeEditor(doc));
+      const originalDoc = result.current.document;
+
+      act(() => {
+        result.current.moveSelectedToTop();
+      });
+      act(() => {
+        result.current.moveSelectedToBottom();
+      });
+
+      // Reference equality: no commit fired (document object unchanged).
+      expect(result.current.document).toBe(originalDoc);
+    });
   });
 });

--- a/src/hooks/useTreeEditor.ts
+++ b/src/hooks/useTreeEditor.ts
@@ -51,6 +51,7 @@ export const useTreeEditor = (
     changeNodeTypes,
     changeNodeFormat,
     moveNodeById,
+    moveNodesToBoundary,
     getReceivingParentId,
   } = useTreeOperations({
     document,
@@ -256,6 +257,34 @@ export const useTreeEditor = (
   }, [store, nodeIdToFlatIndex, indentNodes]);
 
   /**
+   * Move selected nodes to the top or bottom of their respective parents.
+   */
+  const moveSelectedToBoundary = useCallback(
+    (position: 'top' | 'bottom') => {
+      const selectedIds = store.getSelectedIds();
+      if (selectedIds.size === 0) return;
+
+      const sortedIds = [...selectedIds]
+        .map((id) => ({ id, index: nodeIdToFlatIndex.get(id) ?? -1 }))
+        .filter((item) => item.index >= 0)
+        .sort((a, b) => a.index - b.index)
+        .map((item) => item.id);
+
+      moveNodesToBoundary(sortedIds, position);
+    },
+    [store, nodeIdToFlatIndex, moveNodesToBoundary]
+  );
+
+  const moveSelectedToTop = useCallback(
+    () => moveSelectedToBoundary('top'),
+    [moveSelectedToBoundary]
+  );
+  const moveSelectedToBottom = useCallback(
+    () => moveSelectedToBoundary('bottom'),
+    [moveSelectedToBoundary]
+  );
+
+  /**
    * Outdent selected nodes (Shift+Tab).
    */
   const outdentSelected = useCallback(() => {
@@ -304,6 +333,8 @@ export const useTreeEditor = (
     deleteSelected,
     indentSelected,
     outdentSelected,
+    moveSelectedToTop,
+    moveSelectedToBottom,
 
     // History
     undo,

--- a/src/hooks/useTreeOperations.test.ts
+++ b/src/hooks/useTreeOperations.test.ts
@@ -4320,4 +4320,215 @@ describe('useTreeOperations', () => {
       expect(c.format).toBe('NEWLINES');
     });
   });
+
+  describe('moveNodesToBoundary', () => {
+    // Flat root with four siblings, used by reordering tests.
+    const createFlatDocument = (): ContainerDocumentNode => ({
+      id: 'root',
+      number: null,
+      type: 'document',
+      children: [
+        {
+          id: 'A',
+          number: null,
+          type: 'content',
+          format: 'TEXT',
+          contents: { de: 'A' },
+          children: [],
+        } as ContentDocumentNode,
+        {
+          id: 'B',
+          number: null,
+          type: 'content',
+          format: 'TEXT',
+          contents: { de: 'B' },
+          children: [],
+        } as ContentDocumentNode,
+        {
+          id: 'C',
+          number: null,
+          type: 'content',
+          format: 'TEXT',
+          contents: { de: 'C' },
+          children: [],
+        } as ContentDocumentNode,
+        {
+          id: 'D',
+          number: null,
+          type: 'content',
+          format: 'TEXT',
+          contents: { de: 'D' },
+          children: [],
+        } as ContentDocumentNode,
+      ],
+    });
+
+    test('moves a single node to the top of its parent', () => {
+      const doc = createFlatDocument();
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.moveNodesToBoundary(['C'], 'top');
+      });
+
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.id)).toEqual(['C', 'A', 'B', 'D']);
+    });
+
+    test('moves a single node to the bottom of its parent', () => {
+      const doc = createFlatDocument();
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.moveNodesToBoundary(['A'], 'bottom');
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.id)).toEqual(['B', 'C', 'D', 'A']);
+    });
+
+    test('preserves relative order when moving multiple siblings to top', () => {
+      const doc = createFlatDocument();
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.moveNodesToBoundary(['B', 'C'], 'top');
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.id)).toEqual(['B', 'C', 'A', 'D']);
+    });
+
+    test('preserves relative order when moving multiple siblings to bottom', () => {
+      const doc = createFlatDocument();
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.moveNodesToBoundary(['B', 'C'], 'bottom');
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.id)).toEqual(['A', 'D', 'B', 'C']);
+    });
+
+    test('handles nodes in different parents independently with a single commit', () => {
+      // Default test document: root > [h1 > [p1, h2 > [p2]], h1b]
+      // Select p1 (child of h1) and h1b (child of root).
+      // 'top': p1 should move to top of h1 (already there → no change for p1),
+      //        h1b should move to top of root (before h1).
+      const { result } = renderTreeOperations();
+
+      act(() => {
+        result.current.moveNodesToBoundary(['p1', 'h1b'], 'top');
+      });
+
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.id)).toEqual(['h1b', 'h1']);
+      const h1 = newDoc.children[1] as HeadingDocumentNode;
+      // p1 was already first inside h1; relative order untouched.
+      expect(h1.children.map((c) => c.id)).toEqual(['p1', 'h2']);
+    });
+
+    test('does not commit when the selected node is already at the top', () => {
+      const doc = createFlatDocument();
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.moveNodesToBoundary(['A'], 'top');
+      });
+
+      expect(mockCommit).not.toHaveBeenCalled();
+    });
+
+    test('does not commit when the selected node is already at the bottom', () => {
+      const doc = createFlatDocument();
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.moveNodesToBoundary(['D'], 'bottom');
+      });
+
+      expect(mockCommit).not.toHaveBeenCalled();
+    });
+
+    test('does not commit for an empty id list', () => {
+      const { result } = renderTreeOperations();
+
+      act(() => {
+        result.current.moveNodesToBoundary([], 'top');
+      });
+
+      expect(mockCommit).not.toHaveBeenCalled();
+    });
+
+    test('silently ignores ids not present in the index', () => {
+      const doc = createFlatDocument();
+      const { result } = renderTreeOperations(doc);
+
+      act(() => {
+        result.current.moveNodesToBoundary(['nonexistent', 'C'], 'top');
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.id)).toEqual(['C', 'A', 'B', 'D']);
+    });
+
+    test('reorders list_items within their list', () => {
+      const doc = createDocumentWithList();
+      const { result } = renderTreeOperations(doc);
+
+      // List is [li1, li2, li3]; move li3 to top.
+      act(() => {
+        result.current.moveNodesToBoundary(['li3'], 'top');
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const h1 = newDoc.children[0] as HeadingDocumentNode;
+      const list = h1.children[0] as ContainerDocumentNode;
+      expect(list.children.map((c) => c.id)).toEqual(['li3', 'li1', 'li2']);
+    });
+
+    test('handles a selection containing both an ancestor and its descendant', () => {
+      // Default doc: root > [h1 > [p1, h2 > [p2]], h1b].
+      // Select h1 (path [0]) and p2 (path [0, 1, 0]). Move both to top.
+      // p2 should land at the top of h2 (already there → no actual change for p2),
+      // and h1 should land at the top of root (already there → no actual change for h1).
+      // So this is effectively a no-op when both are already at top — pick 'bottom' instead
+      // to make the cross-depth move observable.
+      const { result } = renderTreeOperations();
+
+      act(() => {
+        result.current.moveNodesToBoundary(['h1', 'p2'], 'bottom');
+      });
+
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      // h1 moved to bottom of root.
+      expect(newDoc.children.map((c) => c.id)).toEqual(['h1b', 'h1']);
+      // p2 is the only child of h2, so it stays put — h1's subtree is unchanged.
+      const h1 = newDoc.children[1] as HeadingDocumentNode;
+      const h2 = h1.children[1] as HeadingDocumentNode;
+      expect(h2.children.map((c) => c.id)).toEqual(['p2']);
+    });
+
+    test('mixed parents: commits once when only some parents need to change', () => {
+      // Default doc: root > [h1 > [p1, h2], h1b].
+      // Select p1 (already at top of h1) and h1b (at root, position 1 → moves to top).
+      // Only the root-level reorder should produce a change, but a single commit fires.
+      const { result } = renderTreeOperations();
+
+      act(() => {
+        result.current.moveNodesToBoundary(['p1', 'h1b'], 'top');
+      });
+
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.id)).toEqual(['h1b', 'h1']);
+      // p1 is still the first child of h1 — no actual change inside h1.
+      const h1 = newDoc.children[1] as HeadingDocumentNode;
+      expect(h1.children[0].id).toBe('p1');
+    });
+  });
 });

--- a/src/hooks/useTreeOperations.ts
+++ b/src/hooks/useTreeOperations.ts
@@ -945,6 +945,79 @@ export const useTreeOperations = ({
   );
 
   /**
+   * Cluster the named nodes at the top or bottom of their respective parents.
+   * Nodes keep their current parent; selected siblings preserve their relative
+   * order within each parent. Different parents are reordered independently in
+   * a single commit. Skips parents where the move would be a no-op.
+   */
+  const moveNodesToBoundary = useCallback(
+    (ids: string[], position: 'top' | 'bottom') => {
+      if (ids.length === 0) return;
+
+      // Group ids by parent path.
+      const byParent = new Map<string, { parentPath: NodePath; selectedIds: Set<string> }>();
+      for (const id of ids) {
+        const path = nodeIndex.get(id);
+        if (!path || path.length === 0) continue;
+        const parentPath = path.slice(0, -1);
+        const key = parentPath.join('.');
+        let group = byParent.get(key);
+        if (!group) {
+          group = { parentPath, selectedIds: new Set() };
+          byParent.set(key, group);
+        }
+        group.selectedIds.add(id);
+      }
+
+      // Deepest-first: rewriting a parent's children doesn't disturb the path
+      // to deeper parents we still need to visit (deeper parents live inside
+      // an ancestor we haven't touched yet).
+      const groups = [...byParent.values()].sort(
+        (a, b) => b.parentPath.length - a.parentPath.length
+      );
+
+      let doc = document;
+      let changed = false;
+
+      for (const { parentPath, selectedIds } of groups) {
+        const parent = parentPath.length === 0 ? doc : getNodeAtPath(doc, parentPath);
+        if (!parent || !('children' in parent)) continue;
+
+        // Iterate the parent's children in document order so the selected ones
+        // cluster in their original relative order, regardless of how the
+        // caller ordered ids.
+        const children = parent.children;
+        const selected: DocumentNode[] = [];
+        const unselected: DocumentNode[] = [];
+        for (const child of children) {
+          if (selectedIds.has(child.id)) {
+            selected.push(child);
+          } else {
+            unselected.push(child);
+          }
+        }
+
+        const newChildren =
+          position === 'top' ? [...selected, ...unselected] : [...unselected, ...selected];
+
+        const noChange = newChildren.every((c, i) => c === children[i]);
+        if (noChange) continue;
+
+        doc = updateNodeAtPath(doc, parentPath, (n) => ({
+          ...n,
+          children: newChildren,
+        }));
+        changed = true;
+      }
+
+      if (changed) {
+        commit(doc);
+      }
+    },
+    [document, nodeIndex, commit]
+  );
+
+  /**
    * Get the ID of the node that would become the parent if sourceId were dropped
    * on targetId. Returns null if the move would be invalid.
    */
@@ -985,6 +1058,7 @@ export const useTreeOperations = ({
     changeNodeTypes,
     changeNodeFormat,
     moveNodeById,
+    moveNodesToBoundary,
     getReceivingParentId,
     nodeIndex,
     parentIndex,


### PR DESCRIPTION
## Summary
- New `moveNodesToBoundary` operation in `useTreeOperations` clusters selected nodes at the top or bottom of their respective parents. Multi-parent selections are reordered independently in a single commit; parents with no actual change are skipped (no spurious history entries).
- New `moveSelectedToTop` / `moveSelectedToBottom` exposed from `useTreeEditor`, and two new buttons in `FloatingToolbar` (Lucide `ArrowUpToLine` / `ArrowDownToLine`, with `aria-label` and `title`), placed in their own divider-separated group just before the Delete button.

## Test plan
- [x] `npm run test` — 994 passing (12 new in `useTreeOperations.test.ts`, 4 in `useTreeEditor.test.ts`, 4 in `FloatingToolbar.test.tsx`)
- [x] `npm run build` — clean
- [x] Manual: single selection → top → bottom; multi-selection (ctrl-click) → top clusters at front in document order

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)