### PR TITLE
Fix issue #101 problems 2 & 3: number-field text selection and Tab scroll jump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # StructEdit
 StructEdit is an importer and editor of **tree-structured documents**.
 
-1. On input, StructEdit accepts PDF or DOCX documents.
-2. Parsers like [Mammoth](https://github.com/mwilliamson/mammoth.js) and [Docling](https://github.com/docling-project/docling) are used to convert the original document to an intermediate format such as HTML.
-3. StructEdit translates the intermediate format into a tree structure described by the data model in [src/types/document.ts](./src/types/document.ts).
-4. The tree structure is presented side-by-side with the original document in a user interface designed to make structure edits and fixes simple and efficient.
-5. After manual editing, StructEdit serialises the tree to JSON and (THIS IS NOT IMPLEMENTED YET:) optionally imports it into the [Demokratis](https://demokratis.ch) platform.
-
+1. On input, StructEdit accepts plaintext, HTML, or DOCX documents.
+2. DOCX documents are converted to HTML using [Mammoth](https://github.com/mwilliamson/mammoth.js).
+3. StructEdit translates the intermediate format (HTML or plaintext) into a tree structure described by the data model in [src/types/document.ts](./src/types/document.ts).
+4. A set of rules is applied to (re)construct as much as possible from the original semantic structure of the document. We mostly expect Swiss legal drafts (new laws or amendments). For example, blocks of text starting with `Art. 123` are inferred to be headings.
+5. The tree structure is presented side-by-side with the original document in a user interface designed to make structure edits and fixes simple and efficient.
+6. After manual editing the document tree can be downloaded as JSON.
 
 The current `main` branch is always deployed at https://structedit.demokratis.ch/.
+
+## Planned features
+- Direct upload of the structured document to the [Demokratis](https://demokratis.ch) platform.
+- PDF document support

--- a/src/components/RecursiveTreeNode.tsx
+++ b/src/components/RecursiveTreeNode.tsx
@@ -56,12 +56,17 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
       isInvalidDrop,
     } = useNodeState(store, node.id);
     // Firefox suppresses caret-positioning in a contentEditable when any
-    // ancestor has draggable=true (issue #60). Disable draggable on every
-    // node while any node is in edit mode — drag-to-reorder is unavailable
-    // mid-edit anyway, so this is a no-op behaviour-wise.
+    // ancestor has draggable=true (issue #60). The same draggable ancestor also
+    // hijacks mouse text-selection in the number <input> as node drag&drop
+    // (issue #101). Disable draggable on every node while any node is editing
+    // its content or number — drag-to-reorder is unavailable mid-edit anyway,
+    // so this is a no-op behaviour-wise.
     const isAnyNodeEditing = useSyncExternalStore(
       store.subscribe,
-      useCallback(() => store.getEditingId() !== null, [store])
+      useCallback(
+        () => store.getEditingId() !== null || store.getEditingNumberId() !== null,
+        [store]
+      )
     );
 
     const {

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -356,6 +356,46 @@ describe('double-click inline editing', () => {
     vi.useRealTimers();
   });
 
+  // Regression (issue #101, problem 2): editing a node's number opens a text
+  // <input>. While it's open the surrounding node wrappers must drop
+  // draggable=false, otherwise a mouse drag inside the input starts node
+  // drag&drop instead of selecting text.
+  test('node wrappers drop draggable while editing a number', async () => {
+    renderTreeEditor();
+
+    // Sanity: before editing, every wrapper is draggable.
+    let wrappers = getContainer().querySelectorAll('[draggable]');
+    expect(wrappers.length).toBeGreaterThan(0);
+    for (const w of wrappers) expect(w.getAttribute('draggable')).toBe('true');
+
+    // Double-click the first node's number badge to enter number-edit mode.
+    await act(async () => {
+      fireEvent.doubleClick(getTreePane().getAllByTitle('Double-click to edit number')[0]);
+    });
+
+    // Every wrapper must now declare draggable=false so the browser lets the
+    // user select text inside the number input with the mouse.
+    wrappers = getContainer().querySelectorAll('[draggable]');
+    expect(wrappers.length).toBeGreaterThan(0);
+    for (const w of wrappers) expect(w.getAttribute('draggable')).toBe('false');
+  });
+
+  // Regression (issue #101, problem 3): with no node selected, pressing Tab used
+  // to fall through to the browser's native focus-move, scrolling the pane. The
+  // handler must call preventDefault() even when there's nothing to indent.
+  test('Tab with no selection prevents default (no scroll jump)', () => {
+    renderTreeEditor();
+
+    // Guard the precondition: nothing is selected, so this exercises the
+    // no-selection path rather than the indent path (which also preventDefaults).
+    expectNodeNotSelected('First Heading');
+    expectNodeNotSelected('Second Heading');
+
+    // fireEvent returns false when a handler called preventDefault() on the event.
+    const result = fireEvent.keyDown(getContainer(), { key: 'Tab' });
+    expect(result).toBe(false);
+  });
+
   test('pressing Enter while editing a TEXT-format node does NOT create a sibling', async () => {
     vi.useFakeTimers();
     renderTreeEditor();

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -438,6 +438,10 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
       if (flattenedNodes.length > 0 && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
         e.preventDefault();
         moveSelection(e.key === 'ArrowDown' ? 'down' : 'up', false);
+      } else if (e.key === 'Tab') {
+        // Nothing to indent, but stop the browser's native focus-move, which
+        // otherwise scrolls the pane (issue #101).
+        e.preventDefault();
       }
       return;
     }


### PR DESCRIPTION
## Summary
- Disable node `draggable` while editing a number field, so mouse drags select text in the number `<input>` instead of starting node drag&drop (issue #101, problem 2)
- Call `preventDefault()` on Tab when no node is selected, stopping the browser's native focus-move that scrolled the editor pane (issue #101, problem 3)

## Test plan
- [x] New regression test: node wrappers drop `draggable` while editing a number
- [x] New regression test: Tab with no selection is default-prevented
- [x] Full suite green (1119 passed)
- [x] Manual: double-click a number badge → drag mouse selects text, no node drag
- [x] Manual: clear selection, press Tab → no scroll jump

Addresses problems 2 & 3 of #101 (problems 1, 4, 5 remain open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)