### PR TITLE
Fix #101 (problem 4): tab nodes out of lists, splitting to preserve order

### DIFF
--- a/src/hooks/useTreeEditor.test.ts
+++ b/src/hooks/useTreeEditor.test.ts
@@ -6,6 +6,7 @@ import type {
   HeadingDocumentNode,
   LeafDocumentNode,
 } from '../types/document';
+import { isValidDocument } from '../types/document';
 import { useTreeEditor } from './useTreeEditor';
 
 const createTestDocument = (): ContainerDocumentNode => ({
@@ -394,6 +395,70 @@ describe('useTreeEditor', () => {
     expect(result.current.document.children[1].id).toBe('p1');
     expect(result.current.document.children[2].id).toBe('p2');
     expect(result.current.document.children[3].id).toBe('h2');
+  });
+
+  test('outdentSelected tabs a heading stuck in a list out of the list (issue #101 #4)', () => {
+    const doc: ContainerDocumentNode = {
+      id: 'root',
+      number: null,
+      type: 'DOCUMENT',
+      children: [
+        {
+          id: 'list1',
+          number: null,
+          type: 'LIST',
+          children: [
+            {
+              id: 'li1',
+              number: '1.',
+              type: 'LIST_ITEM',
+              children: [
+                {
+                  id: 'li1-content',
+                  number: null,
+                  type: 'CONTENT',
+                  format: 'TEXT',
+                  contents: { de: 'An item' },
+                  children: [],
+                },
+              ],
+            },
+            {
+              id: 'liH',
+              number: null,
+              type: 'LIST_ITEM',
+              children: [
+                {
+                  id: 'stuck',
+                  number: null,
+                  type: 'HEADING',
+                  format: 'TEXT',
+                  contents: { de: 'Stuck heading' },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { result } = renderHook(() => useTreeEditor(doc));
+
+    act(() => {
+      result.current.handleNodeClick('stuck', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+
+    act(() => {
+      result.current.outdentSelected();
+    });
+
+    // The heading is lifted out to sit after the list; the list keeps its first item.
+    expect(result.current.document.children.map((c) => c.type)).toEqual(['LIST', 'HEADING']);
+    expect(result.current.document.children[1].id).toBe('stuck');
+    const list = result.current.document.children[0] as ContainerDocumentNode;
+    expect(list.children.map((c) => c.id)).toEqual(['li1']);
+    expect(isValidDocument(result.current.document)).toBe(true);
   });
 
   describe('moveSelectedToTop / moveSelectedToBottom', () => {

--- a/src/hooks/useTreeOperations.test.ts
+++ b/src/hooks/useTreeOperations.test.ts
@@ -6,6 +6,7 @@ import type {
   HeadingDocumentNode,
   LeafDocumentNode,
 } from '../types/document';
+import { isValidDocument } from '../types/document';
 import type { NodePath } from '../types/editor';
 import { buildIndices, getNodeAtPath } from '../utils/tree-utils';
 import { useTreeOperations } from './useTreeOperations';
@@ -1133,6 +1134,596 @@ describe('useTreeOperations', () => {
       // h1 should have no children left
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       expect(h1.children.length).toBe(0);
+    });
+  });
+
+  describe('outdentNodes: lift node out of list_item (issue #101 #4)', () => {
+    // Helper: a content child node literal.
+    const content = (id: string, text: string): ContentDocumentNode => ({
+      id,
+      number: null,
+      type: 'CONTENT',
+      format: 'TEXT',
+      contents: { de: text },
+      children: [],
+    });
+    // Helper: a heading child node literal.
+    const heading = (id: string, text: string): HeadingDocumentNode => ({
+      id,
+      number: null,
+      type: 'HEADING',
+      format: 'TEXT',
+      contents: { de: text },
+      children: [],
+    });
+
+    test('lifts a heading out of the last list_item, placing it after the list (no split)', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [
+              createListItem('li1', '1.', 'a'),
+              {
+                id: 'li2',
+                number: '2.',
+                type: 'LIST_ITEM',
+                children: [content('li2-content', 'b'), heading('H', 'Stuck')],
+              } as ContainerDocumentNode,
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      // No content follows the heading, so no trailing list is created.
+      expect(newDoc.children.map((c) => c.id)).toEqual(['list1', 'H']);
+      const list = newDoc.children[0] as ContainerDocumentNode;
+      expect(list.children.map((c) => c.id)).toEqual(['li1', 'li2']);
+      const li2 = list.children[1] as ContainerDocumentNode;
+      // The surviving list_item keeps its id and number.
+      expect(li2.number).toBe('2.');
+      expect(li2.children.map((c) => c.id)).toEqual(['li2-content']);
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('lifts a heading out of a middle list_item, splitting the list around it', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [
+              {
+                id: 'li1',
+                number: '1.',
+                type: 'LIST_ITEM',
+                children: [content('li1-content', 'a'), heading('H', 'Stuck')],
+              } as ContainerDocumentNode,
+              createListItem('li2', '2.', 'b'),
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.type)).toEqual(['LIST', 'HEADING', 'LIST']);
+      expect(newDoc.children[1].id).toBe('H');
+      const before = newDoc.children[0] as ContainerDocumentNode;
+      expect(before.id).toBe('list1');
+      expect(before.children.map((c) => c.id)).toEqual(['li1']);
+      const li1 = before.children[0] as ContainerDocumentNode;
+      expect(li1.children.map((c) => c.id)).toEqual(['li1-content']);
+      const after = newDoc.children[2] as ContainerDocumentNode;
+      expect(after.id).not.toBe('list1');
+      expect(after.children.map((c) => c.id)).toEqual(['li2']);
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('drops an emptied middle list_item when its only child is lifted out', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [
+              createListItem('li1', '1.', 'a'),
+              {
+                id: 'liH',
+                number: null,
+                type: 'LIST_ITEM',
+                children: [heading('H', 'Stuck')],
+              } as ContainerDocumentNode,
+              createListItem('li2', '2.', 'b'),
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.type)).toEqual(['LIST', 'HEADING', 'LIST']);
+      const before = newDoc.children[0] as ContainerDocumentNode;
+      expect(before.children.map((c) => c.id)).toEqual(['li1']);
+      const after = newDoc.children[2] as ContainerDocumentNode;
+      expect(after.children.map((c) => c.id)).toEqual(['li2']);
+      // The emptied list_item is gone entirely.
+      expect(JSON.stringify(newDoc)).not.toContain('liH');
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('splits the list_item itself when the lifted node sits between content', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [
+              {
+                id: 'li1',
+                number: '1.',
+                type: 'LIST_ITEM',
+                children: [content('c-a', 'a'), heading('H', 'Stuck'), content('c-c', 'c')],
+              } as ContainerDocumentNode,
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.type)).toEqual(['LIST', 'HEADING', 'LIST']);
+
+      const beforeItem = (newDoc.children[0] as ContainerDocumentNode)
+        .children[0] as ContainerDocumentNode;
+      expect(beforeItem.id).toBe('li1');
+      expect(beforeItem.number).toBe('1.');
+      expect(beforeItem.children.map((c) => c.id)).toEqual(['c-a']);
+
+      const afterItem = (newDoc.children[2] as ContainerDocumentNode)
+        .children[0] as ContainerDocumentNode;
+      // Tail fragment gets a fresh id and no number to avoid a duplicate label.
+      expect(afterItem.id).not.toBe('li1');
+      expect(afterItem.number).toBeNull();
+      expect(afterItem.children.map((c) => c.id)).toEqual(['c-c']);
+
+      // No duplicate ids despite the split.
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('lifts a heading out of the first list_item, placing it before the list', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [
+              {
+                id: 'liH',
+                number: null,
+                type: 'LIST_ITEM',
+                children: [heading('H', 'Stuck')],
+              } as ContainerDocumentNode,
+              createListItem('li2', '2.', 'b'),
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.id)).toEqual(['H', 'list1']);
+      const after = newDoc.children[1] as ContainerDocumentNode;
+      // No "before" list, so the surviving list reuses the original id.
+      expect(after.id).toBe('list1');
+      expect(after.children.map((c) => c.id)).toEqual(['li2']);
+      // The surviving list_item keeps its original number.
+      expect((after.children[0] as ContainerDocumentNode).number).toBe('2.');
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('replaces a single-item single-child list with just the lifted node', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [
+              {
+                id: 'liH',
+                number: null,
+                type: 'LIST_ITEM',
+                children: [heading('H', 'Stuck')],
+              } as ContainerDocumentNode,
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.id)).toEqual(['H']);
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('keeps document order when lifting from a list nested under a heading', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'T',
+            number: '1',
+            type: 'HEADING',
+            format: 'TEXT',
+            contents: { de: 'Title' },
+            children: [
+              content('pre', 'pre'),
+              {
+                id: 'list1',
+                number: null,
+                type: 'LIST',
+                children: [
+                  createListItem('li1', '1.', 'x'),
+                  {
+                    id: 'liH',
+                    number: null,
+                    type: 'LIST_ITEM',
+                    children: [heading('H', 'Stuck')],
+                  } as ContainerDocumentNode,
+                  createListItem('li2', '2.', 'y'),
+                ],
+              },
+              content('post', 'post'),
+            ],
+          } as HeadingDocumentNode,
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const t = newDoc.children[0] as HeadingDocumentNode;
+      expect(t.children.map((c) => c.type)).toEqual([
+        'CONTENT',
+        'LIST',
+        'HEADING',
+        'LIST',
+        'CONTENT',
+      ]);
+      expect(t.children[0].id).toBe('pre');
+      expect((t.children[1] as ContainerDocumentNode).children.map((c) => c.id)).toEqual(['li1']);
+      expect(t.children[2].id).toBe('H');
+      expect((t.children[3] as ContainerDocumentNode).children.map((c) => c.id)).toEqual(['li2']);
+      expect(t.children[4].id).toBe('post');
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('lifts a normal list item content out of the list', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [createListItem('li1', '1.', 'a'), createListItem('li2', '2.', 'b')],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['li1-content']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.type)).toEqual(['CONTENT', 'LIST']);
+      expect(newDoc.children[0].id).toBe('li1-content');
+      const after = newDoc.children[1] as ContainerDocumentNode;
+      expect(after.id).toBe('list1');
+      expect(after.children.map((c) => c.id)).toEqual(['li2']);
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('lifts a footnote trapped directly in a list_item out of the list', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [
+              {
+                id: 'li1',
+                number: '1.',
+                type: 'LIST_ITEM',
+                children: [
+                  content('c1', 'a'),
+                  {
+                    id: 'fn',
+                    number: 'i.',
+                    type: 'FOOTNOTE',
+                    format: 'TEXT',
+                    contents: { de: 'note' },
+                  } as LeafDocumentNode,
+                ],
+              } as ContainerDocumentNode,
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['fn']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.type)).toEqual(['LIST', 'FOOTNOTE']);
+      expect(newDoc.children[1].id).toBe('fn');
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('lifts multiple sibling nodes out of the same list_item, preserving order', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [
+              {
+                id: 'li1',
+                number: '1.',
+                type: 'LIST_ITEM',
+                children: [
+                  content('c-a', 'a'),
+                  heading('H1', 'H1'),
+                  heading('H2', 'H2'),
+                  content('c-b', 'b'),
+                ],
+              } as ContainerDocumentNode,
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H1', 'H2']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.type)).toEqual(['LIST', 'HEADING', 'HEADING', 'LIST']);
+      expect(newDoc.children[1].id).toBe('H1');
+      expect(newDoc.children[2].id).toBe('H2');
+      const before = newDoc.children[0] as ContainerDocumentNode;
+      expect((before.children[0] as ContainerDocumentNode).children.map((c) => c.id)).toEqual([
+        'c-a',
+      ]);
+      const after = newDoc.children[3] as ContainerDocumentNode;
+      expect((after.children[0] as ContainerDocumentNode).children.map((c) => c.id)).toEqual([
+        'c-b',
+      ]);
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('preserves the lifted node subtree (a heading with body content)', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [
+              {
+                id: 'liH',
+                number: null,
+                type: 'LIST_ITEM',
+                children: [
+                  {
+                    id: 'H',
+                    number: '2',
+                    type: 'HEADING',
+                    format: 'TEXT',
+                    contents: { de: 'Stuck' },
+                    children: [content('body', 'body text')],
+                  } as HeadingDocumentNode,
+                ],
+              } as ContainerDocumentNode,
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      expect(newDoc.children.map((c) => c.id)).toEqual(['H']);
+      const h = newDoc.children[0] as HeadingDocumentNode;
+      // The lifted node keeps its number and its whole subtree.
+      expect(h.number).toBe('2');
+      expect(h.children.map((c) => c.id)).toEqual(['body']);
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('lifts two non-adjacent nodes out of the same list_item, preserving order', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'list1',
+            number: null,
+            type: 'LIST',
+            children: [
+              {
+                id: 'li1',
+                number: '1.',
+                type: 'LIST_ITEM',
+                children: [heading('H1', 'H1'), content('c-mid', 'mid'), heading('H2', 'H2')],
+              } as ContainerDocumentNode,
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H1', 'H2']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      // Order H1, (list holding the middle content), H2 is preserved.
+      expect(newDoc.children.map((c) => c.type)).toEqual(['HEADING', 'LIST', 'HEADING']);
+      expect(newDoc.children[0].id).toBe('H1');
+      expect(newDoc.children[2].id).toBe('H2');
+      const midList = newDoc.children[1] as ContainerDocumentNode;
+      expect((midList.children[0] as ContainerDocumentNode).children.map((c) => c.id)).toEqual([
+        'c-mid',
+      ]);
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('lifts a nested list out of a list_item as a sibling of the outer list', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'outer',
+            number: null,
+            type: 'LIST',
+            children: [
+              {
+                id: 'li1',
+                number: '1.',
+                type: 'LIST_ITEM',
+                children: [
+                  content('c-x', 'x'),
+                  {
+                    id: 'inner',
+                    number: null,
+                    type: 'LIST',
+                    children: [createListItem('lia', 'a.', 'nested')],
+                  } as ContainerDocumentNode,
+                ],
+              } as ContainerDocumentNode,
+            ],
+          },
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['inner']);
+      });
+
+      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      // The two lists are left adjacent and unmerged; order (x, then nested) holds.
+      expect(newDoc.children.map((c) => c.id)).toEqual(['outer', 'inner']);
+      const outer = newDoc.children[0] as ContainerDocumentNode;
+      expect((outer.children[0] as ContainerDocumentNode).children.map((c) => c.id)).toEqual([
+        'c-x',
+      ]);
+      const inner = newDoc.children[1] as ContainerDocumentNode;
+      expect(inner.children.map((c) => c.id)).toEqual(['lia']);
+      expect(isValidDocument(newDoc)).toBe(true);
+    });
+
+    test('does not lift when the list_item is not inside a list (malformed)', () => {
+      const doc: ContainerDocumentNode = {
+        id: 'root',
+        number: null,
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'orphan',
+            number: null,
+            type: 'LIST_ITEM',
+            children: [heading('H', 'Stuck')],
+          } as ContainerDocumentNode,
+        ],
+      };
+
+      const { result } = renderTreeOperations(doc);
+      act(() => {
+        result.current.outdentNodes(['H']);
+      });
+
+      expect(mockCommit).not.toHaveBeenCalled();
     });
   });
 

--- a/src/hooks/useTreeOperations.ts
+++ b/src/hooks/useTreeOperations.ts
@@ -243,6 +243,99 @@ function flattenListToContents(list: ContainerDocumentNode): DocumentNode[] {
   return out;
 }
 
+/**
+ * Lift a node out of the LIST_ITEM that contains it, making it a sibling of the
+ * enclosing LIST while preserving document reading order. The list_item and the
+ * list are split around the node: anything that came before it stays in the
+ * original list (placed before the lifted node); anything that came after moves
+ * into a fresh list placed after the lifted node. Empty fragments are dropped.
+ *
+ * This is what lets a node whose type the LIST schema can't hold — most visibly
+ * a HEADING that ended up inside a list — be "tabbed out" of the list (issue
+ * #101, problem 4). A single level of lifting always lands in a valid parent:
+ * a LIST's parent is always DOCUMENT, HEADING, or LIST_ITEM, all of which accept
+ * every node type a list_item can hold.
+ *
+ * `path` points at the node to lift; its parent must be a LIST_ITEM. Returns
+ * null when the structure isn't the expected LIST > LIST_ITEM > node shape
+ * (e.g. a malformed list_item not inside a list), so odd inputs are left alone.
+ */
+function liftNodeOutOfListItem(
+  doc: ContainerDocumentNode,
+  path: NodePath
+): ContainerDocumentNode | null {
+  const itemPath = path.slice(0, -1);
+  const listPath = itemPath.slice(0, -1);
+
+  const node = getNodeAtPath(doc, path);
+  const item = getNodeAtPath(doc, itemPath);
+  const list = listPath.length === 0 ? doc : getNodeAtPath(doc, listPath);
+  if (!node || !item || item.type !== 'LIST_ITEM' || !list || list.type !== 'LIST') {
+    return null;
+  }
+
+  const gpPath = listPath.slice(0, -1);
+  const gp = gpPath.length === 0 ? doc : getNodeAtPath(doc, gpPath);
+  if (!gp || !('children' in gp)) return null;
+
+  const nodeIndexInItem = path[path.length - 1];
+  const itemIndexInList = itemPath[itemPath.length - 1];
+  const listIndexInGp = listPath[listPath.length - 1];
+
+  const itemChildren = item.children;
+  const beforeChildren = itemChildren.slice(0, nodeIndexInItem);
+  const afterChildren = itemChildren.slice(nodeIndexInItem + 1);
+
+  const listChildren = list.children;
+  const itemsBefore = listChildren.slice(0, itemIndexInList);
+  const itemsAfter = listChildren.slice(itemIndexInList + 1);
+
+  // The "before" fragment of the split list_item keeps the original id/number —
+  // it's the natural start of the item. Omitted when nothing precedes the node.
+  const beforeItem: DocumentNode | null =
+    beforeChildren.length > 0 ? { ...item, children: beforeChildren } : null;
+
+  // The "after" fragment is a continuation: when there's a "before" fragment it
+  // already owns the original id/number, so this one needs a fresh id and drops
+  // the number (a duplicate label would mislead). With no "before" fragment it
+  // IS the surviving remnant of the item, so it keeps the original id/number.
+  const afterItem: DocumentNode | null =
+    afterChildren.length > 0
+      ? beforeItem
+        ? { ...item, id: generateId(), number: null, children: afterChildren }
+        : { ...item, children: afterChildren }
+      : null;
+
+  const beforeListChildren = [...itemsBefore, ...(beforeItem ? [beforeItem] : [])];
+  const afterListChildren = [...(afterItem ? [afterItem] : []), ...itemsAfter];
+
+  // Replace the single list entry in the grandparent with [beforeList?, node, afterList?].
+  // The fragments are left unmerged on purpose: the lifted node sits between them
+  // and `outdentNodes` (unlike the type-change paths) never calls
+  // mergeAdjacentLists — re-joining a split list stays the user's explicit choice.
+  const replacement: DocumentNode[] = [];
+  if (beforeListChildren.length > 0) {
+    replacement.push({ ...list, children: beforeListChildren });
+  }
+  replacement.push(node);
+  if (afterListChildren.length > 0) {
+    // Reuse the original list id only when the "before" list didn't claim it.
+    const afterListId = beforeListChildren.length > 0 ? generateId() : list.id;
+    replacement.push({ ...list, id: afterListId, children: afterListChildren });
+  }
+
+  const newGpChildren = [...gp.children];
+  newGpChildren.splice(listIndexInGp, 1, ...replacement);
+
+  if (gpPath.length === 0) {
+    return { ...doc, children: newGpChildren };
+  }
+  return updateNodeAtPath(doc, gpPath, (n) => ({
+    ...n,
+    children: newGpChildren,
+  }));
+}
+
 /** Create a new empty sibling node appropriate for the given parent. */
 function createNewSiblingNode(parent: DocumentNode, language: Language): DocumentNode {
   if (parent.type === 'LIST') {
@@ -526,6 +619,13 @@ export const useTreeOperations = ({
     const node = getNodeAtPath(doc, path);
 
     if (!parent || !node) return null;
+
+    // Issue #101: a node trapped inside a LIST_ITEM whose type the LIST can't
+    // hold (most visibly a HEADING) is lifted out of the list — splitting the
+    // list_item and the list around it so reading order is preserved.
+    if (parent.type === 'LIST_ITEM') {
+      return liftNodeOutOfListItem(doc, path);
+    }
 
     if (parent.type !== 'HEADING' && parent.type !== 'LIST' && parent.type !== 'CONTENT')
       return null;


### PR DESCRIPTION
## Summary
- A heading (or any node) trapped inside a `list_item` can now be tabbed out with Shift+Tab. Previously outdent was a no-op whenever a node's parent was a `LIST_ITEM`, because `LIST_ITEM` isn't an allowed parent type for those nodes.
- The enclosing `list_item` and `list` are split around the lifted node so document reading order is preserved; the node becomes a sibling of the list.
- Split fragments keep valid, unique ids/numbers (the "before" fragment keeps the original id/number; a continuation gets a fresh id and `null` number); empty fragments are dropped; malformed structures are left untouched.
- No UI changes needed — Shift+Tab already routes to this code path.

## Test plan
- [x] 14 unit cases in `useTreeOperations.test.ts` covering position (first/middle/last item), splitting the list_item itself, emptied-item drop, single-item list consumed, list nested under a heading, normal-item content, footnote, lifted-subtree preservation, adjacent + non-adjacent multi-node order, nested-list lift, number preservation, and malformed no-op — most assert `isValidDocument`
- [x] End-to-end test through `outdentSelected` in `useTreeEditor.test.ts`
- [x] Full suite (1141) passing; `npm run build` clean

Closes #101 (problem 4 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)