### PR TITLE
Refactor #104: per-type node interfaces + format docs in document.ts

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -14,7 +14,6 @@ import {
 function makeTree() {
   return {
     id: 'root',
-    number: null,
     type: 'DOCUMENT' as const,
     children: [
       {

--- a/src/components/DocumentPreview.test.tsx
+++ b/src/components/DocumentPreview.test.tsx
@@ -6,7 +6,6 @@ import { DocumentPreview } from './DocumentPreview';
 
 const makeDoc = (...children: ContainerDocumentNode['children']): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children,
 });

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -1,7 +1,13 @@
 import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useResizable } from '../hooks/useResizable';
-import type { ContainerDocumentNode, DocumentNode, Language, NodeFormat } from '../types/document';
+import type {
+  ContainerDocumentNode,
+  DocumentNode,
+  Language,
+  ListItemDocumentNode,
+  NodeFormat,
+} from '../types/document';
 import { renderContent } from '../utils/format-render';
 import { getDocumentOutline, type OutlineEntry } from '../utils/outline-utils';
 import { DragHandle } from './DragHandle';
@@ -347,7 +353,7 @@ function ListItemNode({
   language,
   headingDepth,
 }: {
-  node: ContainerDocumentNode;
+  node: ListItemDocumentNode;
   language: Language;
   headingDepth: number;
 }) {

--- a/src/components/EditorInterface.test.tsx
+++ b/src/components/EditorInterface.test.tsx
@@ -16,7 +16,6 @@ vi.mock('../utils/document-utils', async () => {
 
 const createTestDocument = (): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children: [
     {

--- a/src/components/LeftPane.test.tsx
+++ b/src/components/LeftPane.test.tsx
@@ -6,7 +6,6 @@ import { LeftPane } from './LeftPane';
 
 const makeDoc = (...children: ContainerDocumentNode['children']): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children,
 });

--- a/src/components/RecentDocumentsList.test.tsx
+++ b/src/components/RecentDocumentsList.test.tsx
@@ -11,7 +11,7 @@ function makeStoredEntry(overrides: Partial<StoredDocumentEntry> = {}): StoredDo
     name: overrides.name ?? 'bill.docx',
     subtitle: overrides.subtitle ?? null,
     language: 'de',
-    tree: { id: 'root', number: null, type: 'DOCUMENT', children: [] },
+    tree: { id: 'root', type: 'DOCUMENT', children: [] },
     source: {
       kind: 'docx',
       mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -7,7 +7,6 @@ import { EditorInterface } from './EditorInterface';
 
 const createTestDocument = (): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children: [
     {
@@ -303,7 +302,6 @@ describe('double-click inline editing', () => {
     vi.useFakeTimers();
     const nestedDoc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -453,7 +451,6 @@ describe('double-click inline editing', () => {
 
     const initialDocument: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -511,7 +508,6 @@ describe('double-click inline editing', () => {
 
     const initialDocument: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -569,7 +565,6 @@ describe('double-click inline editing', () => {
 
     const initialDocument: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -666,7 +661,6 @@ describe('double-click inline editing', () => {
 
     const initialDocument: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -900,7 +894,6 @@ describe('node operations via keyboard', () => {
     // Need heading followed by content at same level for indent to work
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -954,7 +947,6 @@ describe('node operations via keyboard', () => {
   test('Shift+Tab outdents selected node', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -1067,7 +1059,6 @@ describe('edit mode behaviors', () => {
     // Create document with an empty content node
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -1133,7 +1124,6 @@ describe('edit mode behaviors', () => {
 describe('empty document', () => {
   const createEmptyDocument = (): ContainerDocumentNode => ({
     id: 'root',
-    number: null,
     type: 'DOCUMENT',
     children: [],
   });
@@ -1177,7 +1167,6 @@ describe('empty document', () => {
 describe('drag and drop reordering', () => {
   const createThreeNodeDocument = (): ContainerDocumentNode => ({
     id: 'root',
-    number: null,
     type: 'DOCUMENT',
     children: [
       {
@@ -1369,7 +1358,6 @@ describe('inline-marks toolbar — end-to-end toggle', () => {
 
     const initialDocument: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -1438,7 +1426,6 @@ describe('inline-marks toolbar — end-to-end toggle', () => {
 
     const initialDocument: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -1548,7 +1535,6 @@ describe('inline-marks toolbar — end-to-end toggle', () => {
   test('clicking Bold while editing a number input commits to the tree without waiting for blur', async () => {
     const initialDocument: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {

--- a/src/hooks/useAutosave.test.ts
+++ b/src/hooks/useAutosave.test.ts
@@ -21,7 +21,6 @@ vi.mock('../components/ui/Toast', () => ({
 function makeTree(text = 'hello'): ContainerDocumentNode {
   return {
     id: 'root',
-    number: null,
     type: 'DOCUMENT',
     children: [
       {

--- a/src/hooks/useRecentDocuments.test.ts
+++ b/src/hooks/useRecentDocuments.test.ts
@@ -13,7 +13,6 @@ import { useRecentDocuments } from './useRecentDocuments';
 function makeTree(text = 'hello'): ContainerDocumentNode {
   return {
     id: 'root',
-    number: null,
     type: 'DOCUMENT',
     children: [
       {

--- a/src/hooks/useTreeEditor.test.ts
+++ b/src/hooks/useTreeEditor.test.ts
@@ -11,7 +11,6 @@ import { useTreeEditor } from './useTreeEditor';
 
 const createTestDocument = (): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children: [
     {
@@ -314,7 +313,6 @@ describe('useTreeEditor', () => {
     // Create doc: root > [h1, p1, p2]
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -400,7 +398,6 @@ describe('useTreeEditor', () => {
   test('outdentSelected tabs a heading stuck in a list out of the list (issue #101 #4)', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -465,7 +462,6 @@ describe('useTreeEditor', () => {
     // Flat doc: root > [a, b, c, d]
     const createFlatDoc = (): ContainerDocumentNode => ({
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: ['a', 'b', 'c', 'd'].map(
         (id) =>

--- a/src/hooks/useTreeHistory.test.ts
+++ b/src/hooks/useTreeHistory.test.ts
@@ -9,7 +9,6 @@ import { useTreeHistory } from './useTreeHistory';
 
 const createTestDocument = (): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children: [
     {
@@ -312,7 +311,6 @@ describe('useTreeHistory', () => {
     // Reset with new document
     const newDoc: ContainerDocumentNode = {
       id: 'new-root',
-      number: null,
       type: 'DOCUMENT',
       children: [],
     };

--- a/src/hooks/useTreeOperations.test.ts
+++ b/src/hooks/useTreeOperations.test.ts
@@ -5,6 +5,7 @@ import type {
   ContentDocumentNode,
   HeadingDocumentNode,
   LeafDocumentNode,
+  NumberedDocumentNode,
 } from '../types/document';
 import { isValidDocument } from '../types/document';
 import type { NodePath } from '../types/editor';
@@ -14,7 +15,6 @@ import { useTreeOperations } from './useTreeOperations';
 // Helper to create a test document
 const createTestDocument = (): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children: [
     {
@@ -85,7 +85,6 @@ const createListItem = (
 
 const createDocumentWithList = (): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children: [
     {
@@ -335,7 +334,6 @@ describe('useTreeOperations', () => {
       // Create a document with multi-language content
       const multiLangDoc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -367,7 +365,6 @@ describe('useTreeOperations', () => {
       // Create doc with h1, then content at same level
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -419,7 +416,6 @@ describe('useTreeOperations', () => {
       // Create two sibling headings at root level
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -510,7 +506,6 @@ describe('useTreeOperations', () => {
       // append it to that existing list, not create a new sibling list.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -589,7 +584,6 @@ describe('useTreeOperations', () => {
     test('does nothing when list_item has no preceding sibling', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -615,7 +609,6 @@ describe('useTreeOperations', () => {
       // new sublist under li1 should contain li2 unchanged — including liA.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -674,7 +667,6 @@ describe('useTreeOperations', () => {
       // doc: h1, p1, p2 at root level → both p1 and p2 should move under h1
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -726,7 +718,6 @@ describe('useTreeOperations', () => {
       // Neither can be indented
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -763,7 +754,6 @@ describe('useTreeOperations', () => {
       // and D as direct siblings under B — not re-nesting D under C.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -835,7 +825,6 @@ describe('useTreeOperations', () => {
       });
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           heading('A'),
@@ -925,7 +914,6 @@ describe('useTreeOperations', () => {
     test('moves list_item out of nested list', () => {
       const nestedListDoc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -961,7 +949,6 @@ describe('useTreeOperations', () => {
     test('does nothing when outdenting list_item would place it outside any list', () => {
       const docWithTopLevelList: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -988,7 +975,6 @@ describe('useTreeOperations', () => {
     test('does nothing when outdenting list_item in list under heading would violate rules', () => {
       const docWithListUnderHeading: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1023,7 +1009,6 @@ describe('useTreeOperations', () => {
       // list1[li1{content}, li2, li3]  (empty nested list is dropped)
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1080,7 +1065,6 @@ describe('useTreeOperations', () => {
       // list1[li1{nested[li3]}, li2]
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1127,7 +1111,6 @@ describe('useTreeOperations', () => {
       // list1[li1{nested1[li2, li3]}]   (li3 moves up one level, into nested1)
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1189,7 +1172,6 @@ describe('useTreeOperations', () => {
       // list1[li1, li2, li3]  (no nested list left)
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1257,7 +1239,6 @@ describe('useTreeOperations', () => {
       // carrying C and D along unchanged — not scatter them or reverse order.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1323,7 +1304,6 @@ describe('useTreeOperations', () => {
       // processed separately.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1423,7 +1403,6 @@ describe('useTreeOperations', () => {
     test('lifts a heading out of the last list_item, placing it after the list (no split)', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1455,7 +1434,7 @@ describe('useTreeOperations', () => {
       expect(list.children.map((c) => c.id)).toEqual(['li1', 'li2']);
       const li2 = list.children[1] as ContainerDocumentNode;
       // The surviving list_item keeps its id and number.
-      expect(li2.number).toBe('2.');
+      expect((li2 as NumberedDocumentNode).number).toBe('2.');
       expect(li2.children.map((c) => c.id)).toEqual(['li2-content']);
       expect(isValidDocument(newDoc)).toBe(true);
     });
@@ -1463,7 +1442,6 @@ describe('useTreeOperations', () => {
     test('lifts a heading out of a middle list_item, splitting the list around it', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1505,7 +1483,6 @@ describe('useTreeOperations', () => {
     test('drops an emptied middle list_item when its only child is lifted out', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1545,7 +1522,6 @@ describe('useTreeOperations', () => {
     test('splits the list_item itself when the lifted node sits between content', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1575,14 +1551,14 @@ describe('useTreeOperations', () => {
       const beforeItem = (newDoc.children[0] as ContainerDocumentNode)
         .children[0] as ContainerDocumentNode;
       expect(beforeItem.id).toBe('li1');
-      expect(beforeItem.number).toBe('1.');
+      expect((beforeItem as NumberedDocumentNode).number).toBe('1.');
       expect(beforeItem.children.map((c) => c.id)).toEqual(['c-a']);
 
       const afterItem = (newDoc.children[2] as ContainerDocumentNode)
         .children[0] as ContainerDocumentNode;
       // Tail fragment gets a fresh id and no number to avoid a duplicate label.
       expect(afterItem.id).not.toBe('li1');
-      expect(afterItem.number).toBeNull();
+      expect((afterItem as NumberedDocumentNode).number).toBeNull();
       expect(afterItem.children.map((c) => c.id)).toEqual(['c-c']);
 
       // No duplicate ids despite the split.
@@ -1592,7 +1568,6 @@ describe('useTreeOperations', () => {
     test('lifts a heading out of the first list_item, placing it before the list', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1624,14 +1599,13 @@ describe('useTreeOperations', () => {
       expect(after.id).toBe('list1');
       expect(after.children.map((c) => c.id)).toEqual(['li2']);
       // The surviving list_item keeps its original number.
-      expect((after.children[0] as ContainerDocumentNode).number).toBe('2.');
+      expect((after.children[0] as NumberedDocumentNode).number).toBe('2.');
       expect(isValidDocument(newDoc)).toBe(true);
     });
 
     test('replaces a single-item single-child list with just the lifted node', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1663,7 +1637,6 @@ describe('useTreeOperations', () => {
     test('keeps document order when lifting from a list nested under a heading', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1720,7 +1693,6 @@ describe('useTreeOperations', () => {
     test('lifts a normal list item content out of the list', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1749,7 +1721,6 @@ describe('useTreeOperations', () => {
     test('lifts a footnote trapped directly in a list_item out of the list', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1791,7 +1762,6 @@ describe('useTreeOperations', () => {
     test('lifts multiple sibling nodes out of the same list_item, preserving order', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1838,7 +1808,6 @@ describe('useTreeOperations', () => {
     test('preserves the lifted node subtree (a heading with body content)', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1883,7 +1852,6 @@ describe('useTreeOperations', () => {
     test('lifts two non-adjacent nodes out of the same list_item, preserving order', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1922,7 +1890,6 @@ describe('useTreeOperations', () => {
     test('lifts a nested list out of a list_item as a sibling of the outer list', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1969,7 +1936,6 @@ describe('useTreeOperations', () => {
     test('does not lift when the list_item is not inside a list (malformed)', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1994,7 +1960,6 @@ describe('useTreeOperations', () => {
     test('moves footnote under previous sibling content', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -2034,7 +1999,6 @@ describe('useTreeOperations', () => {
     test('does nothing when previous sibling is not content or heading', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -2067,7 +2031,6 @@ describe('useTreeOperations', () => {
     test('moves footnote under previous sibling heading', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -2109,7 +2072,6 @@ describe('useTreeOperations', () => {
     test('moves footnote to be sibling of parent content', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -2153,7 +2115,6 @@ describe('useTreeOperations', () => {
     test('preserves other footnote siblings when outdenting', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -2207,7 +2168,6 @@ describe('useTreeOperations', () => {
       test('converts content to heading with empty children', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2239,7 +2199,6 @@ describe('useTreeOperations', () => {
       test('preserves id, number, and contents', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2271,7 +2230,6 @@ describe('useTreeOperations', () => {
       test('does nothing when already a heading', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2299,7 +2257,6 @@ describe('useTreeOperations', () => {
       test('converts heading without children to content', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2333,7 +2290,6 @@ describe('useTreeOperations', () => {
       test('lifts children as siblings after converted node', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2392,7 +2348,6 @@ describe('useTreeOperations', () => {
       test('does nothing when already content', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2420,7 +2375,6 @@ describe('useTreeOperations', () => {
       test('wraps content in list with single list_item', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2461,7 +2415,6 @@ describe('useTreeOperations', () => {
       test('sets correct number for numbered list', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2484,13 +2437,12 @@ describe('useTreeOperations', () => {
         const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
         const list = newDoc.children[0] as ContainerDocumentNode;
         const item = list.children[0] as ContainerDocumentNode;
-        expect(item.number).toBe('1.');
+        expect((item as NumberedDocumentNode).number).toBe('1.');
       });
 
       test('sets correct number for lettered list', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2513,13 +2465,12 @@ describe('useTreeOperations', () => {
         const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
         const list = newDoc.children[0] as ContainerDocumentNode;
         const item = list.children[0] as ContainerDocumentNode;
-        expect(item.number).toBe('a.');
+        expect((item as NumberedDocumentNode).number).toBe('a.');
       });
 
       test('sets null number for unordered list', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2542,7 +2493,7 @@ describe('useTreeOperations', () => {
         const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
         const list = newDoc.children[0] as ContainerDocumentNode;
         const item = list.children[0] as ContainerDocumentNode;
-        expect(item.number).toBeNull();
+        expect((item as NumberedDocumentNode).number).toBeNull();
       });
     });
 
@@ -2550,7 +2501,6 @@ describe('useTreeOperations', () => {
       test('wraps heading in list, lifts children after list', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2603,7 +2553,6 @@ describe('useTreeOperations', () => {
       test('replaces entire list when only item', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2634,7 +2583,6 @@ describe('useTreeOperations', () => {
       test('extracts item and inserts after list when multiple items', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2677,7 +2625,6 @@ describe('useTreeOperations', () => {
       test('replaces entire list when only item', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2707,7 +2654,6 @@ describe('useTreeOperations', () => {
       test('extracts item and inserts after list when multiple items', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2749,7 +2695,6 @@ describe('useTreeOperations', () => {
       test('changes only selected item to numbered, leaves siblings unchanged', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2775,15 +2720,14 @@ describe('useTreeOperations', () => {
         const list = newDoc.children[0] as ContainerDocumentNode;
 
         // Only li2 (index 1) should change
-        expect((list.children[0] as ContainerDocumentNode).number).toBeNull();
-        expect((list.children[1] as ContainerDocumentNode).number).toBe('2.');
-        expect((list.children[2] as ContainerDocumentNode).number).toBeNull();
+        expect((list.children[0] as NumberedDocumentNode).number).toBeNull();
+        expect((list.children[1] as NumberedDocumentNode).number).toBe('2.');
+        expect((list.children[2] as NumberedDocumentNode).number).toBeNull();
       });
 
       test('changes only selected item to lettered', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2805,14 +2749,13 @@ describe('useTreeOperations', () => {
         const list = newDoc.children[0] as ContainerDocumentNode;
 
         // Only li1 (index 0) should change
-        expect((list.children[0] as ContainerDocumentNode).number).toBe('a.');
-        expect((list.children[1] as ContainerDocumentNode).number).toBe('2.');
+        expect((list.children[0] as NumberedDocumentNode).number).toBe('a.');
+        expect((list.children[1] as NumberedDocumentNode).number).toBe('2.');
       });
 
       test('changes only selected item to unordered', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2834,8 +2777,8 @@ describe('useTreeOperations', () => {
         const list = newDoc.children[0] as ContainerDocumentNode;
 
         // Only li1 (index 0) should change
-        expect((list.children[0] as ContainerDocumentNode).number).toBeNull();
-        expect((list.children[1] as ContainerDocumentNode).number).toBe('2.');
+        expect((list.children[0] as NumberedDocumentNode).number).toBeNull();
+        expect((list.children[1] as NumberedDocumentNode).number).toBe('2.');
       });
     });
 
@@ -2843,7 +2786,6 @@ describe('useTreeOperations', () => {
       test('list node + numbered: changes all children to 1., 2., 3.', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2868,15 +2810,14 @@ describe('useTreeOperations', () => {
         const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
         const list = newDoc.children[0] as ContainerDocumentNode;
 
-        expect((list.children[0] as ContainerDocumentNode).number).toBe('1.');
-        expect((list.children[1] as ContainerDocumentNode).number).toBe('2.');
-        expect((list.children[2] as ContainerDocumentNode).number).toBe('3.');
+        expect((list.children[0] as NumberedDocumentNode).number).toBe('1.');
+        expect((list.children[1] as NumberedDocumentNode).number).toBe('2.');
+        expect((list.children[2] as NumberedDocumentNode).number).toBe('3.');
       });
 
       test('list node + unordered: sets all children numbers to null', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2897,14 +2838,13 @@ describe('useTreeOperations', () => {
         const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
         const list = newDoc.children[0] as ContainerDocumentNode;
 
-        expect((list.children[0] as ContainerDocumentNode).number).toBeNull();
-        expect((list.children[1] as ContainerDocumentNode).number).toBeNull();
+        expect((list.children[0] as NumberedDocumentNode).number).toBeNull();
+        expect((list.children[1] as NumberedDocumentNode).number).toBeNull();
       });
 
       test('list node + lettered: changes all children to a., b., c.', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2929,15 +2869,14 @@ describe('useTreeOperations', () => {
         const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
         const list = newDoc.children[0] as ContainerDocumentNode;
 
-        expect((list.children[0] as ContainerDocumentNode).number).toBe('a.');
-        expect((list.children[1] as ContainerDocumentNode).number).toBe('b.');
-        expect((list.children[2] as ContainerDocumentNode).number).toBe('c.');
+        expect((list.children[0] as NumberedDocumentNode).number).toBe('a.');
+        expect((list.children[1] as NumberedDocumentNode).number).toBe('b.');
+        expect((list.children[2] as NumberedDocumentNode).number).toBe('c.');
       });
 
       test('list node + non-list target: does nothing', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -2976,7 +2915,6 @@ describe('useTreeOperations', () => {
         // remains unsupported because there's no meaningful semantics for it.
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3002,7 +2940,6 @@ describe('useTreeOperations', () => {
       test('merges with preceding list when converting to list', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3044,7 +2981,6 @@ describe('useTreeOperations', () => {
       test('merges with following list when converting to list', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3086,7 +3022,6 @@ describe('useTreeOperations', () => {
       test('merges with both surrounding lists when converting to list', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3135,7 +3070,6 @@ describe('useTreeOperations', () => {
       test('does not merge lists separated by other nodes', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3183,7 +3117,6 @@ describe('useTreeOperations', () => {
       test('converts content to footnote (leaf node without children)', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3217,7 +3150,6 @@ describe('useTreeOperations', () => {
       test('preserves id, number, and contents', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3249,7 +3181,6 @@ describe('useTreeOperations', () => {
       test('lifts footnote children when converting content with footnotes', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3306,7 +3237,6 @@ describe('useTreeOperations', () => {
       test('does nothing when already footnote', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3333,7 +3263,6 @@ describe('useTreeOperations', () => {
       test('converts heading to footnote and lifts children', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3393,7 +3322,6 @@ describe('useTreeOperations', () => {
       test('converts heading without children to footnote', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3428,7 +3356,6 @@ describe('useTreeOperations', () => {
       test('converts footnote to content (adds empty children array)', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3461,7 +3388,6 @@ describe('useTreeOperations', () => {
       test('preserves multi-language contents', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3493,7 +3419,6 @@ describe('useTreeOperations', () => {
       test('cannot convert list to footnote', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3517,7 +3442,6 @@ describe('useTreeOperations', () => {
       test('cannot convert list_item to footnote', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3544,7 +3468,6 @@ describe('useTreeOperations', () => {
       test('preserves list_item.number on the converted content node when it is the only item', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3573,7 +3496,6 @@ describe('useTreeOperations', () => {
       test('handles a list_item with no content child (empty contents, default format)', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3611,7 +3533,6 @@ describe('useTreeOperations', () => {
       test('preserves the list_item content format when converting to content', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3655,7 +3576,6 @@ describe('useTreeOperations', () => {
       test('preserves list_item.number when extracted from a multi-item list', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3680,7 +3600,7 @@ describe('useTreeOperations', () => {
 
         // Remaining list_item is untouched
         const list = newDoc.children[0] as ContainerDocumentNode;
-        expect((list.children[0] as ContainerDocumentNode).number).toBe('1.');
+        expect((list.children[0] as NumberedDocumentNode).number).toBe('1.');
 
         // Extracted content carries its old list_item number
         const converted = newDoc.children[1] as ContentDocumentNode;
@@ -3693,7 +3613,6 @@ describe('useTreeOperations', () => {
       test('preserves list_item.number on the converted heading node', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3723,7 +3642,6 @@ describe('useTreeOperations', () => {
       test('flattens all list_items into content nodes, preserving each number', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3767,7 +3685,6 @@ describe('useTreeOperations', () => {
       test('preserves null number for unnumbered items', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3795,7 +3712,6 @@ describe('useTreeOperations', () => {
       test('flattens nested list recursively, preserving inner numbers', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3861,7 +3777,6 @@ describe('useTreeOperations', () => {
       test('preserves source order when nested list precedes the content child', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3918,7 +3833,6 @@ describe('useTreeOperations', () => {
       test('preserves the source content format on the flattened content node', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -3962,7 +3876,6 @@ describe('useTreeOperations', () => {
       test('lifts a list_item with multiple content children, attaching the number to the first', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4024,7 +3937,6 @@ describe('useTreeOperations', () => {
       test('synthesizes a placeholder content node for a list_item with no content child', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4063,7 +3975,6 @@ describe('useTreeOperations', () => {
       test('preserves footnote children of the list_item content', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4116,7 +4027,6 @@ describe('useTreeOperations', () => {
       test('list -> heading is still a no-op', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4142,7 +4052,6 @@ describe('useTreeOperations', () => {
       test('unordered preserves the content original number on the new list_item', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4166,13 +4075,12 @@ describe('useTreeOperations', () => {
         const list = newDoc.children[0] as ContainerDocumentNode;
         const item = list.children[0] as ContainerDocumentNode;
 
-        expect(item.number).toBe('Art. 5');
+        expect((item as NumberedDocumentNode).number).toBe('Art. 5');
       });
 
       test('numbered overwrites the content number with the generated sequence', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4196,13 +4104,12 @@ describe('useTreeOperations', () => {
         const list = newDoc.children[0] as ContainerDocumentNode;
         const item = list.children[0] as ContainerDocumentNode;
 
-        expect(item.number).toBe('1.');
+        expect((item as NumberedDocumentNode).number).toBe('1.');
       });
 
       test('lettered overwrites the content number with the generated sequence', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4226,13 +4133,12 @@ describe('useTreeOperations', () => {
         const list = newDoc.children[0] as ContainerDocumentNode;
         const item = list.children[0] as ContainerDocumentNode;
 
-        expect(item.number).toBe('a.');
+        expect((item as NumberedDocumentNode).number).toBe('a.');
       });
 
       test('unordered with null content number stays null', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4256,7 +4162,7 @@ describe('useTreeOperations', () => {
         const list = newDoc.children[0] as ContainerDocumentNode;
         const item = list.children[0] as ContainerDocumentNode;
 
-        expect(item.number).toBeNull();
+        expect((item as NumberedDocumentNode).number).toBeNull();
       });
     });
 
@@ -4264,7 +4170,6 @@ describe('useTreeOperations', () => {
       test('content -> unordered list -> content preserves number', () => {
         const startDoc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4286,7 +4191,7 @@ describe('useTreeOperations', () => {
         const afterToList = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
         const list = afterToList.children[0] as ContainerDocumentNode;
         const listItem = list.children[0] as ContainerDocumentNode;
-        expect(listItem.number).toBe('Art. 5');
+        expect((listItem as NumberedDocumentNode).number).toBe('Art. 5');
 
         // Step 2: list_item -> content (rebuild hook over the new doc)
         mockCommit.mockClear();
@@ -4307,7 +4212,6 @@ describe('useTreeOperations', () => {
     test('changes type for multiple content nodes to heading', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -4354,7 +4258,6 @@ describe('useTreeOperations', () => {
     test('handles mixed node types (content + heading -> footnote)', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -4401,7 +4304,6 @@ describe('useTreeOperations', () => {
     test('numbers a numbered-list batch sequentially (1., 2., 3.)', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -4443,15 +4345,14 @@ describe('useTreeOperations', () => {
       const list = newDoc.children[0] as ContainerDocumentNode;
       expect(list.type).toBe('LIST');
       expect(list.children.length).toBe(3);
-      expect((list.children[0] as ContainerDocumentNode).number).toBe('1.');
-      expect((list.children[1] as ContainerDocumentNode).number).toBe('2.');
-      expect((list.children[2] as ContainerDocumentNode).number).toBe('3.');
+      expect((list.children[0] as NumberedDocumentNode).number).toBe('1.');
+      expect((list.children[1] as NumberedDocumentNode).number).toBe('2.');
+      expect((list.children[2] as NumberedDocumentNode).number).toBe('3.');
     });
 
     test('letters a lettered-list batch sequentially (a., b., c.)', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -4491,9 +4392,9 @@ describe('useTreeOperations', () => {
 
       const list = newDoc.children[0] as ContainerDocumentNode;
       expect(list.children.length).toBe(3);
-      expect((list.children[0] as ContainerDocumentNode).number).toBe('a.');
-      expect((list.children[1] as ContainerDocumentNode).number).toBe('b.');
-      expect((list.children[2] as ContainerDocumentNode).number).toBe('c.');
+      expect((list.children[0] as NumberedDocumentNode).number).toBe('a.');
+      expect((list.children[1] as NumberedDocumentNode).number).toBe('b.');
+      expect((list.children[2] as NumberedDocumentNode).number).toBe('c.');
     });
   });
 
@@ -4611,7 +4512,6 @@ describe('useTreeOperations', () => {
       test('rejects moving content directly into list', () => {
         const docWithList: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4646,7 +4546,6 @@ describe('useTreeOperations', () => {
       test('rejects moving heading directly into list', () => {
         const docWithList: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4723,7 +4622,6 @@ describe('useTreeOperations', () => {
       test('allows moving list_item to different list', () => {
         const docWithTwoLists: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4755,7 +4653,6 @@ describe('useTreeOperations', () => {
       test('allows moving content into list_item', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4789,7 +4686,6 @@ describe('useTreeOperations', () => {
       test('allows moving nested list into list_item', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4821,7 +4717,6 @@ describe('useTreeOperations', () => {
       test('rejects moving footnote directly into list', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4853,7 +4748,6 @@ describe('useTreeOperations', () => {
       test('rejects moving list directly into list (must be in list_item)', () => {
         const doc: ContainerDocumentNode = {
           id: 'root',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -4918,7 +4812,6 @@ describe('useTreeOperations', () => {
     test('returns null when move would be invalid (content to list)', () => {
       const docWithList: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -4978,7 +4871,6 @@ describe('useTreeOperations', () => {
     test('returns list id for valid list_item moves between lists', () => {
       const docWithTwoLists: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5091,7 +4983,6 @@ describe('useTreeOperations', () => {
     test('preserves an allowed format when converting content → footnote (NEWLINES is allowed on both)', () => {
       const docWithMarkdown: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5119,7 +5010,6 @@ describe('useTreeOperations', () => {
     test('resets to TEXT when converting content (MARKDOWN) → heading (MARKDOWN not allowed)', () => {
       const docWithMarkdown: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5149,7 +5039,6 @@ describe('useTreeOperations', () => {
     test('preserves NEWLINES when converting heading → content (still allowed)', () => {
       const docWithNewlines: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5179,7 +5068,6 @@ describe('useTreeOperations', () => {
     // Flat root with four siblings, used by reordering tests.
     const createFlatDocument = (): ContainerDocumentNode => ({
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -5390,7 +5278,6 @@ describe('useTreeOperations', () => {
     // Doc with two adjacent content nodes (p1, p1b) sharing parent h1, plus a heading sibling.
     const createMergeDoc = (): ContainerDocumentNode => ({
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -5450,7 +5337,6 @@ describe('useTreeOperations', () => {
       // Build doc with three content siblings under h1 (p1, pmid, p1b) so we can pick non-adjacent ones.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5507,7 +5393,6 @@ describe('useTreeOperations', () => {
     test('does nothing for image nodes', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5551,7 +5436,6 @@ describe('useTreeOperations', () => {
     test('merging content nodes preserves per-language text — empty languages are skipped', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5601,7 +5485,6 @@ describe('useTreeOperations', () => {
       // `\n\n` — otherwise the merge would visually concatenate the prose.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5635,7 +5518,6 @@ describe('useTreeOperations', () => {
     test('merging content nodes concatenates footnote children in source order', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5691,7 +5573,6 @@ describe('useTreeOperations', () => {
     test('merging two heading nodes joins contents with a single space', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5727,7 +5608,6 @@ describe('useTreeOperations', () => {
       // Headings join with whitespace, so there's no need to floor to NEWLINES — TEXT must remain valid.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5760,7 +5640,6 @@ describe('useTreeOperations', () => {
     test('merging heading nodes appends children in source order', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5811,7 +5690,6 @@ describe('useTreeOperations', () => {
     test('merging two footnote nodes joins contents with newlines and floors format to NEWLINES', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5854,7 +5732,6 @@ describe('useTreeOperations', () => {
     test('merging two list_items concatenates their children', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5884,7 +5761,6 @@ describe('useTreeOperations', () => {
     test('merging two lists concatenates list_item children', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5922,7 +5798,6 @@ describe('useTreeOperations', () => {
     test('merges three contiguous content nodes in flat order', () => {
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -5975,7 +5850,6 @@ describe('useTreeOperations', () => {
       // Those children shouldn't block the merge — they come along inside the merged container.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -6015,7 +5889,6 @@ describe('useTreeOperations', () => {
       // those children have different parents and aren't siblings to each other.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -6034,7 +5907,6 @@ describe('useTreeOperations', () => {
       // {li, li-content} → filter drops li-content → only li remains → too few to merge.
       const doc: ContainerDocumentNode = {
         id: 'root',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {

--- a/src/types/document.test.ts
+++ b/src/types/document.test.ts
@@ -1,16 +1,68 @@
 import { describe, expect, it } from 'vitest';
 import {
   ALLOWED_FORMATS,
+  type ContentDocumentNode,
   canBeChildOf,
   canHaveFormat,
   DEFAULT_FORMAT,
   DOC_TREE_VERSION,
+  type DocumentNode,
+  type DocumentRootNode,
   exampleDocument,
+  type FootnoteDocumentNode,
+  type HeadingDocumentNode,
+  type ImageDocumentNode,
   isValidDocTreeEnvelope,
   isValidDocument,
   isValidNode,
+  type ListDocumentNode,
+  type ListItemDocumentNode,
   type NodeFormat,
+  type NumberedDocumentNode,
 } from './document';
+
+/**
+ * ============================ Type-level assertions (issue #104) ============================
+ * These are erased at runtime; they are verified by `npm run typecheck` (tsc). They lock the
+ * per-node-type interface shapes so the module stays a faithful reference for the DocTree format.
+ */
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false;
+
+// Collected into one (non-exported) tuple so tsc checks them without exporting from a test module.
+type _TypeAssertions = [
+  // Each node type owns its own `type` discriminant.
+  Expect<Equal<DocumentRootNode['type'], 'DOCUMENT'>>,
+  Expect<Equal<ListDocumentNode['type'], 'LIST'>>,
+  Expect<Equal<ListItemDocumentNode['type'], 'LIST_ITEM'>>,
+  Expect<Equal<HeadingDocumentNode['type'], 'HEADING'>>,
+  Expect<Equal<ContentDocumentNode['type'], 'CONTENT'>>,
+  Expect<Equal<FootnoteDocumentNode['type'], 'FOOTNOTE'>>,
+  Expect<Equal<ImageDocumentNode['type'], 'IMAGE'>>,
+  // The document root has no `number`; every other node type does.
+  Expect<Equal<HasKey<DocumentRootNode, 'number'>, false>>,
+  Expect<Equal<HasKey<ListDocumentNode, 'number'>, true>>,
+  Expect<Equal<HasKey<HeadingDocumentNode, 'number'>, true>>,
+  Expect<Equal<HasKey<FootnoteDocumentNode, 'number'>, true>>,
+  // `DocumentNode` is the union of all seven per-type interfaces.
+  Expect<
+    Equal<
+      DocumentNode,
+      | DocumentRootNode
+      | ListDocumentNode
+      | ListItemDocumentNode
+      | HeadingDocumentNode
+      | ContentDocumentNode
+      | FootnoteDocumentNode
+      | ImageDocumentNode
+    >
+  >,
+  // `NumberedDocumentNode` is exactly the non-root nodes, and every one carries a `number`.
+  Expect<Equal<HasKey<NumberedDocumentNode, 'number'>, true>>,
+  Expect<Equal<Extract<NumberedDocumentNode, DocumentRootNode>, never>>,
+];
 
 describe('Document validation', () => {
   it('validates the example document', () => {
@@ -48,7 +100,6 @@ describe('Document validation', () => {
       expect(
         isValidDocument({
           id: '1',
-          number: null,
           type: 'DOCUMENT',
           children: [],
         })
@@ -70,7 +121,6 @@ describe('Document validation', () => {
       expect(
         isValidDocument({
           id: '1',
-          number: null,
           type: 'DOCUMENT',
           children: [
             {
@@ -129,7 +179,6 @@ describe('Document validation', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           { id: '2', number: null, type: 'CONTENT', contents: { en: 'A' }, children: [] },
@@ -143,7 +192,6 @@ describe('Document validation', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -163,7 +211,6 @@ describe('Document validation', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -197,7 +244,6 @@ describe('Document validation', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -215,7 +261,6 @@ describe('Document validation', () => {
     expect(
       isValidNode({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [],
         contents: { en: 'Should not have this' },
@@ -265,6 +310,34 @@ describe('Document validation', () => {
         number: 'i.',
         type: 'FOOTNOTE',
         children: [{ id: '2', number: null, type: 'CONTENT', contents: { en: 'Text' } }],
+      })
+    ).toBe(false);
+  });
+});
+
+describe('DOCUMENT number-field rules (issue #104)', () => {
+  it('accepts a DOCUMENT root with no number field', () => {
+    expect(isValidDocument({ id: '1', type: 'DOCUMENT', children: [] })).toBe(true);
+  });
+
+  it('rejects a DOCUMENT root carrying a real (string) number', () => {
+    expect(isValidDocument({ id: '1', number: 'X', type: 'DOCUMENT', children: [] })).toBe(false);
+  });
+
+  it('still accepts a legacy DOCUMENT root with number: null', () => {
+    // Persisted documents created before the field was removed still carry `number: null`.
+    expect(isValidDocument({ id: '1', number: null, type: 'DOCUMENT', children: [] })).toBe(true);
+  });
+
+  it('still rejects a non-DOCUMENT node that omits the number field', () => {
+    // Guards against an over-broad loosening: only the document root may drop number.
+    expect(
+      isValidNode({
+        id: '1',
+        type: 'CONTENT',
+        contents: { en: 'x' },
+        children: [],
+        format: 'TEXT',
       })
     ).toBe(false);
   });
@@ -399,7 +472,6 @@ describe('Document validation - parent-child rules', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -425,7 +497,6 @@ describe('Document validation - parent-child rules', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -445,7 +516,6 @@ describe('Document validation - parent-child rules', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -485,7 +555,6 @@ describe('Document validation - parent-child rules', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -503,7 +572,6 @@ describe('Document validation - parent-child rules', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -521,7 +589,6 @@ describe('Document validation - parent-child rules', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -577,7 +644,6 @@ describe('Document validation - parent-child rules', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -605,7 +671,6 @@ describe('Document validation - parent-child rules', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -1064,7 +1129,6 @@ describe('isValidNode — format field rules', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [],
         format: 'TEXT',
@@ -1076,7 +1140,6 @@ describe('isValidNode — format field rules', () => {
     expect(
       isValidDocument({
         id: '1',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,17 +1,192 @@
 /**
- * ================================ Document tree types ================================
+ * ============================================================================================
+ * DocTree — the tree-structured document format
+ * ============================================================================================
+ *
+ * This module is the canonical reference for the DocTree data model. It is organised as:
+ *   1. Type definitions  — the node interfaces and supporting type aliases.
+ *   2. Constants         — format allow-lists, defaults, and validation tables.
+ *   3. Functions         — `canHaveFormat`, `canBeChildOf`, and the runtime validators.
+ *   4. Example           — a small, valid document used in tests and as living documentation.
+ *
+ * A DocTree is a tree of `DocumentNode`s rooted at a single `DocumentRootNode` (`type:
+ * 'DOCUMENT'`). Only `id` and `type` are present on every node type; all other fields differ
+ * per type (see the individual interfaces below).
  */
 
-export type Language = 'en' | 'de' | 'fr' | 'it' | 'rm';
+/**
+ * ================================ 1. Type definitions ================================
+ */
+
+/**
+ * Languages a node's `contents` (and a document's `title`) may be keyed by. The runtime list is
+ * the single source of truth; the `Language` type is derived from it so the two never drift.
+ */
+export const LANGUAGES = ['en', 'de', 'fr', 'it', 'rm'] as const;
+export type Language = (typeof LANGUAGES)[number];
+
+/** Language-keyed text. Each present language holds the same content in that language. */
+export type LocalizedText = Partial<{ [K in Language]: string }>;
 
 /**
  * Per-node formatting mode. Values match the Demokratis platform spec
  * (`SCREAMING_SNAKE_CASE`) so JSON crossing the boundary needs no translation.
+ *
+ * Each level has a deterministic rendering contract (see `renderContent` and the spec at
+ * `openspec/changes/add-per-node-formatting-mode/specs/node-formatting/spec.md`):
+ *
+ * - `TEXT`             — plain text. Newlines are collapsed to a space and all HTML is escaped.
+ * - `NEWLINES`         — plain text where `\n` becomes `<br>`; all other HTML is escaped.
+ * - `MARKDOWN_MINIMAL` — single-line inline Markdown supporting only bold/italic/strike/sup/sub.
+ *                        Newlines are collapsed to a space (never preserved as `<br>`).
+ * - `MARKDOWN_INLINE`  — CommonMark inline + strike/sup/sub, no block elements, no bare HTML.
+ * - `MARKDOWN`         — full CommonMark + GFM (paragraphs, lists, tables, …) with bare HTML
+ *                        disabled (raw `<tag>` in the source is dropped, not rendered).
+ *
+ * Which levels a node may use depends on its type — see {@link ALLOWED_FORMATS}.
  */
 export type NodeFormat = 'TEXT' | 'NEWLINES' | 'MARKDOWN_MINIMAL' | 'MARKDOWN_INLINE' | 'MARKDOWN';
 
+/** Node types that carry `contents` and a `format` (i.e. anything that can hold text/an image). */
 export type ContentBearingNodeType = 'HEADING' | 'CONTENT' | 'FOOTNOTE' | 'IMAGE';
 
+/** Container-only node types: they hold `children` but no `contents`/`format` of their own. */
+export type ContainerDocumentNodeType = 'DOCUMENT' | 'LIST' | 'LIST_ITEM';
+
+/** Leaf node types: they carry `contents` but never `children`. */
+export type LeafDocumentNodeType = 'IMAGE' | 'FOOTNOTE';
+
+/**
+ * The tree root. There is exactly one per document, and — unlike every other node type — it
+ * carries no `number` (it is not a numbered element of the document) and no `contents`/`format`.
+ */
+export interface DocumentRootNode {
+  id: string;
+  type: 'DOCUMENT';
+  // Runtime validation restricts the allowed child types (see ALLOWED_CHILDREN). Tightening this
+  // field's type to the exact child union is tracked as a follow-up to issue #104 (point 3).
+  children: DocumentNode[];
+}
+
+/** An ordered or unordered list. Its children are exclusively `LIST_ITEM` nodes (enforced at runtime). */
+export interface ListDocumentNode {
+  id: string;
+  number: string | null;
+  type: 'LIST';
+  // See note on DocumentRootNode.children — child types are enforced at runtime, not yet in the type.
+  children: DocumentNode[];
+}
+
+/** A single item within a `LIST`. Its own text lives in a child `CONTENT` node. */
+export interface ListItemDocumentNode {
+  id: string;
+  number: string | null;
+  type: 'LIST_ITEM';
+  // See note on DocumentRootNode.children.
+  children: DocumentNode[];
+}
+
+/** A heading. Has both content and children because headings define the document's structure. */
+export interface HeadingDocumentNode {
+  id: string;
+  number: string | null;
+  type: 'HEADING';
+  contents: LocalizedText;
+  format: NodeFormat;
+  // See note on DocumentRootNode.children.
+  children: DocumentNode[];
+}
+
+/**
+ * A block of content (e.g. a paragraph). Has text and may carry `FOOTNOTE` children only
+ * (enforced at runtime), making it a hybrid of a content node and a container.
+ */
+export interface ContentDocumentNode {
+  id: string;
+  number: string | null;
+  type: 'CONTENT';
+  contents: LocalizedText;
+  format: NodeFormat;
+  // Runtime validation allows only FOOTNOTE children here (see ALLOWED_CHILDREN). See the note
+  // on DocumentRootNode.children regarding tightening this type.
+  children: DocumentNode[];
+}
+
+/** A footnote. A leaf: it has text but no children. */
+export interface FootnoteDocumentNode {
+  id: string;
+  number: string | null;
+  type: 'FOOTNOTE';
+  contents: LocalizedText;
+  format: NodeFormat;
+}
+
+/** An image. A leaf: `contents` holds the source/alt text, keyed by language. */
+export interface ImageDocumentNode {
+  id: string;
+  number: string | null;
+  type: 'IMAGE';
+  contents: LocalizedText;
+  format: NodeFormat;
+}
+
+/** Any node in a DocTree, including the tree root. */
+export type DocumentNode =
+  | DocumentRootNode
+  | ListDocumentNode
+  | ListItemDocumentNode
+  | HeadingDocumentNode
+  | ContentDocumentNode
+  | FootnoteDocumentNode
+  | ImageDocumentNode;
+
+/**
+ * Any node that carries a `number` — i.e. every node type except the tree root. The root is the
+ * only node without a number, so this is exactly the set of nodes one can read `.number` from.
+ */
+export type NumberedDocumentNode = Exclude<DocumentNode, DocumentRootNode>;
+
+/**
+ * Convenience grouping alias for the container-only node types (tree root + list structure);
+ * matches the previous `ContainerDocumentNode` membership exactly. Prefer the specific per-type
+ * interfaces in new code — consumers are migrated off this alias in the follow-up to issue #104.
+ */
+export type ContainerDocumentNode = DocumentRootNode | ListDocumentNode | ListItemDocumentNode;
+
+/**
+ * Convenience grouping alias for the leaf node types. Prefer {@link FootnoteDocumentNode} or
+ * {@link ImageDocumentNode} directly in new code.
+ */
+export type LeafDocumentNode = FootnoteDocumentNode | ImageDocumentNode;
+
+/** A node type that may legally contain children, plus `null` for the document's root level. */
+export type ParentType = ContainerDocumentNodeType | 'HEADING' | 'CONTENT' | null;
+
+/**
+ * Versioned wrapper around an exported document tree. Lets the export format evolve (and later
+ * carry attachments or other metadata) without breaking downstream consumers.
+ */
+export interface DocTreeMetadata {
+  title: LocalizedText;
+}
+
+export interface DocTreeEnvelope {
+  DocTreeVersion: typeof DOC_TREE_VERSION;
+  metadata: DocTreeMetadata;
+  // The deprecated `ContainerDocumentNode` alias still includes the document root; the app-wide
+  // document type is migrated to `DocumentRootNode` as part of the deferred follow-up to #104.
+  document: ContainerDocumentNode;
+}
+
+/**
+ * ================================ 2. Constants ================================
+ */
+
+/**
+ * Allowed formats per content-bearing node type — the single source of truth used by validation,
+ * the renderer, and the UI. Headings are single-line, so they top out at `MARKDOWN_MINIMAL`;
+ * images carry no rich text, so they allow only `TEXT`/`NEWLINES`.
+ */
 export const ALLOWED_FORMATS: Record<ContentBearingNodeType, NodeFormat[]> = {
   HEADING: ['TEXT', 'NEWLINES', 'MARKDOWN_MINIMAL'],
   CONTENT: ['TEXT', 'NEWLINES', 'MARKDOWN'],
@@ -19,6 +194,7 @@ export const ALLOWED_FORMATS: Record<ContentBearingNodeType, NodeFormat[]> = {
   IMAGE: ['TEXT', 'NEWLINES'],
 };
 
+/** Default format assigned to each content-bearing node type at creation/import. */
 export const DEFAULT_FORMAT: Record<ContentBearingNodeType, NodeFormat> = {
   HEADING: 'TEXT',
   CONTENT: 'TEXT',
@@ -26,112 +202,8 @@ export const DEFAULT_FORMAT: Record<ContentBearingNodeType, NodeFormat> = {
   IMAGE: 'TEXT',
 };
 
-export const canHaveFormat = (nodeType: ContentBearingNodeType, format: NodeFormat): boolean => {
-  const allowed = ALLOWED_FORMATS[nodeType];
-  return Array.isArray(allowed) && allowed.includes(format);
-};
+export const DOC_TREE_VERSION = 1 as const;
 
-/**
- * Container-only nodes have children but no content of their own.
- */
-export type ContainerDocumentNodeType =
-  | 'DOCUMENT' // Tree root
-  | 'LIST'
-  | 'LIST_ITEM'; // List item container; text content goes in child 'CONTENT' node
-
-export interface ContainerDocumentNode {
-  id: string;
-  number: string | null;
-  type: ContainerDocumentNodeType;
-  children: DocumentNode[];
-}
-
-/**
- * Leaf-only nodes have content but no children.
- */
-export type LeafDocumentNodeType = 'IMAGE' | 'FOOTNOTE';
-
-export interface LeafDocumentNode {
-  id: string;
-  number: string | null;
-  type: LeafDocumentNodeType;
-  contents: Partial<{ [K in Language]: string }>;
-  format: NodeFormat;
-}
-
-/**
- * Heading nodes have both content and children because they define the tree structure.
- */
-export interface HeadingDocumentNode {
-  id: string;
-  number: string | null;
-  type: 'HEADING';
-  contents: Partial<{ [K in Language]: string }>;
-  children: DocumentNode[];
-  format: NodeFormat;
-}
-
-/**
- * Content nodes have both content and optional footnote children.
- * Similar to heading, but can only contain footnote nodes as children.
- */
-export interface ContentDocumentNode {
-  id: string;
-  number: string | null;
-  type: 'CONTENT';
-  contents: Partial<{ [K in Language]: string }>;
-  children: DocumentNode[]; // Can only contain FOOTNOTE nodes
-  format: NodeFormat;
-}
-
-export type DocumentNode =
-  | ContainerDocumentNode
-  | LeafDocumentNode
-  | HeadingDocumentNode
-  | ContentDocumentNode;
-
-/**
- * ================================ Example ================================
- */
-
-export const exampleDocument: ContainerDocumentNode = {
-  id: '001',
-  number: null,
-  type: 'DOCUMENT',
-  children: [
-    {
-      id: '002',
-      number: '1',
-      type: 'HEADING',
-      contents: { en: 'Introduction' },
-      format: 'TEXT',
-      children: [
-        {
-          id: '003',
-          number: null,
-          type: 'CONTENT',
-          contents: { en: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' },
-          format: 'TEXT',
-          children: [
-            {
-              id: '004',
-              number: 'i.',
-              type: 'FOOTNOTE',
-              contents: { en: 'This is a footnote.', de: 'Dies ist eine Fussnote.' },
-              format: 'TEXT',
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
-
-/**
- * ================================ Validation ================================
- */
-
-const VALID_LANGUAGES: Language[] = ['en', 'de', 'fr', 'it', 'rm'];
 const CONTAINER_TYPES: ContainerDocumentNodeType[] = ['DOCUMENT', 'LIST', 'LIST_ITEM'];
 const LEAF_TYPES: LeafDocumentNodeType[] = ['IMAGE', 'FOOTNOTE'];
 const VALID_FORMATS: NodeFormat[] = [
@@ -142,9 +214,7 @@ const VALID_FORMATS: NodeFormat[] = [
   'MARKDOWN',
 ];
 
-/**
- * Mapping of parent types to their allowed child types.
- */
+/** Mapping of parent types to their allowed child types. */
 const ALLOWED_CHILDREN: Record<
   ContainerDocumentNodeType | 'HEADING' | 'CONTENT',
   DocumentNode['type'][]
@@ -156,11 +226,17 @@ const ALLOWED_CHILDREN: Record<
   CONTENT: ['FOOTNOTE'],
 };
 
-export type ParentType = ContainerDocumentNodeType | 'HEADING' | 'CONTENT' | null;
-
 /**
- * Check if a node type can be a valid child of a parent type.
+ * ================================ 3. Functions ================================
  */
+
+/** Whether a content-bearing node type may use a given format (see {@link ALLOWED_FORMATS}). */
+export const canHaveFormat = (nodeType: ContentBearingNodeType, format: NodeFormat): boolean => {
+  const allowed = ALLOWED_FORMATS[nodeType];
+  return Array.isArray(allowed) && allowed.includes(format);
+};
+
+/** Check if a node type can be a valid child of a parent type. */
 export const canBeChildOf = (childType: DocumentNode['type'], parentType: ParentType): boolean => {
   // Root level (null parent) uses DOCUMENT rules
   const effectiveParentType = parentType ?? 'DOCUMENT';
@@ -168,11 +244,11 @@ export const canBeChildOf = (childType: DocumentNode['type'], parentType: Parent
   return allowedChildren?.includes(childType) ?? false;
 };
 
-const isValidContents = (contents: unknown): contents is Partial<{ [K in Language]: string }> => {
+const isValidContents = (contents: unknown): contents is LocalizedText => {
   if (typeof contents !== 'object' || contents === null) return false;
   const c = contents as Record<string, unknown>;
   return Object.keys(c).every(
-    (key) => VALID_LANGUAGES.includes(key as Language) && typeof c[key] === 'string'
+    (key) => LANGUAGES.includes(key as Language) && typeof c[key] === 'string'
   );
 };
 
@@ -184,16 +260,24 @@ const isValidNodeInternal = (
   if (typeof obj !== 'object' || obj === null) return false;
   const node = obj as Record<string, unknown>;
 
-  // Check common fields
+  // Check common fields (id and type are the only fields present on every node type).
   if (typeof node.id !== 'string') return false;
-  if (node.number !== null && typeof node.number !== 'string') return false;
   if (typeof node.type !== 'string') return false;
+
+  const type = node.type as DocumentNode['type'];
+
+  // The document root carries no number; tolerate an explicit null for documents persisted
+  // before the field was removed, but reject any other value. Every other node type still
+  // requires a number field (null or a string label).
+  if (type === 'DOCUMENT') {
+    if ('number' in node && node.number !== null) return false;
+  } else {
+    if (node.number !== null && typeof node.number !== 'string') return false;
+  }
 
   // Check for duplicate ids
   if (seenIds.has(node.id)) return false;
   seenIds.add(node.id);
-
-  const type = node.type as DocumentNode['type'];
 
   // Check parent-child relationship
   if (parentType !== null && !canBeChildOf(type, parentType)) return false;
@@ -246,29 +330,11 @@ export const isValidNode = (obj: unknown): obj is DocumentNode => {
   return isValidNodeInternal(obj, null, new Set());
 };
 
-export const isValidDocument = (obj: unknown): obj is DocumentNode => {
-  return (obj as any)?.type === 'DOCUMENT' && isValidNodeInternal(obj, null, new Set());
+export const isValidDocument = (obj: unknown): obj is DocumentRootNode => {
+  return (
+    (obj as { type?: unknown })?.type === 'DOCUMENT' && isValidNodeInternal(obj, null, new Set())
+  );
 };
-
-/**
- * ================================ DocTree envelope ================================
- *
- * Versioned wrapper around an exported document tree. Lets the export format
- * evolve (and later carry attachments or other metadata) without breaking
- * downstream consumers.
- */
-
-export const DOC_TREE_VERSION = 1 as const;
-
-export interface DocTreeMetadata {
-  title: Partial<{ [K in Language]: string }>;
-}
-
-export interface DocTreeEnvelope {
-  DocTreeVersion: typeof DOC_TREE_VERSION;
-  metadata: DocTreeMetadata;
-  document: ContainerDocumentNode;
-}
 
 export const isValidDocTreeEnvelope = (obj: unknown): obj is DocTreeEnvelope => {
   if (typeof obj !== 'object' || obj === null) return false;
@@ -280,4 +346,40 @@ export const isValidDocTreeEnvelope = (obj: unknown): obj is DocTreeEnvelope => 
   if (!isValidContents(metadata.title)) return false;
   if (!isValidDocument(env.document)) return false;
   return true;
+};
+
+/**
+ * ================================ 4. Example ================================
+ */
+
+export const exampleDocument: DocumentRootNode = {
+  id: '001',
+  type: 'DOCUMENT',
+  children: [
+    {
+      id: '002',
+      number: '1',
+      type: 'HEADING',
+      contents: { en: 'Introduction' },
+      format: 'TEXT',
+      children: [
+        {
+          id: '003',
+          number: null,
+          type: 'CONTENT',
+          contents: { en: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' },
+          format: 'TEXT',
+          children: [
+            {
+              id: '004',
+              number: 'i.',
+              type: 'FOOTNOTE',
+              contents: { en: 'This is a footnote.', de: 'Dies ist eine Fussnote.' },
+              format: 'TEXT',
+            },
+          ],
+        },
+      ],
+    },
+  ],
 };

--- a/src/utils/document-storage-migrations.test.ts
+++ b/src/utils/document-storage-migrations.test.ts
@@ -144,7 +144,6 @@ describe('document-storage-migrations', () => {
       // hand-edit in storage) should still produce a fully-upgraded valid tree.
       const v1 = makeV1Entry({
         id: 'r',
-        number: null,
         type: 'DOCUMENT',
         children: [
           {
@@ -166,7 +165,7 @@ describe('document-storage-migrations', () => {
   describe('passthrough and incompatibility', () => {
     it('passes through a v2 record unchanged', () => {
       const v2 = {
-        ...makeV1Entry({ id: 'r', number: null, type: 'DOCUMENT', children: [] }),
+        ...makeV1Entry({ id: 'r', type: 'DOCUMENT', children: [] }),
         schemaVersion: 2,
       };
       const out = migrateEntry(v2);

--- a/src/utils/document-storage.test.ts
+++ b/src/utils/document-storage.test.ts
@@ -18,7 +18,6 @@ import {
 function makeTree(text = 'hello'): ContainerDocumentNode {
   return {
     id: 'root',
-    number: null,
     type: 'DOCUMENT',
     children: [
       {
@@ -341,7 +340,7 @@ describe('document-storage', () => {
         name: 'futuristic.docx',
         subtitle: null,
         language: 'de',
-        tree: { id: 'r', number: null, type: 'DOCUMENT', children: [] },
+        tree: { id: 'r', type: 'DOCUMENT', children: [] },
         source: {
           kind: 'docx',
           mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -371,7 +370,7 @@ describe('document-storage', () => {
         name: 'futuristic.docx',
         subtitle: null,
         language: 'de',
-        tree: { id: 'r', number: null, type: 'DOCUMENT', children: [] },
+        tree: { id: 'r', type: 'DOCUMENT', children: [] },
         source: {
           kind: 'docx',
           mime: 'application/octet-stream',

--- a/src/utils/document-utils.test.ts
+++ b/src/utils/document-utils.test.ts
@@ -7,6 +7,7 @@ import {
   type HeadingDocumentNode,
   isValidDocTreeEnvelope,
   type LeafDocumentNode,
+  type NumberedDocumentNode,
 } from '../types/document';
 import {
   buildDocTreeEnvelope,
@@ -35,7 +36,6 @@ describe('deriveJsonFilename', () => {
 describe('buildDocTreeEnvelope', () => {
   const tree: ContainerDocumentNode = {
     id: 'root',
-    number: null,
     type: 'DOCUMENT',
     children: [
       {
@@ -219,7 +219,7 @@ describe('Document Utils', () => {
       expect(list.children.length).toBe(2);
       const item1 = list.children[0] as ContainerDocumentNode;
       expect(item1.type).toBe('LIST_ITEM');
-      expect(item1.number).toBeNull(); // ul has no numbering
+      expect((item1 as NumberedDocumentNode).number).toBeNull(); // ul has no numbering
       // Content is now in a child content node
       const item1Content = item1.children[0] as LeafDocumentNode;
       expect(item1Content.type).toBe('CONTENT');
@@ -233,12 +233,12 @@ describe('Document Utils', () => {
       expect(list.type).toBe('LIST');
       const item1 = list.children[0] as ContainerDocumentNode;
       expect(item1.type).toBe('LIST_ITEM');
-      expect(item1.number).toBe('1.');
+      expect((item1 as NumberedDocumentNode).number).toBe('1.');
       // Content is now in a child content node
       const item1Content = item1.children[0] as LeafDocumentNode;
       expect(item1Content.type).toBe('CONTENT');
       const item2 = list.children[1] as ContainerDocumentNode;
-      expect(item2.number).toBe('2.');
+      expect((item2 as NumberedDocumentNode).number).toBe('2.');
     });
 
     it('uses list-style-type for numbering when present', () => {
@@ -251,11 +251,11 @@ describe('Document Utils', () => {
       const list = doc.children[0] as ContainerDocumentNode;
       expect(list.type).toBe('LIST');
       const item1 = list.children[0] as ContainerDocumentNode;
-      expect(item1.number).toBe('a)');
+      expect((item1 as NumberedDocumentNode).number).toBe('a)');
       const item2 = list.children[1] as ContainerDocumentNode;
-      expect(item2.number).toBe('b)');
+      expect((item2 as NumberedDocumentNode).number).toBe('b)');
       const item3 = list.children[2] as ContainerDocumentNode;
-      expect(item3.number).toBe('c)');
+      expect((item3 as NumberedDocumentNode).number).toBe('c)');
     });
 
     it('converts nested ol lists into nested list structure', () => {
@@ -291,7 +291,7 @@ describe('Document Utils', () => {
 
       const nestedItem1 = nestedList.children[0] as ContainerDocumentNode;
       expect(nestedItem1.type).toBe('LIST_ITEM');
-      expect(nestedItem1.number).toBe('1.');
+      expect((nestedItem1 as NumberedDocumentNode).number).toBe('1.');
       const nestedItem1Content = nestedItem1.children[0] as ContentDocumentNode;
       expect(nestedItem1Content.type).toBe('CONTENT');
       expect(nestedItem1Content.contents.de).toContain('die öffentliche Volksschule');
@@ -669,7 +669,7 @@ describe('Document Utils', () => {
       expect(list.type).toBe('LIST');
       const item1 = list.children[0] as ContainerDocumentNode;
       expect(item1.type).toBe('LIST_ITEM');
-      expect(item1.number).toBe('a.');
+      expect((item1 as NumberedDocumentNode).number).toBe('a.');
       // Content is now in a child content node
       const item1Content = item1.children[0] as LeafDocumentNode;
       expect(item1Content.type).toBe('CONTENT');
@@ -793,10 +793,10 @@ describe('Document Utils', () => {
       collectLists(doc);
       // The second list should be the ol with a), b) items
       const olList = allLists.find((l) =>
-        l.children.some((c) => (c as ContainerDocumentNode).number === 'a)')
+        l.children.some((c) => (c as NumberedDocumentNode).number === 'a)')
       );
       expect(olList).toBeDefined();
-      const items = olList!.children as ContainerDocumentNode[];
+      const items = olList!.children as NumberedDocumentNode[];
       expect(items[0].number).toBe('a)');
       expect(items[1].number).toBe('b)');
     });
@@ -860,14 +860,13 @@ describe('isEmptyDocument', () => {
   };
 
   it('returns true for a DOCUMENT with no children', () => {
-    const doc: ContainerDocumentNode = { id: 'root', number: null, type: 'DOCUMENT', children: [] };
+    const doc: ContainerDocumentNode = { id: 'root', type: 'DOCUMENT', children: [] };
     expect(isEmptyDocument(doc)).toBe(true);
   });
 
   it('returns true for a tree whose only nodes carry no text', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -902,7 +901,6 @@ describe('isEmptyDocument', () => {
     // `contents` empty — that is still real content, not an empty import.
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {

--- a/src/utils/document-utils.ts
+++ b/src/utils/document-utils.ts
@@ -5,6 +5,7 @@ import {
   DOC_TREE_VERSION,
   type DocTreeEnvelope,
   type DocumentNode,
+  type DocumentRootNode,
   type HeadingDocumentNode,
   type Language,
   type NodeFormat,
@@ -88,8 +89,8 @@ export const preserveListStyleType = (html: string): string => {
 export const isEmptyDocument = (doc: ContainerDocumentNode): boolean => {
   const hasText = (node: DocumentNode): boolean => {
     // A label like "Art. 5" or "I." that legal transforms moved into `number` is
-    // still real content even when `contents` is empty.
-    if (typeof node.number === 'string' && node.number.trim().length > 0) {
+    // still real content even when `contents` is empty. (The document root has no `number`.)
+    if ('number' in node && typeof node.number === 'string' && node.number.trim().length > 0) {
       return true;
     }
     if ('contents' in node && node.contents) {
@@ -146,9 +147,8 @@ export const parseHtmlToTree = (
   const parser = new DOMParser();
   const doc = parser.parseFromString(cleanHtml, 'text/html');
 
-  const root: ContainerDocumentNode = {
+  const root: DocumentRootNode = {
     id: generateId(),
-    number: null,
     type: 'DOCUMENT',
     children: [],
   };

--- a/src/utils/file-processing.integration.test.ts
+++ b/src/utils/file-processing.integration.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-import type { DocumentNode } from '../types/document';
+import type { DocumentNode, NumberedDocumentNode } from '../types/document';
 import { processDocxFile } from './file-processing';
 
 const FIXTURE_DIR = path.join(__dirname, '../test/fixtures/realistic/docx/without_table');
@@ -132,10 +132,14 @@ describe('file-processing integration', () => {
       // Find the converted Absätze by text. Each was a <li><sup>N</sup>…</li> in the
       // Mammoth HTML; after the fix it must be a `content` node, not a `list_item`.
       const lorem1 = contentNodes.find(
-        (c) => textOf(c).startsWith('Lorem ipsum dolor sit amet') && c.number === '^1^'
+        (c) =>
+          textOf(c).startsWith('Lorem ipsum dolor sit amet') &&
+          (c as NumberedDocumentNode).number === '^1^'
       );
       const lorem3 = contentNodes.find(
-        (c) => textOf(c) === 'Lorem ipsum dolor sit amet.' && c.number === '^3^'
+        (c) =>
+          textOf(c) === 'Lorem ipsum dolor sit amet.' &&
+          (c as NumberedDocumentNode).number === '^3^'
       );
       expect(lorem1).toBeDefined();
       expect(lorem3).toBeDefined();
@@ -145,7 +149,7 @@ describe('file-processing integration', () => {
       // The converted content node's number is the raw markdown source `^N^`. When
       // rendered through NumberMarkup (MARKDOWN_MINIMAL), this becomes <sup>N</sup>.
       const absatzNumbers = contentNodes
-        .map((c) => c.number)
+        .map((c) => (c as NumberedDocumentNode).number)
         .filter((n): n is string => typeof n === 'string' && /^\^\d+(?:bis|ter)?\^$/.test(n));
 
       // Three Absätze convert (Art. 1 Abs. 1 / 3, Art. 2 Abs. 2). The other two
@@ -186,7 +190,9 @@ describe('file-processing integration', () => {
       // The simple Absätze ("Lorem ipsum dolor sit amet.") have no other marks, so
       // their format must downgrade from MARKDOWN to TEXT.
       const plainAbsatz = contentNodes.find(
-        (c) => textOf(c) === 'Lorem ipsum dolor sit amet.' && c.number === '^3^'
+        (c) =>
+          textOf(c) === 'Lorem ipsum dolor sit amet.' &&
+          (c as NumberedDocumentNode).number === '^3^'
       );
       expect(plainAbsatz).toBeDefined();
       expect('format' in plainAbsatz! && plainAbsatz.format).toBe('TEXT');
@@ -195,12 +201,12 @@ describe('file-processing integration', () => {
     // Issue #89: the bold `**I.**` and italic `*Art. 1 Lorem ipsum*` paragraphs
     // in the fixture must be promoted to headings by the legal transforms.
     it('detects the top-level Roman numeral section `I.` as a heading', () => {
-      const romanSection = headings.find((h) => h.number === 'I.');
+      const romanSection = headings.find((h) => (h as NumberedDocumentNode).number === 'I.');
       expect(romanSection).toBeDefined();
     });
 
     it('detects `Art. 1 Lorem ipsum` as an article heading', () => {
-      const article = headings.find((h) => h.number === 'Art. 1');
+      const article = headings.find((h) => (h as NumberedDocumentNode).number === 'Art. 1');
       expect(article).toBeDefined();
       expect(textOf(article!)).toBe('Lorem ipsum');
     });

--- a/src/utils/file-processing.ts
+++ b/src/utils/file-processing.ts
@@ -37,7 +37,6 @@ export function createPlainTextDocument(text: string): ContainerDocumentNode {
   const lines = text.split('\n').filter((line) => line.trim().length > 0);
   return {
     id: generateId(),
-    number: null,
     type: 'DOCUMENT',
     children:
       lines.length > 0

--- a/src/utils/legal-transforms/heading-number-extract.test.ts
+++ b/src/utils/legal-transforms/heading-number-extract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { HeadingDocumentNode } from '../../types/document';
+import type { HeadingDocumentNode, NumberedDocumentNode } from '../../types/document';
 import { headingNumberExtractTransform } from './heading-number-extract';
 import { content, createDoc, heading } from './test-helpers';
 
@@ -122,6 +122,6 @@ describe('headingNumberExtractTransform', () => {
     const result = headingNumberExtractTransform(input, 'de');
 
     expect(result.children[0].type).toBe('CONTENT');
-    expect(result.children[0].number).toBeNull();
+    expect((result.children[0] as NumberedDocumentNode).number).toBeNull();
   });
 });

--- a/src/utils/legal-transforms/index.test.ts
+++ b/src/utils/legal-transforms/index.test.ts
@@ -3,6 +3,7 @@ import type {
   ContainerDocumentNode,
   ContentDocumentNode,
   HeadingDocumentNode,
+  NumberedDocumentNode,
 } from '../../types/document';
 import { applySwissLegalTransforms, composeTransforms } from './index';
 import { content, createDoc, heading, list } from './test-helpers';
@@ -95,8 +96,8 @@ describe('applySwissLegalTransforms', () => {
     // List should have 2 items
     const list = article.children[0] as ContainerDocumentNode;
     expect(list.children).toHaveLength(2);
-    expect(list.children[0].number).toBe('a.');
-    expect(list.children[1].number).toBe('b.');
+    expect((list.children[0] as NumberedDocumentNode).number).toBe('a.');
+    expect((list.children[1] as NumberedDocumentNode).number).toBe('b.');
   });
 
   it('respects config to disable romanSections', () => {
@@ -171,7 +172,12 @@ describe('applySwissLegalTransforms', () => {
 
     expect(result.children).toHaveLength(1);
     const merged = result.children[0] as ContainerDocumentNode;
-    expect(merged.children.map((c) => c.number)).toEqual(['a)', 'b)', 'a)', 'b)']);
+    expect(merged.children.map((c) => (c as NumberedDocumentNode).number)).toEqual([
+      'a)',
+      'b)',
+      'a)',
+      'b)',
+    ]);
   });
 
   it('handles complex nested structure', () => {

--- a/src/utils/legal-transforms/lettered-items.test.ts
+++ b/src/utils/legal-transforms/lettered-items.test.ts
@@ -3,6 +3,7 @@ import type {
   ContainerDocumentNode,
   ContentDocumentNode,
   HeadingDocumentNode,
+  NumberedDocumentNode,
 } from '../../types/document';
 import { letteredItemsTransform } from './lettered-items';
 import { content, createDoc, heading, list } from './test-helpers';
@@ -24,7 +25,7 @@ describe('letteredItemsTransform', () => {
     const result = letteredItemsTransform(input, 'de');
 
     const listNode = result.children[0] as ContainerDocumentNode;
-    expect(listNode.children[0].number).toBe('a.');
+    expect((listNode.children[0] as NumberedDocumentNode).number).toBe('a.');
   });
 
   it('strips letter prefix from content', () => {
@@ -180,8 +181,8 @@ describe('letteredItemsTransform', () => {
 
     const listNode = result.children[0] as ContainerDocumentNode;
     expect(listNode.children).toHaveLength(4);
-    expect(listNode.children[0].number).toBe('a.');
-    expect(listNode.children[3].number).toBe('z.');
+    expect((listNode.children[0] as NumberedDocumentNode).number).toBe('a.');
+    expect((listNode.children[3] as NumberedDocumentNode).number).toBe('z.');
   });
 
   it('creates list_item with content child', () => {

--- a/src/utils/legal-transforms/list-number-dedup.test.ts
+++ b/src/utils/legal-transforms/list-number-dedup.test.ts
@@ -4,6 +4,7 @@ import {
   type ContentDocumentNode,
   type HeadingDocumentNode,
   isValidDocument,
+  type NumberedDocumentNode,
 } from '../../types/document';
 import { generateId, parseHtmlToTree } from '../document-utils';
 import { listNumberDedupTransform } from './list-number-dedup';
@@ -21,8 +22,8 @@ describe('listNumberDedupTransform', () => {
     const result = listNumberDedupTransform(input, 'de');
 
     const listNode = result.children[0] as ContainerDocumentNode;
-    expect(listNode.children[0].number).toBe('1');
-    expect(listNode.children[1].number).toBe('2');
+    expect((listNode.children[0] as NumberedDocumentNode).number).toBe('1');
+    expect((listNode.children[1] as NumberedDocumentNode).number).toBe('2');
   });
 
   it('strips number prefix from content text', () => {
@@ -89,8 +90,8 @@ describe('listNumberDedupTransform', () => {
     const result = listNumberDedupTransform(input, 'de');
 
     const listNode = result.children[0] as ContainerDocumentNode;
-    expect(listNode.children[0].number).toBe('1.');
-    expect(listNode.children[1].number).toBe('2.');
+    expect((listNode.children[0] as NumberedDocumentNode).number).toBe('1.');
+    expect((listNode.children[1] as NumberedDocumentNode).number).toBe('2.');
 
     const content0 = (listNode.children[0] as ContainerDocumentNode)
       .children[0] as ContentDocumentNode;
@@ -109,9 +110,9 @@ describe('listNumberDedupTransform', () => {
     const result = listNumberDedupTransform(input, 'de');
 
     const listNode = result.children[0] as ContainerDocumentNode;
-    expect(listNode.children[0].number).toBe('1');
-    expect(listNode.children[1].number).toBe('1bis');
-    expect(listNode.children[2].number).toBe('2');
+    expect((listNode.children[0] as NumberedDocumentNode).number).toBe('1');
+    expect((listNode.children[1] as NumberedDocumentNode).number).toBe('1bis');
+    expect((listNode.children[2] as NumberedDocumentNode).number).toBe('2');
   });
 
   it('applies recursively to nested structures', () => {
@@ -128,8 +129,8 @@ describe('listNumberDedupTransform', () => {
 
     const h = result.children[0] as HeadingDocumentNode;
     const listNode = h.children[0] as ContainerDocumentNode;
-    expect(listNode.children[0].number).toBe('1');
-    expect(listNode.children[1].number).toBe('2');
+    expect((listNode.children[0] as NumberedDocumentNode).number).toBe('1');
+    expect((listNode.children[1] as NumberedDocumentNode).number).toBe('2');
   });
 
   it('preserves non-list nodes unchanged', () => {
@@ -187,14 +188,14 @@ describe('listNumberDedupTransform', () => {
     const outerItem = outerList.children[0] as ContainerDocumentNode;
 
     // Outer item should be deduped
-    expect(outerItem.number).toBe('1');
+    expect((outerItem as NumberedDocumentNode).number).toBe('1');
     const outerContent = outerItem.children[0] as ContentDocumentNode;
     expect(outerContent.contents.de).toBe('Outer text');
 
     // Inner list should also be deduped
     const innerList = outerItem.children[1] as ContainerDocumentNode;
-    expect(innerList.children[0].number).toBe('1');
-    expect(innerList.children[1].number).toBe('2');
+    expect((innerList.children[0] as NumberedDocumentNode).number).toBe('1');
+    expect((innerList.children[1] as NumberedDocumentNode).number).toBe('2');
 
     const innerContent0 = (innerList.children[0] as ContainerDocumentNode)
       .children[0] as ContentDocumentNode;
@@ -231,7 +232,7 @@ describe('listNumberDedupTransform', () => {
     // The nested list should still be processed
     const innerList = outerItem.children[0] as ContainerDocumentNode;
     expect(innerList.type).toBe('LIST');
-    expect(innerList.children[0].number).toBe('1');
+    expect((innerList.children[0] as NumberedDocumentNode).number).toBe('1');
   });
 
   it('preserves the document id', () => {
@@ -372,7 +373,7 @@ describe('listNumberDedupTransform', () => {
 
       const firstList = result.children[0] as ContainerDocumentNode;
       expect(firstList.children).toHaveLength(1);
-      expect((firstList.children[0] as ContainerDocumentNode).number).toBe('1.');
+      expect((firstList.children[0] as NumberedDocumentNode).number).toBe('1.');
 
       const absatz = result.children[1] as ContentDocumentNode;
       expect(absatz.number).toBe('^2^');
@@ -380,7 +381,7 @@ describe('listNumberDedupTransform', () => {
 
       const secondList = result.children[2] as ContainerDocumentNode;
       expect(secondList.children).toHaveLength(1);
-      expect((secondList.children[0] as ContainerDocumentNode).number).toBe('3.');
+      expect((secondList.children[0] as NumberedDocumentNode).number).toBe('3.');
       expect(isValidDocument(result)).toBe(true);
     });
 
@@ -424,7 +425,7 @@ describe('listNumberDedupTransform', () => {
       expect(outerList.type).toBe('LIST');
       const li = outerList.children[0] as ContainerDocumentNode;
       expect(li.type).toBe('LIST_ITEM');
-      expect(li.number).toBe('1');
+      expect((li as NumberedDocumentNode).number).toBe('1');
       const content = li.children[0] as ContentDocumentNode;
       expect(content.type).toBe('CONTENT');
       expect(content.contents.de).toBe('Absatz with sublist');

--- a/src/utils/legal-transforms/list-number-dedup.ts
+++ b/src/utils/legal-transforms/list-number-dedup.ts
@@ -4,6 +4,7 @@ import type {
   DocumentNode,
   HeadingDocumentNode,
   Language,
+  ListItemDocumentNode,
   NodeFormat,
 } from '../../types/document';
 import { generateId } from '../document-utils';
@@ -41,10 +42,10 @@ function downgradeFormatIfPlain(source: string, format: NodeFormat): NodeFormat 
  * because the leading <sup>N</sup> marks it as an Absatznummer.
  */
 type ProcessedListItem =
-  | { kind: 'LIST_ITEM'; node: ContainerDocumentNode }
+  | { kind: 'LIST_ITEM'; node: DocumentNode }
   | { kind: 'CONTENT'; node: ContentDocumentNode };
 
-function processListItem(listItem: ContainerDocumentNode, language: Language): ProcessedListItem {
+function processListItem(listItem: ListItemDocumentNode, language: Language): ProcessedListItem {
   if (listItem.children.length === 0) {
     return { kind: 'LIST_ITEM', node: listItem };
   }
@@ -144,13 +145,14 @@ function processListItem(listItem: ContainerDocumentNode, language: Language): P
 function processList(listNode: ContainerDocumentNode, language: Language): DocumentNode[] {
   const processed = listNode.children.map((item): ProcessedListItem => {
     if (item.type !== 'LIST_ITEM') {
-      return { kind: 'LIST_ITEM', node: item as ContainerDocumentNode };
+      return { kind: 'LIST_ITEM', node: item };
     }
-    return processListItem(item as ContainerDocumentNode, language);
+    // `item` is narrowed to the LIST_ITEM member of the DocumentNode union here.
+    return processListItem(item, language);
   });
 
   const result: DocumentNode[] = [];
-  let buffer: ContainerDocumentNode[] = [];
+  let buffer: DocumentNode[] = [];
   let firstSegment = true;
 
   const flush = () => {

--- a/src/utils/legal-transforms/merge-adjacent-lists.test.ts
+++ b/src/utils/legal-transforms/merge-adjacent-lists.test.ts
@@ -3,6 +3,7 @@ import type {
   ContainerDocumentNode,
   ContentDocumentNode,
   HeadingDocumentNode,
+  NumberedDocumentNode,
 } from '../../types/document';
 import { parseHtmlLegalToTree, parseHtmlToTree } from '../document-utils';
 import { mergeAdjacentListsTransform } from './merge-adjacent-lists';
@@ -199,7 +200,7 @@ describe('mergeAdjacentListsTransform', () => {
       const result = mergeAdjacentListsTransform(input, 'de');
 
       const merged = result.children[0] as ContainerDocumentNode;
-      const numbers = merged.children.map((c) => c.number);
+      const numbers = merged.children.map((c) => (c as NumberedDocumentNode).number);
       expect(numbers).toEqual(['a)', 'b)', 'c)', 'd)', 'a)', 'b)', 'c)']);
     });
 
@@ -219,7 +220,7 @@ describe('mergeAdjacentListsTransform', () => {
       const result = mergeAdjacentListsTransform(input, 'de');
 
       const merged = result.children[0] as ContainerDocumentNode;
-      const numbers = merged.children.map((c) => c.number);
+      const numbers = merged.children.map((c) => (c as NumberedDocumentNode).number);
       expect(numbers).toEqual(['1.', '2.', '3.', '1.', '2.']);
     });
 
@@ -235,7 +236,7 @@ describe('mergeAdjacentListsTransform', () => {
       const result = mergeAdjacentListsTransform(input, 'de');
 
       const merged = result.children[0] as ContainerDocumentNode;
-      const numbers = merged.children.map((c) => c.number);
+      const numbers = merged.children.map((c) => (c as NumberedDocumentNode).number);
       expect(numbers).toEqual([null, null, null]);
     });
   });
@@ -251,7 +252,7 @@ describe('mergeAdjacentListsTransform', () => {
       const merged = result.children[0] as ContainerDocumentNode;
       expect(merged.children).toHaveLength(2);
       // position-derived numbers are preserved as-is (no renumbering)
-      expect(merged.children.map((c) => c.number)).toEqual(['1.', '1.']);
+      expect(merged.children.map((c) => (c as NumberedDocumentNode).number)).toEqual(['1.', '1.']);
     });
 
     it('issue #67 scenario: merge runs before dedup so <sup> Absatznummern numbering is continuous', () => {
@@ -270,7 +271,11 @@ describe('mergeAdjacentListsTransform', () => {
 
       expect(tree.children).toHaveLength(3);
       expect(tree.children.every((c) => c.type === 'CONTENT')).toBe(true);
-      expect(tree.children.map((c) => c.number)).toEqual(['^1^', '^2^', '^3^']);
+      expect(tree.children.map((c) => (c as NumberedDocumentNode).number)).toEqual([
+        '^1^',
+        '^2^',
+        '^3^',
+      ]);
     });
 
     it('preserves data-list-style-type markers across the merge (no overwrite)', () => {
@@ -282,7 +287,7 @@ describe('mergeAdjacentListsTransform', () => {
       const merged = tree.children[0] as ContainerDocumentNode;
       expect(merged.children).toHaveLength(2);
       // Explicit list-style-type markers preserved exactly — restart kept.
-      expect(merged.children.map((c) => c.number)).toEqual(['a)', 'a)']);
+      expect(merged.children.map((c) => (c as NumberedDocumentNode).number)).toEqual(['a)', 'a)']);
     });
   });
 });

--- a/src/utils/legal-transforms/test-helpers.ts
+++ b/src/utils/legal-transforms/test-helpers.ts
@@ -13,7 +13,6 @@ import { generateId } from '../document-utils';
 export function createDoc(children: DocumentNode[]): ContainerDocumentNode {
   return {
     id: generateId(),
-    number: null,
     type: 'DOCUMENT',
     children,
   };

--- a/src/utils/outline-utils.test.ts
+++ b/src/utils/outline-utils.test.ts
@@ -4,7 +4,6 @@ import { getDocumentOutline } from './outline-utils';
 
 const makeDoc = (...children: ContainerDocumentNode['children']): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children,
 });

--- a/src/utils/tree-mutations.test.ts
+++ b/src/utils/tree-mutations.test.ts
@@ -4,7 +4,9 @@ import type {
   ContentDocumentNode,
   HeadingDocumentNode,
   LeafDocumentNode,
+  ListItemDocumentNode,
   NodeFormat,
+  NumberedDocumentNode,
 } from '../types/document';
 import type { NodePath } from '../types/editor';
 import {
@@ -71,7 +73,6 @@ const list = (id: string, children: ContainerDocumentNode['children']): Containe
 
 const doc = (children: ContainerDocumentNode['children']): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children,
 });
@@ -239,7 +240,6 @@ describe('findPreviousSiblingTarget', () => {
   test('returns the nearest preceding HEADING', () => {
     const parent: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [heading('h1', 'A'), content('p1', 'x'), content('p2', 'y')],
     };
@@ -250,7 +250,6 @@ describe('findPreviousSiblingTarget', () => {
   test('returns a preceding CONTENT node for a FOOTNOTE', () => {
     const parent: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [content('p1', 'x'), heading('hh', 'H')],
     };
@@ -262,7 +261,6 @@ describe('findPreviousSiblingTarget', () => {
   test('returns null when nothing qualifies', () => {
     const parent: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [content('p1', 'x'), content('p2', 'y')],
     };
@@ -426,7 +424,7 @@ describe('changeNodeTypeInDoc', () => {
     const list = getNodeAtPath(result!, [0]) as ContainerDocumentNode;
     expect(list.type).toBe('LIST');
     expect(list.children[0].type).toBe('LIST_ITEM');
-    expect(list.children[0].number).toBe('1.');
+    expect((list.children[0] as NumberedDocumentNode).number).toBe('1.');
   });
 
   test('flattens a list to content nodes', () => {
@@ -482,7 +480,11 @@ describe('changeNodeTypeInDoc', () => {
     expect(result!.children).toHaveLength(1);
     const merged = result!.children[0] as ContainerDocumentNode;
     expect(merged.type).toBe('LIST');
-    expect(merged.children.map((c) => c.number)).toEqual(['1.', '2.', '3.']);
+    expect(merged.children.map((c) => (c as NumberedDocumentNode).number)).toEqual([
+      '1.',
+      '2.',
+      '3.',
+    ]);
   });
 
   test('returns null for the root node', () => {
@@ -500,7 +502,7 @@ describe('extractAndConvertListItemInDoc', () => {
       children: [listItem('li1', 'one', '1.')],
     };
     const d = doc([list]);
-    const item = getNodeAtPath(d, [0, 0]) as ContainerDocumentNode;
+    const item = getNodeAtPath(d, [0, 0]) as ListItemDocumentNode;
     const result = extractAndConvertListItemInDoc(d, [0, 0], item, 'CONTENT');
     expect(result).not.toBeNull();
     expect(result!.children).toHaveLength(1);
@@ -515,7 +517,7 @@ describe('extractAndConvertListItemInDoc', () => {
       children: [listItem('li1', 'one', '1.'), listItem('li2', 'two', '2.')],
     };
     const d = doc([list]);
-    const item = getNodeAtPath(d, [0, 0]) as ContainerDocumentNode;
+    const item = getNodeAtPath(d, [0, 0]) as ListItemDocumentNode;
     const result = extractAndConvertListItemInDoc(d, [0, 0], item, 'HEADING');
     expect(result).not.toBeNull();
     expect(result!.children[0]).toMatchObject({ id: 'li1', type: 'HEADING', number: '1.' });

--- a/src/utils/tree-mutations.ts
+++ b/src/utils/tree-mutations.ts
@@ -6,6 +6,7 @@ import type {
   HeadingDocumentNode,
   Language,
   LeafDocumentNode,
+  ListItemDocumentNode,
   NodeFormat,
   ParentType,
 } from '../types/document';
@@ -210,7 +211,7 @@ export function flattenListToContents(list: ContainerDocumentNode): DocumentNode
   const out: DocumentNode[] = [];
   for (const item of list.children) {
     if (item.type !== 'LIST_ITEM') continue;
-    const listItem = item as ContainerDocumentNode;
+    const listItem = item as ListItemDocumentNode;
 
     const flattenedChildren: DocumentNode[] = [];
     let numberAttached = false;
@@ -593,7 +594,7 @@ const hasContents = (
 export const extractAndConvertListItemInDoc = (
   doc: ContainerDocumentNode,
   itemPath: NodePath,
-  item: ContainerDocumentNode,
+  item: ListItemDocumentNode,
   targetType: 'HEADING' | 'CONTENT'
 ): ContainerDocumentNode | null => {
   const listPath = itemPath.slice(0, -1);
@@ -694,7 +695,7 @@ export const changeNodeTypeInDoc = (
       return null;
     }
     // Extract from list and convert
-    return extractAndConvertListItemInDoc(doc, path, node as ContainerDocumentNode, targetType);
+    return extractAndConvertListItemInDoc(doc, path, node as ListItemDocumentNode, targetType);
   }
 
   // Handle list node - can only change list style or flatten to content

--- a/src/utils/tree-utils.test.ts
+++ b/src/utils/tree-utils.test.ts
@@ -41,7 +41,6 @@ const createListItem = (
 // Helper to create test documents
 const createTestDocument = (): ContainerDocumentNode => ({
   id: 'root',
-  number: null,
   type: 'DOCUMENT',
   children: [
     {
@@ -342,7 +341,6 @@ describe('buildIndices', () => {
   test('handles deeply nested structure', () => {
     const deepDoc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -452,7 +450,6 @@ describe('flattenForRendering', () => {
   test('includes list_item children in flattening', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -479,7 +476,6 @@ describe('mergeAdjacentLists', () => {
   test('merges two adjacent lists into one', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -510,7 +506,6 @@ describe('mergeAdjacentLists', () => {
   test('merges three adjacent lists into one', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -544,7 +539,6 @@ describe('mergeAdjacentLists', () => {
   test('does not merge non-adjacent lists', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -578,7 +572,6 @@ describe('mergeAdjacentLists', () => {
   test('returns unchanged document when no lists to merge', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -608,7 +601,6 @@ describe('mergeAdjacentLists', () => {
   test('merges lists within nested container', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -646,7 +638,6 @@ describe('mergeAdjacentLists', () => {
   test('preserves first list id when merging', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -703,7 +694,6 @@ describe('nested lists', () => {
   test('supports nested lists (list inside list_item)', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -750,7 +740,6 @@ describe('nested lists', () => {
   test('flattens nested lists correctly', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -786,7 +775,6 @@ describe('nested lists', () => {
   test('computes correct depth for nested list items', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -816,7 +804,6 @@ describe('nested lists', () => {
   test('can access and update nested list items', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -854,7 +841,6 @@ describe('nested lists', () => {
   test('can remove nested list items', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -882,7 +868,6 @@ describe('nested lists', () => {
   test('can insert items into nested list', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -909,7 +894,6 @@ describe('nested lists', () => {
   test('can move nested list item to parent list', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {
@@ -989,7 +973,6 @@ describe('changeNodeFormat', () => {
   test('no-ops when target node is a container (no format)', () => {
     const doc: ContainerDocumentNode = {
       id: 'root',
-      number: null,
       type: 'DOCUMENT',
       children: [
         {


### PR DESCRIPTION
## Summary
Makes `src/types/document.ts` a self-documenting reference for the DocTree format (issue #104, points 1, 2, 4):

- **Per-type interfaces (point 2):** split the two shape-grouped interfaces into **seven per-type interfaces** — `DocumentRootNode`, `ListDocumentNode`, `ListItemDocumentNode`, `HeadingDocumentNode`, `ContentDocumentNode`, `FootnoteDocumentNode`, `ImageDocumentNode`. Only `id` and `type` are universal; **`DocumentRootNode` has no `number`**. `ContainerDocumentNode`/`LeafDocumentNode` are kept as convenience grouping aliases, and a new `NumberedDocumentNode` names "any non-root node".
- **Reorg (point 1):** file is now ordered type definitions → constants → functions → example.
- **Format docs (point 4):** rich JSDoc on `NodeFormat` documenting each level's rendering contract, referencing the node-formatting spec.
- **Validation:** `number` is now validated **type-aware** — only the document root may omit `number` (tolerating a legacy `null` for persisted docs); every other node type still requires it.
- **Bonus:** `Language` is now derived from a single `LANGUAGES` source-of-truth array, removing the duplicated language list.

The production blast radius is small (a handful of narrowed casts); most of the diff is mechanical removal of `number` from `DOCUMENT` literals in test fixtures.

### Scope
Addresses **#104** (points 1, 2, 4). Point 3 — tightening each node's `children` to its exact allowed child types — is **deferred to #114** (a spike showed it forces ~380 compile-site fixes and casts through the generic mutation utilities; it warrants its own PR). #104 stays open until #114 lands.

## Test plan
- [x] New runtime tests: DOCUMENT validates with no `number`; rejects a real `number`; still accepts legacy `number: null`; non-DOCUMENT node still requires `number` (over-loosening guard)
- [x] New type-level assertions (`_TypeAssertions` tuple) lock the seven discriminants, the `DocumentNode` union, and the root-has-no-`number` invariant — verified non-vacuous via `tsc`
- [x] `npm run test:run` — 1196 tests pass
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` (biome) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)