### PR TITLE
Refactor #116: migrate app-wide document type to DocumentRootNode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,44 +3,56 @@ What this app is about: @README.md
 
 ## Standards
 - Use TDD when adding features or fixing bugs.
+- Tests live next to the code they cover as `*.test.ts(x)`.
 
-## How the App Works
+## Architecture
 
 ### Two views
-- `LoadDocument` - Upload view for PDF/DOCX/HTML files
-- `TreeEditor` - Main editor with tree on the right, original document preview on the left
+- **LoadDocument** — upload / paste view (PDF, DOCX, HTML, plaintext).
+- **EditorInterface** — the main editor: the document tree alongside a preview of the original.
 
-### Document processing pipeline
-```
-File upload/pasted text → Mammoth/DOMParser → document tree (DocumentNode)
-```
+### Processing pipeline
+File or pasted text → Mammoth (DOCX) / DOMParser (HTML) → a tree of `DocumentNode`s → Swiss-legal
+transforms reconstruct semantic structure (headings, `Art.`/`§` articles, lists). Export
+serializes the tree back out as JSON.
 
-### State management (immutable tree + hooks)
-- `useTreeEditor` - Main orchestrator: selection, drag-drop, keyboard navigation
-- `useTreeHistory` - Undo/redo stack
-- `useTreeOperations` - Mutations (add, remove, move, indent, change type) that commit to history
+### The tree
+- The document is an **immutable tree** rooted at a single `DocumentRootNode`. Every node has a
+  `type` (HEADING, CONTENT, LIST, LIST_ITEM, …). `types/document.ts` is the canonical reference
+  for node shapes, allowed children, and formatting rules — read it before touching the model.
+- **Paths are index arrays** — `[0, 2, 1]` means root's 1st child → its 3rd child → its 2nd
+  child. All edits are immutable and go through `utils/tree-utils.ts`.
 
-### Tree navigation
-Paths are index arrays (e.g., `[0, 2, 1]` = root's first child → its third child → its second child). All updates are immutable via `tree-utils.ts`.
+### State & subsystems
+- Editing flows through hooks in `hooks/`; **`useTreeEditor`** is the orchestrator and composes
+  history/undo and the tree-mutation operations.
+- Selection, editing, and drag state live in a **non-reactive store** (`stores/`), subscribed to
+  outside the normal render path.
+- Content is edited per node with a **formatting mode** (plain text → Markdown); see `NodeFormat`
+  in the data model and the render/inline-mark utils.
+- Documents **persist to IndexedDB** (recent documents + autosave), so work survives reloads.
 
-## Repository Structure
+## Repository
 
 ### Tech stack
-React 19, TypeScript, Vite, TailwindCSS + DaisyUI, Vitest
+React 19, TypeScript, Vite, TailwindCSS + DaisyUI, Vitest.
 
-### Source directories (`src/`)
-- `components/` - UI: TreeEditor, RecursiveTreeNode, ContentBlock, LoadDocument, FloatingToolbar, Toolbar, Header, SourcePreview, ui/
-- `hooks/` - useTreeEditor, useTreeHistory, useTreeOperations (all have tests)
-- `types/` - document.ts (tree types), editor.ts (selection/state), index.ts (Docling API types), mammoth.d.ts
-- `utils/` - tree-utils.ts (immutable ops), document-utils.ts (parsing), legal-transforms/ (Swiss legal document patterns)
-- `test/` - Fixtures and integration tests
+### Layout (`src/`)
+- `components/` — editor UI (tree, content blocks, toolbars, preview, upload).
+- `hooks/` — editor state & behavior; `useTreeEditor` is the entry point.
+- `stores/` — non-reactive UI state (selection / editing / drag).
+- `utils/` — pure logic: tree operations, parsing, formatting/rendering, export, persistence.
+  - `legal-transforms/` — modular pipeline detecting Swiss legal patterns.
+- `types/` — `document.ts` is the canonical data model; `editor.ts` holds editor/selection types.
+- `test/` — fixtures (real DOCX/PDF/HTML) and integration tests.
 
-### Key files
-- `src/types/document.ts` - Core tree types: DocumentNode, ContainerDocumentNode, LeafDocumentNode, HeadingDocumentNode, ContentDocumentNode
-- `src/utils/tree-utils.ts` - getNodeAtPath, updateNodeAtPath, insertNodeAtPath, removeNodeAtPath, moveNode, buildIndices, mergeAdjacentLists, flattenForRendering
-- `src/hooks/useTreeEditor.ts` - Main editor hook integrating all state
+### Where to start reading
+- `types/document.ts` — the data model and its rules.
+- `utils/tree-utils.ts` — immutable tree primitives (get / insert / remove / move at a path).
+- `hooks/useTreeEditor.ts` — how the editor wires everything together.
 
 ### Commands
-`npm run dev` (port 3000), `npm run build`, `npm run test`
+`npm run dev` (port 3000), `npm run build`, `npm run test`.
 
-The app runs at http://localhost:3000/. You almost never need to start or stop the dev server yourself because the human operator is usually running it already.
+The app runs at http://localhost:3000/. You almost never need to start or stop the dev server
+yourself — the human operator is usually already running it.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,10 @@ import { Header } from './components/Header';
 import { LoadDocument } from './components/LoadDocument';
 import { Toast } from './components/ui/Toast';
 import { useRecentDocuments } from './hooks/useRecentDocuments';
-import type { ContainerDocumentNode } from './types/document';
+import type { DocumentRootNode } from './types/document';
 
 function App() {
-  const [document, setDocument] = useState<ContainerDocumentNode | null>(null);
+  const [document, setDocument] = useState<DocumentRootNode | null>(null);
   const [documentUrl, setDocumentUrl] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
   const [currentEntryId, setCurrentEntryId] = useState<string | null>(null);
@@ -24,7 +24,7 @@ function App() {
   const { entries, loadEntry, deleteEntry, refresh: refreshRecents } = useRecentDocuments();
 
   const handleConvert = (
-    doc: ContainerDocumentNode,
+    doc: DocumentRootNode,
     url: string | null,
     _html: string | undefined,
     name: string | null,

--- a/src/components/DocumentPreview.test.tsx
+++ b/src/components/DocumentPreview.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
-import type { BlockDocumentNode, ContainerDocumentNode } from '../types/document';
+import type { BlockDocumentNode, DocumentRootNode } from '../types/document';
 import { DocumentPreview } from './DocumentPreview';
 
-const makeDoc = (...children: BlockDocumentNode[]): ContainerDocumentNode => ({
+const makeDoc = (...children: BlockDocumentNode[]): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children,

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -2,9 +2,10 @@ import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useResizable } from '../hooks/useResizable';
 import type {
-  ContainerDocumentNode,
   DocumentNode,
+  DocumentRootNode,
   Language,
+  ListDocumentNode,
   ListItemDocumentNode,
   NodeFormat,
 } from '../types/document';
@@ -40,7 +41,7 @@ function MarkupBlock({ source, format }: { source: string; format: NodeFormat })
 }
 
 interface DocumentPreviewProps {
-  document: ContainerDocumentNode;
+  document: DocumentRootNode;
   language: Language;
   onHeadingClick?: (nodeId: string) => void;
 }
@@ -335,7 +336,7 @@ function ListNode({
   language,
   headingDepth,
 }: {
-  node: ContainerDocumentNode;
+  node: ListDocumentNode;
   language: Language;
   headingDepth: number;
 }) {

--- a/src/components/EditorInterface.test.tsx
+++ b/src/components/EditorInterface.test.tsx
@@ -1,10 +1,6 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
-import {
-  type ContainerDocumentNode,
-  DOC_TREE_VERSION,
-  isValidDocTreeEnvelope,
-} from '../types/document';
+import { DOC_TREE_VERSION, type DocumentRootNode, isValidDocTreeEnvelope } from '../types/document';
 import { EditorInterface } from './EditorInterface';
 
 const downloadFileSpy = vi.fn();
@@ -14,7 +10,7 @@ vi.mock('../utils/document-utils', async () => {
   return { ...actual, downloadFile: (...args: unknown[]) => downloadFileSpy(...args) };
 });
 
-const createTestDocument = (): ContainerDocumentNode => ({
+const createTestDocument = (): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children: [

--- a/src/components/EditorInterface.tsx
+++ b/src/components/EditorInterface.tsx
@@ -2,7 +2,7 @@ import { useCallback, useLayoutEffect, useRef } from 'react';
 import { useAutosave } from '../hooks/useAutosave';
 import { useResizable } from '../hooks/useResizable';
 import { useTreeEditor } from '../hooks/useTreeEditor';
-import type { ContainerDocumentNode, Language } from '../types/document';
+import type { DocumentRootNode, Language } from '../types/document';
 import { buildDocTreeEnvelope, deriveJsonFilename, downloadFile } from '../utils/document-utils';
 import { DragHandle } from './DragHandle';
 import { LeftPane } from './LeftPane';
@@ -10,7 +10,7 @@ import { Toolbar } from './Toolbar';
 import { TreeEditor } from './TreeEditor';
 
 interface EditorInterfaceProps {
-  initialDocument: ContainerDocumentNode;
+  initialDocument: DocumentRootNode;
   documentUrl: string | null;
   documentName?: string | null;
   language?: Language;

--- a/src/components/LeftPane.test.tsx
+++ b/src/components/LeftPane.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
-import type { BlockDocumentNode, ContainerDocumentNode } from '../types/document';
+import type { BlockDocumentNode, DocumentRootNode } from '../types/document';
 import { LeftPane } from './LeftPane';
 
-const makeDoc = (...children: BlockDocumentNode[]): ContainerDocumentNode => ({
+const makeDoc = (...children: BlockDocumentNode[]): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children,

--- a/src/components/LeftPane.tsx
+++ b/src/components/LeftPane.tsx
@@ -1,11 +1,11 @@
 import * as Tabs from '@radix-ui/react-tabs';
-import type { ContainerDocumentNode, Language } from '../types/document';
+import type { DocumentRootNode, Language } from '../types/document';
 import { DocumentPreview } from './DocumentPreview';
 import { SourcePreview } from './SourcePreview';
 
 interface LeftPaneProps {
   documentUrl: string | null;
-  document: ContainerDocumentNode;
+  document: DocumentRootNode;
   language: Language;
   onHeadingClick: (nodeId: string) => void;
 }

--- a/src/components/LoadDocument.tsx
+++ b/src/components/LoadDocument.tsx
@@ -1,7 +1,7 @@
 import { AlertTriangle, ArrowRight, Loader2, Upload } from 'lucide-react';
 import type React from 'react';
 import { useRef, useState } from 'react';
-import type { ContainerDocumentNode } from '../types/document';
+import type { DocumentRootNode } from '../types/document';
 import {
   createEntry,
   formatQuotaMessage,
@@ -17,7 +17,7 @@ import { Textarea } from './ui/textarea';
 
 interface LoadDocumentProps {
   onConvert: (
-    doc: ContainerDocumentNode,
+    doc: DocumentRootNode,
     url: string | null,
     html: string | undefined,
     filename: string | null,
@@ -45,7 +45,7 @@ export function LoadDocument({
   const persistInitialEntry = async (
     name: string,
     subtitle: string | null,
-    tree: ContainerDocumentNode,
+    tree: DocumentRootNode,
     source: ReturnType<typeof processTextInput>['source']
   ): Promise<string | null> => {
     const id = crypto.randomUUID();

--- a/src/components/RecursiveTreeNode.test.tsx
+++ b/src/components/RecursiveTreeNode.test.tsx
@@ -3,10 +3,11 @@ import type React from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { TreeUIStore } from '../stores/TreeUIStore';
 import type {
-  ContainerDocumentNode,
   ContentDocumentNode,
   HeadingDocumentNode,
   LeafDocumentNode,
+  ListDocumentNode,
+  ListItemDocumentNode,
 } from '../types/document';
 import { RecursiveTreeNode } from './RecursiveTreeNode';
 import {
@@ -180,7 +181,7 @@ describe('RecursiveTreeNode', () => {
 
     test('list item bullet with null number triggers onNumberDoubleClick on double-click', () => {
       const onNumberDoubleClick = vi.fn();
-      const node: ContainerDocumentNode = {
+      const node: ListItemDocumentNode = {
         id: 'li-no-num',
         number: null,
         type: 'LIST_ITEM',
@@ -249,7 +250,7 @@ describe('RecursiveTreeNode', () => {
     });
 
     test('list node with null number renders a dashed placeholder badge', () => {
-      const node: ContainerDocumentNode = {
+      const node: ListDocumentNode = {
         id: 'list-no-num',
         number: null,
         type: 'LIST',
@@ -263,7 +264,7 @@ describe('RecursiveTreeNode', () => {
 
     test('list node with a number renders a solid badge', () => {
       const onNumberDoubleClick = vi.fn();
-      const node: ContainerDocumentNode = {
+      const node: ListDocumentNode = {
         id: 'list-with-num',
         number: 'A.',
         type: 'LIST',
@@ -493,7 +494,7 @@ describe('RecursiveTreeNode', () => {
     });
 
     test('container-only node (LIST_ITEM) shows just the type, no format', () => {
-      const node: ContainerDocumentNode = {
+      const node: ListItemDocumentNode = {
         id: 'li',
         number: '1.',
         type: 'LIST_ITEM',

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -2,10 +2,10 @@
 // Rendered via EditorInterface since TreeEditor requires the useTreeEditor hook output as a prop.
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
-import type { ContainerDocumentNode } from '../types/document';
+import type { DocumentRootNode } from '../types/document';
 import { EditorInterface } from './EditorInterface';
 
-const createTestDocument = (): ContainerDocumentNode => ({
+const createTestDocument = (): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children: [
@@ -300,7 +300,7 @@ describe('double-click inline editing', () => {
   // while any node is in edit mode.
   test('all node wrappers drop draggable while any node is editing', async () => {
     vi.useFakeTimers();
-    const nestedDoc: ContainerDocumentNode = {
+    const nestedDoc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -449,7 +449,7 @@ describe('double-click inline editing', () => {
   test('pressing Enter while editing a NEWLINES-format node inserts \\n via execCommand', async () => {
     vi.useFakeTimers();
 
-    const initialDocument: ContainerDocumentNode = {
+    const initialDocument: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -506,7 +506,7 @@ describe('double-click inline editing', () => {
   test('pressing Enter while editing a MARKDOWN_MINIMAL-format heading is a no-op', async () => {
     vi.useFakeTimers();
 
-    const initialDocument: ContainerDocumentNode = {
+    const initialDocument: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -563,7 +563,7 @@ describe('double-click inline editing', () => {
   test('pressing Enter while editing a MARKDOWN-format node inserts \\n via execCommand', async () => {
     vi.useFakeTimers();
 
-    const initialDocument: ContainerDocumentNode = {
+    const initialDocument: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -659,7 +659,7 @@ describe('double-click inline editing', () => {
   test('Shift+Enter inserts \\n in MARKDOWN-format edit mode (same as Enter)', async () => {
     vi.useFakeTimers();
 
-    const initialDocument: ContainerDocumentNode = {
+    const initialDocument: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -892,7 +892,7 @@ describe('node operations via keyboard', () => {
 
   test('Tab indents selected node under previous sibling', () => {
     // Need heading followed by content at same level for indent to work
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -945,7 +945,7 @@ describe('node operations via keyboard', () => {
   });
 
   test('Shift+Tab outdents selected node', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -1057,7 +1057,7 @@ describe('edit mode behaviors', () => {
     vi.useFakeTimers();
 
     // Create document with an empty content node
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -1122,7 +1122,7 @@ describe('edit mode behaviors', () => {
 });
 
 describe('empty document', () => {
-  const createEmptyDocument = (): ContainerDocumentNode => ({
+  const createEmptyDocument = (): DocumentRootNode => ({
     id: 'root',
     type: 'DOCUMENT',
     children: [],
@@ -1165,7 +1165,7 @@ describe('empty document', () => {
 });
 
 describe('drag and drop reordering', () => {
-  const createThreeNodeDocument = (): ContainerDocumentNode => ({
+  const createThreeNodeDocument = (): DocumentRootNode => ({
     id: 'root',
     type: 'DOCUMENT',
     children: [
@@ -1356,7 +1356,7 @@ describe('inline-marks toolbar — end-to-end toggle', () => {
   test('clicking Bold while editing a MARKDOWN_MINIMAL heading wraps the selected text and updates the tree', async () => {
     vi.useFakeTimers();
 
-    const initialDocument: ContainerDocumentNode = {
+    const initialDocument: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -1424,7 +1424,7 @@ describe('inline-marks toolbar — end-to-end toggle', () => {
   test('Google Docs–style keyboard shortcuts toggle the corresponding mark on the editing contenteditable', async () => {
     vi.useFakeTimers();
 
-    const initialDocument: ContainerDocumentNode = {
+    const initialDocument: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -1533,7 +1533,7 @@ describe('inline-marks toolbar — end-to-end toggle', () => {
   });
 
   test('clicking Bold while editing a number input commits to the tree without waiting for blur', async () => {
-    const initialDocument: ContainerDocumentNode = {
+    const initialDocument: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [

--- a/src/hooks/useAutosave.test.ts
+++ b/src/hooks/useAutosave.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { IDBFactory } from 'fake-indexeddb';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ContainerDocumentNode } from '../types/document';
+import type { DocumentRootNode } from '../types/document';
 import {
   __setStorageEstimatorForTesting,
   __setWriteFailHookForTesting,
@@ -18,7 +18,7 @@ vi.mock('../components/ui/Toast', () => ({
   useToast: () => ({ showToast: showToastSpy, dismissToast: vi.fn() }),
 }));
 
-function makeTree(text = 'hello'): ContainerDocumentNode {
+function makeTree(text = 'hello'): DocumentRootNode {
   return {
     id: 'root',
     type: 'DOCUMENT',
@@ -97,7 +97,7 @@ describe('useAutosave', () => {
     const t3 = makeTree('c');
 
     const { rerender } = renderHook(({ id, tree }) => useAutosave(id, tree), {
-      initialProps: { id: input.id, tree: t1 as ContainerDocumentNode | null },
+      initialProps: { id: input.id, tree: t1 as DocumentRootNode | null },
     });
 
     // Within the debounce window we rerender twice — each rerender resets the timer.
@@ -122,7 +122,7 @@ describe('useAutosave', () => {
 
     const edited = makeTree('flushed-on-switch');
     const { rerender } = renderHook(({ id, tree }) => useAutosave(id, tree), {
-      initialProps: { id: a.id, tree: edited as ContainerDocumentNode | null },
+      initialProps: { id: a.id, tree: edited as DocumentRootNode | null },
     });
 
     // Don't wait for debounce. Switch entry — the pending write to A should still flush.

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useToast } from '../components/ui/Toast';
-import type { ContainerDocumentNode } from '../types/document';
+import type { DocumentRootNode } from '../types/document';
 import {
   formatQuotaMessage,
   StorageQuotaUnresolvableError,
@@ -23,13 +23,13 @@ const DEBOUNCE_MS = 500;
  */
 export function useAutosave(
   currentEntryId: string | null,
-  tree: ContainerDocumentNode | null
+  tree: DocumentRootNode | null
 ): { flush: () => Promise<void> } {
   const { showToast } = useToast();
   const showToastRef = useRef(showToast);
   showToastRef.current = showToast;
 
-  const pendingRef = useRef<{ id: string; tree: ContainerDocumentNode } | null>(null);
+  const pendingRef = useRef<{ id: string; tree: DocumentRootNode } | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const performWrite = useCallback((): Promise<void> => {

--- a/src/hooks/useRecentDocuments.test.ts
+++ b/src/hooks/useRecentDocuments.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { IDBFactory } from 'fake-indexeddb';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ContainerDocumentNode } from '../types/document';
+import type { DocumentRootNode } from '../types/document';
 import {
   type CreateEntryInput,
   closeDb,
@@ -10,7 +10,7 @@ import {
 } from '../utils/document-storage';
 import { useRecentDocuments } from './useRecentDocuments';
 
-function makeTree(text = 'hello'): ContainerDocumentNode {
+function makeTree(text = 'hello'): DocumentRootNode {
   return {
     id: 'root',
     type: 'DOCUMENT',

--- a/src/hooks/useTreeEditor.test.ts
+++ b/src/hooks/useTreeEditor.test.ts
@@ -1,15 +1,16 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 import type {
-  ContainerDocumentNode,
   ContentDocumentNode,
+  DocumentRootNode,
   HeadingDocumentNode,
   LeafDocumentNode,
+  ListDocumentNode,
 } from '../types/document';
 import { isValidDocument } from '../types/document';
 import { useTreeEditor } from './useTreeEditor';
 
-const createTestDocument = (): ContainerDocumentNode => ({
+const createTestDocument = (): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children: [
@@ -311,7 +312,7 @@ describe('useTreeEditor', () => {
 
   test('indentSelected indents all selected nodes', () => {
     // Create doc: root > [h1, p1, p2]
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -396,7 +397,7 @@ describe('useTreeEditor', () => {
   });
 
   test('outdentSelected tabs a heading stuck in a list out of the list (issue #101 #4)', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -453,14 +454,14 @@ describe('useTreeEditor', () => {
     // The heading is lifted out to sit after the list; the list keeps its first item.
     expect(result.current.document.children.map((c) => c.type)).toEqual(['LIST', 'HEADING']);
     expect(result.current.document.children[1].id).toBe('stuck');
-    const list = result.current.document.children[0] as ContainerDocumentNode;
+    const list = result.current.document.children[0] as ListDocumentNode;
     expect(list.children.map((c) => c.id)).toEqual(['li1']);
     expect(isValidDocument(result.current.document)).toBe(true);
   });
 
   describe('moveSelectedToTop / moveSelectedToBottom', () => {
     // Flat doc: root > [a, b, c, d]
-    const createFlatDoc = (): ContainerDocumentNode => ({
+    const createFlatDoc = (): DocumentRootNode => ({
       id: 'root',
       type: 'DOCUMENT',
       children: ['a', 'b', 'c', 'd'].map(

--- a/src/hooks/useTreeEditor.ts
+++ b/src/hooks/useTreeEditor.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { TreeUIStore } from '../stores/TreeUIStore';
-import type { ContainerDocumentNode, Language } from '../types/document';
+import type { DocumentRootNode, Language } from '../types/document';
 import type { FlattenedNode } from '../types/editor';
 import { DEFAULT_LANGUAGE } from '../utils/document-utils';
 import { flattenForRendering } from '../utils/tree-utils';
@@ -14,7 +14,7 @@ interface ClickModifiers {
 }
 
 export const useTreeEditor = (
-  initialDocument: ContainerDocumentNode,
+  initialDocument: DocumentRootNode,
   language: Language = DEFAULT_LANGUAGE
 ) => {
   // History management

--- a/src/hooks/useTreeHistory.test.ts
+++ b/src/hooks/useTreeHistory.test.ts
@@ -1,13 +1,9 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
-import type {
-  ContainerDocumentNode,
-  ContentDocumentNode,
-  HeadingDocumentNode,
-} from '../types/document';
+import type { ContentDocumentNode, DocumentRootNode, HeadingDocumentNode } from '../types/document';
 import { useTreeHistory } from './useTreeHistory';
 
-const createTestDocument = (): ContainerDocumentNode => ({
+const createTestDocument = (): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children: [
@@ -35,7 +31,7 @@ describe('useTreeHistory', () => {
   test('commit updates document state', () => {
     const { result } = renderHook(() => useTreeHistory(createTestDocument()));
 
-    const newDoc: ContainerDocumentNode = {
+    const newDoc: DocumentRootNode = {
       ...result.current.document,
       children: [],
     };
@@ -50,7 +46,7 @@ describe('useTreeHistory', () => {
   test('commit adds to history when saveHistory is true', () => {
     const { result } = renderHook(() => useTreeHistory(createTestDocument()));
 
-    const newDoc: ContainerDocumentNode = {
+    const newDoc: DocumentRootNode = {
       ...result.current.document,
       children: [],
     };
@@ -65,7 +61,7 @@ describe('useTreeHistory', () => {
   test('commit does not add to history when saveHistory is false', () => {
     const { result } = renderHook(() => useTreeHistory(createTestDocument()));
 
-    const newDoc: ContainerDocumentNode = {
+    const newDoc: DocumentRootNode = {
       ...result.current.document,
       children: [],
     };
@@ -83,7 +79,7 @@ describe('useTreeHistory', () => {
     const { result } = renderHook(() => useTreeHistory(createTestDocument()));
 
     // Make a change
-    const newDoc: ContainerDocumentNode = {
+    const newDoc: DocumentRootNode = {
       ...result.current.document,
       children: [],
     };
@@ -117,7 +113,7 @@ describe('useTreeHistory', () => {
     const { result } = renderHook(() => useTreeHistory(createTestDocument()));
 
     // Make a change
-    const newDoc: ContainerDocumentNode = {
+    const newDoc: DocumentRootNode = {
       ...result.current.document,
       children: [],
     };
@@ -210,7 +206,7 @@ describe('useTreeHistory', () => {
     expect(result.current.nodeIndex.get('p1')).toBeDefined();
 
     // Add a new node
-    const newDoc: ContainerDocumentNode = {
+    const newDoc: DocumentRootNode = {
       ...result.current.document,
       children: [
         ...result.current.document.children,
@@ -243,7 +239,7 @@ describe('useTreeHistory', () => {
 
     // Add a new node under h1
     const h1 = result.current.document.children[0] as HeadingDocumentNode;
-    const newDoc: ContainerDocumentNode = {
+    const newDoc: DocumentRootNode = {
       ...result.current.document,
       children: [
         {
@@ -309,7 +305,7 @@ describe('useTreeHistory', () => {
     expect(result.current.historyLength).toBe(3);
 
     // Reset with new document
-    const newDoc: ContainerDocumentNode = {
+    const newDoc: DocumentRootNode = {
       id: 'new-root',
       type: 'DOCUMENT',
       children: [],

--- a/src/hooks/useTreeHistory.ts
+++ b/src/hooks/useTreeHistory.ts
@@ -1,12 +1,12 @@
 import { useCallback, useMemo, useState } from 'react';
-import type { ContainerDocumentNode } from '../types/document';
+import type { DocumentRootNode } from '../types/document';
 import { buildIndices } from '../utils/tree-utils';
 
 const MAX_HISTORY_LENGTH = 50;
 
-export const useTreeHistory = (initialDocument: ContainerDocumentNode) => {
-  const [document, setDocument] = useState<ContainerDocumentNode>(initialDocument);
-  const [history, setHistory] = useState<ContainerDocumentNode[]>([initialDocument]);
+export const useTreeHistory = (initialDocument: DocumentRootNode) => {
+  const [document, setDocument] = useState<DocumentRootNode>(initialDocument);
+  const [history, setHistory] = useState<DocumentRootNode[]>([initialDocument]);
   const [historyIndex, setHistoryIndex] = useState(0);
 
   /**
@@ -15,7 +15,7 @@ export const useTreeHistory = (initialDocument: ContainerDocumentNode) => {
    * @param saveHistory - Whether to save to undo history (default true)
    */
   const commit = useCallback(
-    (newDoc: ContainerDocumentNode, saveHistory = true) => {
+    (newDoc: DocumentRootNode, saveHistory = true) => {
       setDocument(newDoc);
 
       if (saveHistory) {
@@ -77,7 +77,7 @@ export const useTreeHistory = (initialDocument: ContainerDocumentNode) => {
   /**
    * Reset history with a new document.
    */
-  const reset = useCallback((newDoc: ContainerDocumentNode) => {
+  const reset = useCallback((newDoc: DocumentRootNode) => {
     setDocument(newDoc);
     setHistory([newDoc]);
     setHistoryIndex(0);

--- a/src/hooks/useTreeOperations.test.ts
+++ b/src/hooks/useTreeOperations.test.ts
@@ -2,10 +2,11 @@ import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, type MockedFunction, test, vi } from 'vitest';
 import type {
   BlockDocumentNode,
-  ContainerDocumentNode,
   ContentDocumentNode,
+  DocumentRootNode,
   HeadingDocumentNode,
   LeafDocumentNode,
+  ListDocumentNode,
   ListItemDocumentNode,
   NumberedDocumentNode,
 } from '../types/document';
@@ -15,7 +16,7 @@ import { buildIndices, getNodeAtPath } from '../utils/tree-utils';
 import { useTreeOperations } from './useTreeOperations';
 
 // Helper to create a test document
-const createTestDocument = (): ContainerDocumentNode => ({
+const createTestDocument = (): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children: [
@@ -85,7 +86,7 @@ const createListItem = (
   ],
 });
 
-const createDocumentWithList = (): ContainerDocumentNode => ({
+const createDocumentWithList = (): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children: [
@@ -112,8 +113,8 @@ const createDocumentWithList = (): ContainerDocumentNode => ({
 });
 
 describe('useTreeOperations', () => {
-  let mockCommit: MockedFunction<(doc: ContainerDocumentNode, saveHistory?: boolean) => void>;
-  let document: ContainerDocumentNode;
+  let mockCommit: MockedFunction<(doc: DocumentRootNode, saveHistory?: boolean) => void>;
+  let document: DocumentRootNode;
   let _indices: { nodeIndex: Map<string, NodePath>; parentIndex: Map<string, string> };
 
   beforeEach(() => {
@@ -122,7 +123,7 @@ describe('useTreeOperations', () => {
     _indices = buildIndices(document);
   });
 
-  const renderTreeOperations = (doc: ContainerDocumentNode = document) => {
+  const renderTreeOperations = (doc: DocumentRootNode = document) => {
     const idx = buildIndices(doc);
     return renderHook(() =>
       useTreeOperations({
@@ -144,7 +145,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
 
       // New node should be inserted after p1 (index 1)
@@ -164,7 +165,7 @@ describe('useTreeOperations', () => {
         result.current.addNodeAfter('p1');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       const newNode = h1.children[1] as LeafDocumentNode;
       expect(newNode.type).toBe('CONTENT');
@@ -178,12 +179,12 @@ describe('useTreeOperations', () => {
         result.current.addNodeAfter('li1');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
-      const list = h1.children[0] as ContainerDocumentNode;
+      const list = h1.children[0] as ListDocumentNode;
 
       expect(list.children.length).toBe(4);
-      const newItem = list.children[1] as LeafDocumentNode;
+      const newItem = list.children[1] as ListItemDocumentNode;
       expect(newItem.type).toBe('LIST_ITEM');
     });
   });
@@ -197,7 +198,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
 
       // New node should be inserted before h2 (was at index 1, now at index 2)
@@ -217,7 +218,7 @@ describe('useTreeOperations', () => {
         result.current.addNodeBefore('p1');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       const newNode = h1.children[0] as LeafDocumentNode;
       expect(newNode.type).toBe('CONTENT');
@@ -232,13 +233,13 @@ describe('useTreeOperations', () => {
         result.current.addNodeBefore('li2');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
-      const list = h1.children[0] as ContainerDocumentNode;
+      const list = h1.children[0] as ListDocumentNode;
 
       expect(list.children.length).toBe(4);
       // New item should be at index 1 (before li2 which shifts to index 2)
-      const newItem = list.children[1] as ContainerDocumentNode;
+      const newItem = list.children[1] as ListItemDocumentNode;
       expect(newItem.type).toBe('LIST_ITEM');
       expect(list.children[2].id).toBe('li2');
     });
@@ -254,7 +255,7 @@ describe('useTreeOperations', () => {
       expect(newId).toBeDefined();
       expect(typeof newId).toBe('string');
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       expect(h1.children[0].id).toBe(newId);
     });
@@ -279,7 +280,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
 
       expect(h1.children.length).toBe(1);
@@ -293,7 +294,7 @@ describe('useTreeOperations', () => {
         result.current.removeNodes(['h2']); // Has p2 as child
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
 
       expect(h1.children.length).toBe(1);
@@ -311,7 +312,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
 
       // h1 should have no children left
@@ -327,14 +328,14 @@ describe('useTreeOperations', () => {
         result.current.updateNodeContents('p1', 'Updated content');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const p1 = getNodeAtPath(newDoc, [0, 0]) as LeafDocumentNode;
       expect(p1.contents.de).toBe('Updated content');
     });
 
     test('preserves other languages', () => {
       // Create a document with multi-language content
-      const multiLangDoc: ContainerDocumentNode = {
+      const multiLangDoc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -355,7 +356,7 @@ describe('useTreeOperations', () => {
         result.current.updateNodeContents('p1', 'Neuer Text');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const p1 = newDoc.children[0] as LeafDocumentNode;
       expect(p1.contents.de).toBe('Neuer Text');
       expect(p1.contents.en).toBe('English'); // Preserved
@@ -365,7 +366,7 @@ describe('useTreeOperations', () => {
   describe('indentNodes (Tab)', () => {
     test('moves content under previous sibling heading', () => {
       // Create doc with h1, then content at same level
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -394,7 +395,7 @@ describe('useTreeOperations', () => {
         result.current.indentNodes(['p1']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       // p1 should now be a child of h1
       expect(newDoc.children.length).toBe(1);
       const h1 = newDoc.children[0] as HeadingDocumentNode;
@@ -416,7 +417,7 @@ describe('useTreeOperations', () => {
 
     test('moves heading under previous sibling heading', () => {
       // Create two sibling headings at root level
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -445,7 +446,7 @@ describe('useTreeOperations', () => {
         result.current.indentNodes(['h2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.length).toBe(1);
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       expect(h1.children.length).toBe(1);
@@ -460,9 +461,9 @@ describe('useTreeOperations', () => {
         result.current.indentNodes(['li2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
-      const list = h1.children[0] as ContainerDocumentNode;
+      const list = h1.children[0] as ListDocumentNode;
 
       // li2 has been pulled out of the outer list, so only li1 and li3 remain.
       expect(list.children.length).toBe(2);
@@ -470,10 +471,10 @@ describe('useTreeOperations', () => {
       expect(list.children[1].id).toBe('li3');
 
       // li1 now ends with a nested list whose only child is li2.
-      const li1 = list.children[0] as ContainerDocumentNode;
+      const li1 = list.children[0] as ListItemDocumentNode;
       const li1Last = li1.children[li1.children.length - 1];
       expect(li1Last.type).toBe('LIST');
-      const nested = li1Last as ContainerDocumentNode;
+      const nested = li1Last as ListDocumentNode;
       expect(nested.children.length).toBe(1);
       expect(nested.children[0].id).toBe('li2');
     });
@@ -486,18 +487,18 @@ describe('useTreeOperations', () => {
         result.current.indentNodes(['li2', 'li3']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
-      const list = h1.children[0] as ContainerDocumentNode;
+      const list = h1.children[0] as ListDocumentNode;
 
       // Only li1 remains at the outer level; li2 and li3 are nested under it.
       expect(list.children.length).toBe(1);
       expect(list.children[0].id).toBe('li1');
 
-      const li1 = list.children[0] as ContainerDocumentNode;
+      const li1 = list.children[0] as ListItemDocumentNode;
       const li1Last = li1.children[li1.children.length - 1];
       expect(li1Last.type).toBe('LIST');
-      const nested = li1Last as ContainerDocumentNode;
+      const nested = li1Last as ListDocumentNode;
       expect(nested.children.length).toBe(2);
       expect(nested.children[0].id).toBe('li2');
       expect(nested.children[1].id).toBe('li3');
@@ -506,7 +507,7 @@ describe('useTreeOperations', () => {
     test('appends list_item to existing nested list under preceding sibling', () => {
       // li1 already has a nested list with liA inside. Indenting li2 should
       // append it to that existing list, not create a new sibling list.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -548,12 +549,12 @@ describe('useTreeOperations', () => {
         result.current.indentNodes(['li2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-      const list1 = newDoc.children[0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+      const list1 = newDoc.children[0] as ListDocumentNode;
       expect(list1.children.length).toBe(1);
 
-      const li1 = list1.children[0] as ContainerDocumentNode;
-      const nested = li1.children.find((c) => c.type === 'LIST') as ContainerDocumentNode;
+      const li1 = list1.children[0] as ListItemDocumentNode;
+      const nested = li1.children.find((c) => c.type === 'LIST') as ListDocumentNode;
       // Same nested list (same id), now with both items inside.
       expect(nested.id).toBe('oldNested');
       expect(nested.children.length).toBe(2);
@@ -571,20 +572,20 @@ describe('useTreeOperations', () => {
         result.current.indentNodes(['li1', 'li2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
-      const list = h1.children[0] as ContainerDocumentNode;
+      const list = h1.children[0] as ListDocumentNode;
 
       // li1 stays at outer level, li2 is now nested under it, li3 still at outer level.
       expect(list.children.map((c) => c.id)).toEqual(['li1', 'li3']);
-      const li1 = list.children[0] as ContainerDocumentNode;
-      const nested = li1.children[li1.children.length - 1] as ContainerDocumentNode;
+      const li1 = list.children[0] as ListItemDocumentNode;
+      const nested = li1.children[li1.children.length - 1] as ListDocumentNode;
       expect(nested.type).toBe('LIST');
       expect(nested.children.map((c) => c.id)).toEqual(['li2']);
     });
 
     test('does nothing when list_item has no preceding sibling', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -609,7 +610,7 @@ describe('useTreeOperations', () => {
     test("preserves the list_item's own nested children when indenting", () => {
       // li2 carries its own nested list (with liA). After indenting li2, the
       // new sublist under li1 should contain li2 unchanged — including liA.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -651,23 +652,23 @@ describe('useTreeOperations', () => {
         result.current.indentNodes(['li2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-      const list1 = newDoc.children[0] as ContainerDocumentNode;
-      const li1 = list1.children[0] as ContainerDocumentNode;
-      const newSublist = li1.children[li1.children.length - 1] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+      const list1 = newDoc.children[0] as ListDocumentNode;
+      const li1 = list1.children[0] as ListItemDocumentNode;
+      const newSublist = li1.children[li1.children.length - 1] as ListDocumentNode;
       expect(newSublist.type).toBe('LIST');
 
-      const movedLi2 = newSublist.children[0] as ContainerDocumentNode;
+      const movedLi2 = newSublist.children[0] as ListItemDocumentNode;
       expect(movedLi2.id).toBe('li2');
       // li2 still has its content + its own nested list
       const movedNested = movedLi2.children.find((c) => c.id === 'li2-nested');
       expect(movedNested).toBeDefined();
-      expect((movedNested as ContainerDocumentNode).children[0].id).toBe('liA');
+      expect((movedNested as ListDocumentNode).children[0].id).toBe('liA');
     });
 
     test('indents multiple sibling nodes under previous heading', () => {
       // doc: h1, p1, p2 at root level → both p1 and p2 should move under h1
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -705,7 +706,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       // Only h1 remains at root
       expect(newDoc.children.length).toBe(1);
       const h1 = newDoc.children[0] as HeadingDocumentNode;
@@ -718,7 +719,7 @@ describe('useTreeOperations', () => {
     test('skips nodes that cannot be indented in a batch', () => {
       // doc: p1, h1 → p1 has no previous heading, h1 has no previous heading
       // Neither can be indented
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -754,7 +755,7 @@ describe('useTreeOperations', () => {
       // doc: HeadingA, HeadingB(HeadingC, HeadingD). Selecting B together with
       // its children C and D and indenting must nest B under A while leaving C
       // and D as direct siblings under B — not re-nesting D under C.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -800,7 +801,7 @@ describe('useTreeOperations', () => {
         result.current.indentNodes(['B', 'C', 'D']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(isValidDocument(newDoc)).toBe(true);
 
       // A is the only root child; B nested under it.
@@ -825,7 +826,7 @@ describe('useTreeOperations', () => {
         contents: { de: id },
         children,
       });
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -844,7 +845,7 @@ describe('useTreeOperations', () => {
         result.current.indentNodes(['B', 'C', 'E', 'Y', 'Z']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(isValidDocument(newDoc)).toBe(true);
 
       // A and X remain at root; B nested under A, Y nested under X.
@@ -873,7 +874,7 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['p1']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       // Should have 3 children now: h1, p1, h1b
       expect(newDoc.children.length).toBe(3);
       expect(newDoc.children[0].id).toBe('h1');
@@ -905,7 +906,7 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['h2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       // Should have 3 children: h1, h2, h1b
       expect(newDoc.children.length).toBe(3);
       expect(newDoc.children[0].id).toBe('h1');
@@ -914,7 +915,7 @@ describe('useTreeOperations', () => {
     });
 
     test('moves list_item out of nested list', () => {
-      const nestedListDoc: ContainerDocumentNode = {
+      const nestedListDoc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -944,15 +945,15 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['li2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-      const list1 = newDoc.children[0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+      const list1 = newDoc.children[0] as ListDocumentNode;
 
       // li2 is hoisted into list1 and the (now-empty) malformed inner list is dropped.
       expect(list1.children.map((c) => c.id)).toEqual(['li1', 'li2']);
     });
 
     test('does nothing when outdenting list_item would place it outside any list', () => {
-      const docWithTopLevelList: ContainerDocumentNode = {
+      const docWithTopLevelList: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -978,7 +979,7 @@ describe('useTreeOperations', () => {
     });
 
     test('does nothing when outdenting list_item in list under heading would violate rules', () => {
-      const docWithListUnderHeading: ContainerDocumentNode = {
+      const docWithListUnderHeading: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1012,7 +1013,7 @@ describe('useTreeOperations', () => {
     test('outdents list_item out of a properly nested list under preceding sibling', () => {
       // list1[li1{content, nested[li2]}, li3] → shift-tab on li2 →
       // list1[li1{content}, li2, li3]  (empty nested list is dropped)
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1054,21 +1055,21 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['li2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-      const list1 = newDoc.children[0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+      const list1 = newDoc.children[0] as ListDocumentNode;
 
       // list1 now has [li1, li2, li3] in order
       expect(list1.children.map((c) => c.id)).toEqual(['li1', 'li2', 'li3']);
 
       // li1's nested list is gone (it became empty after li2 left)
-      const li1 = list1.children[0] as ContainerDocumentNode;
+      const li1 = list1.children[0] as ListItemDocumentNode;
       expect(li1.children.some((c) => c.type === 'LIST')).toBe(false);
     });
 
     test('keeps nested list when other items remain after outdent', () => {
       // list1[li1{nested[li2, li3]}] → shift-tab on li2 →
       // list1[li1{nested[li3]}, li2]
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1101,12 +1102,12 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['li2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-      const list1 = newDoc.children[0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+      const list1 = newDoc.children[0] as ListDocumentNode;
       expect(list1.children.map((c) => c.id)).toEqual(['li1', 'li2']);
 
-      const li1 = list1.children[0] as ContainerDocumentNode;
-      const nested = li1.children.find((c) => c.type === 'LIST') as ContainerDocumentNode;
+      const li1 = list1.children[0] as ListItemDocumentNode;
+      const nested = li1.children.find((c) => c.type === 'LIST') as ListDocumentNode;
       expect(nested).toBeDefined();
       expect(nested.children.map((c) => c.id)).toEqual(['li3']);
     });
@@ -1114,7 +1115,7 @@ describe('useTreeOperations', () => {
     test('outdents from a doubly-nested list one level at a time', () => {
       // list1[li1{nested1[li2{nested2[li3]}]}] → shift-tab on li3 →
       // list1[li1{nested1[li2, li3]}]   (li3 moves up one level, into nested1)
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1161,21 +1162,21 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['li3']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-      const list1 = newDoc.children[0] as ContainerDocumentNode;
-      const li1 = list1.children[0] as ContainerDocumentNode;
-      const nested1 = li1.children[0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+      const list1 = newDoc.children[0] as ListDocumentNode;
+      const li1 = list1.children[0] as ListItemDocumentNode;
+      const nested1 = li1.children[0] as ListDocumentNode;
 
       // li3 sits next to li2 in nested1; nested2 is gone (it became empty).
       expect(nested1.children.map((c) => c.id)).toEqual(['li2', 'li3']);
-      const li2 = nested1.children[0] as ContainerDocumentNode;
+      const li2 = nested1.children[0] as ListItemDocumentNode;
       expect(li2.children.some((c) => c.type === 'LIST')).toBe(false);
     });
 
     test('outdents two list_items from nested list, dropping empty list', () => {
       // list1[li1{nested[li2, li3]}] → shift-tab on [li2, li3] →
       // list1[li1, li2, li3]  (no nested list left)
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1208,11 +1209,11 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['li2', 'li3']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-      const list1 = newDoc.children[0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+      const list1 = newDoc.children[0] as ListDocumentNode;
       expect(list1.children.map((c) => c.id)).toEqual(['li1', 'li2', 'li3']);
 
-      const li1 = list1.children[0] as ContainerDocumentNode;
+      const li1 = list1.children[0] as ListItemDocumentNode;
       expect(li1.children.some((c) => c.type === 'LIST')).toBe(false);
     });
 
@@ -1225,7 +1226,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       // Should have: h1, p1, h2 (with p2 child), h1b
       expect(newDoc.children.length).toBe(4);
       expect(newDoc.children[0].id).toBe('h1');
@@ -1242,7 +1243,7 @@ describe('useTreeOperations', () => {
       // doc: HeadingA(HeadingB(HeadingC, HeadingD)). Selecting B together with
       // its children C and D and outdenting must lift B to be a sibling of A,
       // carrying C and D along unchanged — not scatter them or reverse order.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1289,7 +1290,7 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['B', 'C', 'D']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(isValidDocument(newDoc)).toBe(true);
 
       // B lifted to be a sibling of A, after it.
@@ -1307,7 +1308,7 @@ describe('useTreeOperations', () => {
       // with its nested descendant liA and outdenting must lift li1 to be a
       // sibling of outerLi, carrying nested2/liA along — liA must not be
       // processed separately.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1370,16 +1371,16 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['li1', 'liA']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(isValidDocument(newDoc)).toBe(true);
 
       // li1 popped out to be a sibling of outerLi in the outer list.
-      const list1 = newDoc.children[0] as ContainerDocumentNode;
+      const list1 = newDoc.children[0] as ListDocumentNode;
       expect(list1.children.map((c) => c.id)).toEqual(['outerLi', 'li1']);
 
       // li1 still carries its own nested2 list with liA unchanged.
-      const li1 = list1.children[1] as ContainerDocumentNode;
-      const nested2 = li1.children.find((c) => c.id === 'nested2') as ContainerDocumentNode;
+      const li1 = list1.children[1] as ListItemDocumentNode;
+      const nested2 = li1.children.find((c) => c.id === 'nested2') as ListDocumentNode;
       expect(nested2).toBeDefined();
       expect(nested2.children.map((c) => c.id)).toEqual(['liA']);
     });
@@ -1406,7 +1407,7 @@ describe('useTreeOperations', () => {
     });
 
     test('lifts a heading out of the last list_item, placing it after the list (no split)', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1432,12 +1433,12 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['H']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       // No content follows the heading, so no trailing list is created.
       expect(newDoc.children.map((c) => c.id)).toEqual(['list1', 'H']);
-      const list = newDoc.children[0] as ContainerDocumentNode;
+      const list = newDoc.children[0] as ListDocumentNode;
       expect(list.children.map((c) => c.id)).toEqual(['li1', 'li2']);
-      const li2 = list.children[1] as ContainerDocumentNode;
+      const li2 = list.children[1] as ListItemDocumentNode;
       // The surviving list_item keeps its id and number.
       expect((li2 as NumberedDocumentNode).number).toBe('2.');
       expect(li2.children.map((c) => c.id)).toEqual(['li2-content']);
@@ -1445,7 +1446,7 @@ describe('useTreeOperations', () => {
     });
 
     test('lifts a heading out of a middle list_item, splitting the list around it', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1471,22 +1472,22 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['H']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.type)).toEqual(['LIST', 'HEADING', 'LIST']);
       expect(newDoc.children[1].id).toBe('H');
-      const before = newDoc.children[0] as ContainerDocumentNode;
+      const before = newDoc.children[0] as ListDocumentNode;
       expect(before.id).toBe('list1');
       expect(before.children.map((c) => c.id)).toEqual(['li1']);
-      const li1 = before.children[0] as ContainerDocumentNode;
+      const li1 = before.children[0] as ListItemDocumentNode;
       expect(li1.children.map((c) => c.id)).toEqual(['li1-content']);
-      const after = newDoc.children[2] as ContainerDocumentNode;
+      const after = newDoc.children[2] as ListDocumentNode;
       expect(after.id).not.toBe('list1');
       expect(after.children.map((c) => c.id)).toEqual(['li2']);
       expect(isValidDocument(newDoc)).toBe(true);
     });
 
     test('drops an emptied middle list_item when its only child is lifted out', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1513,11 +1514,11 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['H']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.type)).toEqual(['LIST', 'HEADING', 'LIST']);
-      const before = newDoc.children[0] as ContainerDocumentNode;
+      const before = newDoc.children[0] as ListDocumentNode;
       expect(before.children.map((c) => c.id)).toEqual(['li1']);
-      const after = newDoc.children[2] as ContainerDocumentNode;
+      const after = newDoc.children[2] as ListDocumentNode;
       expect(after.children.map((c) => c.id)).toEqual(['li2']);
       // The emptied list_item is gone entirely.
       expect(JSON.stringify(newDoc)).not.toContain('liH');
@@ -1525,7 +1526,7 @@ describe('useTreeOperations', () => {
     });
 
     test('splits the list_item itself when the lifted node sits between content', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1550,17 +1551,17 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['H']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.type)).toEqual(['LIST', 'HEADING', 'LIST']);
 
-      const beforeItem = (newDoc.children[0] as ContainerDocumentNode)
-        .children[0] as ContainerDocumentNode;
+      const beforeItem = (newDoc.children[0] as ListDocumentNode)
+        .children[0] as ListItemDocumentNode;
       expect(beforeItem.id).toBe('li1');
       expect((beforeItem as NumberedDocumentNode).number).toBe('1.');
       expect(beforeItem.children.map((c) => c.id)).toEqual(['c-a']);
 
-      const afterItem = (newDoc.children[2] as ContainerDocumentNode)
-        .children[0] as ContainerDocumentNode;
+      const afterItem = (newDoc.children[2] as ListDocumentNode)
+        .children[0] as ListItemDocumentNode;
       // Tail fragment gets a fresh id and no number to avoid a duplicate label.
       expect(afterItem.id).not.toBe('li1');
       expect((afterItem as NumberedDocumentNode).number).toBeNull();
@@ -1571,7 +1572,7 @@ describe('useTreeOperations', () => {
     });
 
     test('lifts a heading out of the first list_item, placing it before the list', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1597,9 +1598,9 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['H']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['H', 'list1']);
-      const after = newDoc.children[1] as ContainerDocumentNode;
+      const after = newDoc.children[1] as ListDocumentNode;
       // No "before" list, so the surviving list reuses the original id.
       expect(after.id).toBe('list1');
       expect(after.children.map((c) => c.id)).toEqual(['li2']);
@@ -1609,7 +1610,7 @@ describe('useTreeOperations', () => {
     });
 
     test('replaces a single-item single-child list with just the lifted node', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1634,13 +1635,13 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['H']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['H']);
       expect(isValidDocument(newDoc)).toBe(true);
     });
 
     test('keeps document order when lifting from a list nested under a heading', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1678,7 +1679,7 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['H']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const t = newDoc.children[0] as HeadingDocumentNode;
       expect(t.children.map((c) => c.type)).toEqual([
         'CONTENT',
@@ -1688,15 +1689,15 @@ describe('useTreeOperations', () => {
         'CONTENT',
       ]);
       expect(t.children[0].id).toBe('pre');
-      expect((t.children[1] as ContainerDocumentNode).children.map((c) => c.id)).toEqual(['li1']);
+      expect((t.children[1] as ListDocumentNode).children.map((c) => c.id)).toEqual(['li1']);
       expect(t.children[2].id).toBe('H');
-      expect((t.children[3] as ContainerDocumentNode).children.map((c) => c.id)).toEqual(['li2']);
+      expect((t.children[3] as ListDocumentNode).children.map((c) => c.id)).toEqual(['li2']);
       expect(t.children[4].id).toBe('post');
       expect(isValidDocument(newDoc)).toBe(true);
     });
 
     test('lifts a normal list item content out of the list', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1714,17 +1715,17 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['li1-content']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.type)).toEqual(['CONTENT', 'LIST']);
       expect(newDoc.children[0].id).toBe('li1-content');
-      const after = newDoc.children[1] as ContainerDocumentNode;
+      const after = newDoc.children[1] as ListDocumentNode;
       expect(after.id).toBe('list1');
       expect(after.children.map((c) => c.id)).toEqual(['li2']);
       expect(isValidDocument(newDoc)).toBe(true);
     });
 
     test('lifts a footnote trapped directly in a list_item out of the list', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1758,14 +1759,14 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['fn']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.type)).toEqual(['LIST', 'FOOTNOTE']);
       expect(newDoc.children[1].id).toBe('fn');
       expect(isValidDocument(newDoc)).toBe(true);
     });
 
     test('lifts multiple sibling nodes out of the same list_item, preserving order', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1795,23 +1796,23 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['H1', 'H2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.type)).toEqual(['LIST', 'HEADING', 'HEADING', 'LIST']);
       expect(newDoc.children[1].id).toBe('H1');
       expect(newDoc.children[2].id).toBe('H2');
-      const before = newDoc.children[0] as ContainerDocumentNode;
-      expect((before.children[0] as ContainerDocumentNode).children.map((c) => c.id)).toEqual([
+      const before = newDoc.children[0] as ListDocumentNode;
+      expect((before.children[0] as ListItemDocumentNode).children.map((c) => c.id)).toEqual([
         'c-a',
       ]);
-      const after = newDoc.children[3] as ContainerDocumentNode;
-      expect((after.children[0] as ContainerDocumentNode).children.map((c) => c.id)).toEqual([
+      const after = newDoc.children[3] as ListDocumentNode;
+      expect((after.children[0] as ListItemDocumentNode).children.map((c) => c.id)).toEqual([
         'c-b',
       ]);
       expect(isValidDocument(newDoc)).toBe(true);
     });
 
     test('preserves the lifted node subtree (a heading with body content)', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1845,7 +1846,7 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['H']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['H']);
       const h = newDoc.children[0] as HeadingDocumentNode;
       // The lifted node keeps its number and its whole subtree.
@@ -1855,7 +1856,7 @@ describe('useTreeOperations', () => {
     });
 
     test('lifts two non-adjacent nodes out of the same list_item, preserving order', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1880,20 +1881,20 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['H1', 'H2']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       // Order H1, (list holding the middle content), H2 is preserved.
       expect(newDoc.children.map((c) => c.type)).toEqual(['HEADING', 'LIST', 'HEADING']);
       expect(newDoc.children[0].id).toBe('H1');
       expect(newDoc.children[2].id).toBe('H2');
-      const midList = newDoc.children[1] as ContainerDocumentNode;
-      expect((midList.children[0] as ContainerDocumentNode).children.map((c) => c.id)).toEqual([
+      const midList = newDoc.children[1] as ListDocumentNode;
+      expect((midList.children[0] as ListItemDocumentNode).children.map((c) => c.id)).toEqual([
         'c-mid',
       ]);
       expect(isValidDocument(newDoc)).toBe(true);
     });
 
     test('lifts a nested list out of a list_item as a sibling of the outer list', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1926,20 +1927,20 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['inner']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       // The two lists are left adjacent and unmerged; order (x, then nested) holds.
       expect(newDoc.children.map((c) => c.id)).toEqual(['outer', 'inner']);
-      const outer = newDoc.children[0] as ContainerDocumentNode;
-      expect((outer.children[0] as ContainerDocumentNode).children.map((c) => c.id)).toEqual([
+      const outer = newDoc.children[0] as ListDocumentNode;
+      expect((outer.children[0] as ListItemDocumentNode).children.map((c) => c.id)).toEqual([
         'c-x',
       ]);
-      const inner = newDoc.children[1] as ContainerDocumentNode;
+      const inner = newDoc.children[1] as ListDocumentNode;
       expect(inner.children.map((c) => c.id)).toEqual(['lia']);
       expect(isValidDocument(newDoc)).toBe(true);
     });
 
     test('does not lift when the list_item is not inside a list (malformed)', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1965,7 +1966,7 @@ describe('useTreeOperations', () => {
 
   describe('indentNodes footnote into content', () => {
     test('moves footnote under previous sibling content', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -1994,7 +1995,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
       // Footnote should now be child of content
       expect(newDoc.children.length).toBe(1);
@@ -2004,7 +2005,7 @@ describe('useTreeOperations', () => {
     });
 
     test('does nothing when previous sibling is not content or heading', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -2036,7 +2037,7 @@ describe('useTreeOperations', () => {
     });
 
     test('moves footnote under previous sibling heading', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -2065,7 +2066,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
       // Footnote should now be child of heading
       expect(newDoc.children.length).toBe(1);
@@ -2077,7 +2078,7 @@ describe('useTreeOperations', () => {
 
   describe('outdentNodes footnote from content', () => {
     test('moves footnote to be sibling of parent content', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -2107,7 +2108,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
       // Should have 2 children: p1, fn1
       expect(newDoc.children.length).toBe(2);
@@ -2120,7 +2121,7 @@ describe('useTreeOperations', () => {
     });
 
     test('preserves other footnote siblings when outdenting', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -2156,7 +2157,7 @@ describe('useTreeOperations', () => {
         result.current.outdentNodes(['fn1']);
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
       // Should have 2 children: p1, fn1
       expect(newDoc.children.length).toBe(2);
@@ -2173,7 +2174,7 @@ describe('useTreeOperations', () => {
   describe('changeNodeTypes', () => {
     describe('content -> heading', () => {
       test('converts content to heading with empty children', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2195,7 +2196,7 @@ describe('useTreeOperations', () => {
         });
 
         expect(mockCommit).toHaveBeenCalledTimes(1);
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as HeadingDocumentNode;
 
         expect(converted.type).toBe('HEADING');
@@ -2204,7 +2205,7 @@ describe('useTreeOperations', () => {
       });
 
       test('preserves id, number, and contents', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2225,7 +2226,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'HEADING');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as HeadingDocumentNode;
 
         expect(converted.id).toBe('p1');
@@ -2235,7 +2236,7 @@ describe('useTreeOperations', () => {
       });
 
       test('does nothing when already a heading', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2262,7 +2263,7 @@ describe('useTreeOperations', () => {
 
     describe('heading -> content', () => {
       test('converts heading without children to content', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2284,7 +2285,7 @@ describe('useTreeOperations', () => {
         });
 
         expect(mockCommit).toHaveBeenCalledTimes(1);
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as ContentDocumentNode;
 
         expect(converted.type).toBe('CONTENT');
@@ -2295,7 +2296,7 @@ describe('useTreeOperations', () => {
       });
 
       test('lifts children as siblings after converted node', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2341,7 +2342,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['h1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Should have 4 children: converted h1, p1, p2, h2
         expect(newDoc.children.length).toBe(4);
@@ -2353,7 +2354,7 @@ describe('useTreeOperations', () => {
       });
 
       test('does nothing when already content', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2380,7 +2381,7 @@ describe('useTreeOperations', () => {
 
     describe('content -> list', () => {
       test('wraps content in list with single list_item', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2401,16 +2402,16 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'numbered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Should have a list at root level
         expect(newDoc.children.length).toBe(1);
-        const list = newDoc.children[0] as ContainerDocumentNode;
+        const list = newDoc.children[0] as ListDocumentNode;
         expect(list.type).toBe('LIST');
 
         // List should contain one list_item with child content node
         expect(list.children.length).toBe(1);
-        const item = list.children[0] as ContainerDocumentNode;
+        const item = list.children[0] as ListItemDocumentNode;
         expect(item.type).toBe('LIST_ITEM');
         // The original content node becomes a child with its id preserved
         const itemContent = item.children[0] as LeafDocumentNode;
@@ -2420,7 +2421,7 @@ describe('useTreeOperations', () => {
       });
 
       test('sets correct number for numbered list', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2441,14 +2442,14 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'numbered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
-        const item = list.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
+        const item = list.children[0] as ListItemDocumentNode;
         expect((item as NumberedDocumentNode).number).toBe('1.');
       });
 
       test('sets correct number for lettered list', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2469,14 +2470,14 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'lettered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
-        const item = list.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
+        const item = list.children[0] as ListItemDocumentNode;
         expect((item as NumberedDocumentNode).number).toBe('a.');
       });
 
       test('sets null number for unordered list', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2497,16 +2498,16 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'unordered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
-        const item = list.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
+        const item = list.children[0] as ListItemDocumentNode;
         expect((item as NumberedDocumentNode).number).toBeNull();
       });
     });
 
     describe('heading -> list', () => {
       test('wraps heading in list, lifts children after list', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2536,16 +2537,16 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['h1'], 'LIST', 'numbered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Should have 2 children: the new list and the lifted p1
         expect(newDoc.children.length).toBe(2);
 
-        const list = newDoc.children[0] as ContainerDocumentNode;
+        const list = newDoc.children[0] as ListDocumentNode;
         expect(list.type).toBe('LIST');
         expect(list.children.length).toBe(1);
 
-        const item = list.children[0] as ContainerDocumentNode;
+        const item = list.children[0] as ListItemDocumentNode;
         expect(item.type).toBe('LIST_ITEM');
         // The original heading content is now in the child content node
         const itemContent = item.children[0] as LeafDocumentNode;
@@ -2558,7 +2559,7 @@ describe('useTreeOperations', () => {
 
     describe('list_item -> content', () => {
       test('replaces entire list when only item', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2577,7 +2578,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // List should be replaced with content node
         expect(newDoc.children.length).toBe(1);
@@ -2588,7 +2589,7 @@ describe('useTreeOperations', () => {
       });
 
       test('extracts item and inserts after list when multiple items', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2610,13 +2611,13 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li2'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Should have list and extracted content
         expect(newDoc.children.length).toBe(2);
 
         // List should still exist with one item
-        const list = newDoc.children[0] as ContainerDocumentNode;
+        const list = newDoc.children[0] as ListDocumentNode;
         expect(list.type).toBe('LIST');
         expect(list.children.length).toBe(1);
         expect(list.children[0].id).toBe('li1');
@@ -2630,7 +2631,7 @@ describe('useTreeOperations', () => {
 
     describe('list_item -> heading', () => {
       test('replaces entire list when only item', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2649,7 +2650,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li1'], 'HEADING');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         expect(newDoc.children.length).toBe(1);
         const converted = newDoc.children[0] as HeadingDocumentNode;
@@ -2659,7 +2660,7 @@ describe('useTreeOperations', () => {
       });
 
       test('extracts item and inserts after list when multiple items', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2681,7 +2682,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li1'], 'HEADING');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         expect(newDoc.children.length).toBe(2);
 
@@ -2691,7 +2692,7 @@ describe('useTreeOperations', () => {
         expect(converted.id).toBe('li1');
 
         // List with remaining item should follow
-        const list = newDoc.children[1] as ContainerDocumentNode;
+        const list = newDoc.children[1] as ListDocumentNode;
         expect(list.type).toBe('LIST');
         expect(list.children.length).toBe(1);
         expect(list.children[0].id).toBe('li2');
@@ -2700,7 +2701,7 @@ describe('useTreeOperations', () => {
 
     describe('list_item style change (single item only)', () => {
       test('changes only selected item to numbered, leaves siblings unchanged', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2723,8 +2724,8 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li2'], 'LIST', 'numbered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
 
         // Only li2 (index 1) should change
         expect((list.children[0] as NumberedDocumentNode).number).toBeNull();
@@ -2733,7 +2734,7 @@ describe('useTreeOperations', () => {
       });
 
       test('changes only selected item to lettered', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2752,8 +2753,8 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li1'], 'LIST', 'lettered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
 
         // Only li1 (index 0) should change
         expect((list.children[0] as NumberedDocumentNode).number).toBe('a.');
@@ -2761,7 +2762,7 @@ describe('useTreeOperations', () => {
       });
 
       test('changes only selected item to unordered', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2780,8 +2781,8 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li1'], 'LIST', 'unordered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
 
         // Only li1 (index 0) should change
         expect((list.children[0] as NumberedDocumentNode).number).toBeNull();
@@ -2791,7 +2792,7 @@ describe('useTreeOperations', () => {
 
     describe('list node style change', () => {
       test('list node + numbered: changes all children to 1., 2., 3.', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2814,8 +2815,8 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'LIST', 'numbered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
 
         expect((list.children[0] as NumberedDocumentNode).number).toBe('1.');
         expect((list.children[1] as NumberedDocumentNode).number).toBe('2.');
@@ -2823,7 +2824,7 @@ describe('useTreeOperations', () => {
       });
 
       test('list node + unordered: sets all children numbers to null', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2842,15 +2843,15 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'LIST', 'unordered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
 
         expect((list.children[0] as NumberedDocumentNode).number).toBeNull();
         expect((list.children[1] as NumberedDocumentNode).number).toBeNull();
       });
 
       test('list node + lettered: changes all children to a., b., c.', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2873,8 +2874,8 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'LIST', 'lettered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
 
         expect((list.children[0] as NumberedDocumentNode).number).toBe('a.');
         expect((list.children[1] as NumberedDocumentNode).number).toBe('b.');
@@ -2882,7 +2883,7 @@ describe('useTreeOperations', () => {
       });
 
       test('list node + non-list target: does nothing', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2920,7 +2921,7 @@ describe('useTreeOperations', () => {
         // list -> content is valid (issue #80: flattens with number preservation),
         // and list -> heading is a no-op (covered elsewhere). list -> footnote
         // remains unsupported because there's no meaningful semantics for it.
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2945,7 +2946,7 @@ describe('useTreeOperations', () => {
 
     describe('adjacent list merging', () => {
       test('merges with preceding list when converting to list', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -2972,21 +2973,21 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'numbered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Should have merged into one list
         expect(newDoc.children.length).toBe(1);
         expect(newDoc.children[0].type).toBe('LIST');
-        const mergedList = newDoc.children[0] as ContainerDocumentNode;
+        const mergedList = newDoc.children[0] as ListDocumentNode;
         expect(mergedList.children.length).toBe(2);
         expect(mergedList.children[0].id).toBe('li1');
         // The converted content's id is now in the child content node
-        const newItem = mergedList.children[1] as ContainerDocumentNode;
+        const newItem = mergedList.children[1] as ListItemDocumentNode;
         expect((newItem.children[0] as LeafDocumentNode).id).toBe('p1');
       });
 
       test('merges with following list when converting to list', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3013,21 +3014,21 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'numbered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Should have merged into one list
         expect(newDoc.children.length).toBe(1);
         expect(newDoc.children[0].type).toBe('LIST');
-        const mergedList = newDoc.children[0] as ContainerDocumentNode;
+        const mergedList = newDoc.children[0] as ListDocumentNode;
         expect(mergedList.children.length).toBe(2);
         // The converted content's id is now in the child content node
-        const newItem = mergedList.children[0] as ContainerDocumentNode;
+        const newItem = mergedList.children[0] as ListItemDocumentNode;
         expect((newItem.children[0] as LeafDocumentNode).id).toBe('p1');
         expect(mergedList.children[1].id).toBe('li1');
       });
 
       test('merges with both surrounding lists when converting to list', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3060,22 +3061,22 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'numbered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Should have merged all three into one list
         expect(newDoc.children.length).toBe(1);
         expect(newDoc.children[0].type).toBe('LIST');
-        const mergedList = newDoc.children[0] as ContainerDocumentNode;
+        const mergedList = newDoc.children[0] as ListDocumentNode;
         expect(mergedList.children.length).toBe(3);
         expect(mergedList.children[0].id).toBe('li1');
         // The converted content's id is now in the child content node
-        const newItem = mergedList.children[1] as ContainerDocumentNode;
+        const newItem = mergedList.children[1] as ListItemDocumentNode;
         expect((newItem.children[0] as LeafDocumentNode).id).toBe('p1');
         expect(mergedList.children[2].id).toBe('li2');
       });
 
       test('does not merge lists separated by other nodes', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3110,7 +3111,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'numbered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Should have 3 children: list1, heading, and new list
         expect(newDoc.children.length).toBe(3);
@@ -3122,7 +3123,7 @@ describe('useTreeOperations', () => {
 
     describe('content -> footnote', () => {
       test('converts content to footnote (leaf node without children)', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3144,7 +3145,7 @@ describe('useTreeOperations', () => {
         });
 
         expect(mockCommit).toHaveBeenCalledTimes(1);
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as LeafDocumentNode;
 
         expect(converted.type).toBe('FOOTNOTE');
@@ -3155,7 +3156,7 @@ describe('useTreeOperations', () => {
       });
 
       test('preserves id, number, and contents', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3176,7 +3177,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'FOOTNOTE');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as LeafDocumentNode;
 
         expect(converted.id).toBe('p1');
@@ -3186,7 +3187,7 @@ describe('useTreeOperations', () => {
       });
 
       test('lifts footnote children when converting content with footnotes', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3230,7 +3231,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'FOOTNOTE');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Should have 4 children: converted p1, fn1, fn2, p2
         expect(newDoc.children.length).toBe(4);
@@ -3242,7 +3243,7 @@ describe('useTreeOperations', () => {
       });
 
       test('does nothing when already footnote', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3268,7 +3269,7 @@ describe('useTreeOperations', () => {
 
     describe('heading -> footnote', () => {
       test('converts heading to footnote and lifts children', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3314,7 +3315,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['h1'], 'FOOTNOTE');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Should have 4 children: converted h1, p1, p2, h2
         expect(newDoc.children.length).toBe(4);
@@ -3327,7 +3328,7 @@ describe('useTreeOperations', () => {
       });
 
       test('converts heading without children to footnote', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3348,7 +3349,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['h1'], 'FOOTNOTE');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as LeafDocumentNode;
 
         expect(converted.type).toBe('FOOTNOTE');
@@ -3361,7 +3362,7 @@ describe('useTreeOperations', () => {
 
     describe('footnote -> content', () => {
       test('converts footnote to content (adds empty children array)', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3382,7 +3383,7 @@ describe('useTreeOperations', () => {
         });
 
         expect(mockCommit).toHaveBeenCalledTimes(1);
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as ContentDocumentNode;
 
         expect(converted.type).toBe('CONTENT');
@@ -3393,7 +3394,7 @@ describe('useTreeOperations', () => {
       });
 
       test('preserves multi-language contents', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3413,7 +3414,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['fn1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as ContentDocumentNode;
 
         expect(converted.contents.de).toBe('German');
@@ -3424,7 +3425,7 @@ describe('useTreeOperations', () => {
 
     describe('footnote conversion edge cases', () => {
       test('cannot convert list to footnote', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3447,7 +3448,7 @@ describe('useTreeOperations', () => {
       });
 
       test('cannot convert list_item to footnote', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3473,7 +3474,7 @@ describe('useTreeOperations', () => {
     // Issue #80: lossless number preservation between lists and content nodes.
     describe('list_item -> content (number preservation, issue #80)', () => {
       test('preserves list_item.number on the converted content node when it is the only item', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3492,7 +3493,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as ContentDocumentNode;
 
         expect(converted.type).toBe('CONTENT');
@@ -3501,7 +3502,7 @@ describe('useTreeOperations', () => {
       });
 
       test('handles a list_item with no content child (empty contents, default format)', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3527,7 +3528,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as ContentDocumentNode;
 
         expect(converted.type).toBe('CONTENT');
@@ -3538,7 +3539,7 @@ describe('useTreeOperations', () => {
       });
 
       test('preserves the list_item content format when converting to content', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3573,7 +3574,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as ContentDocumentNode;
 
         expect(converted.format).toBe('MARKDOWN');
@@ -3581,7 +3582,7 @@ describe('useTreeOperations', () => {
       });
 
       test('preserves list_item.number when extracted from a multi-item list', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3603,10 +3604,10 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li2'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         // Remaining list_item is untouched
-        const list = newDoc.children[0] as ContainerDocumentNode;
+        const list = newDoc.children[0] as ListDocumentNode;
         expect((list.children[0] as NumberedDocumentNode).number).toBe('1.');
 
         // Extracted content carries its old list_item number
@@ -3618,7 +3619,7 @@ describe('useTreeOperations', () => {
 
     describe('list_item -> heading (number preservation, issue #80)', () => {
       test('preserves list_item.number on the converted heading node', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3637,7 +3638,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['li1'], 'HEADING');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as HeadingDocumentNode;
 
         expect(converted.type).toBe('HEADING');
@@ -3647,7 +3648,7 @@ describe('useTreeOperations', () => {
 
     describe('list -> content (issue #80)', () => {
       test('flattens all list_items into content nodes, preserving each number', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3670,7 +3671,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         expect(newDoc.children.length).toBe(3);
 
@@ -3690,7 +3691,7 @@ describe('useTreeOperations', () => {
       });
 
       test('preserves null number for unnumbered items', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3709,7 +3710,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         expect(newDoc.children.length).toBe(2);
         expect((newDoc.children[0] as ContentDocumentNode).number).toBeNull();
@@ -3717,7 +3718,7 @@ describe('useTreeOperations', () => {
       });
 
       test('flattens nested list recursively, preserving inner numbers', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3762,7 +3763,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         expect(newDoc.children.length).toBe(4);
 
@@ -3782,7 +3783,7 @@ describe('useTreeOperations', () => {
       });
 
       test('preserves source order when nested list precedes the content child', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3823,7 +3824,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         expect(newDoc.children.length).toBe(2);
 
@@ -3838,7 +3839,7 @@ describe('useTreeOperations', () => {
       });
 
       test('preserves the source content format on the flattened content node', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3873,7 +3874,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as ContentDocumentNode;
 
         expect(converted.format).toBe('MARKDOWN');
@@ -3881,7 +3882,7 @@ describe('useTreeOperations', () => {
       });
 
       test('lifts a list_item with multiple content children, attaching the number to the first', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3924,7 +3925,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         expect(newDoc.children.length).toBe(2);
 
@@ -3942,7 +3943,7 @@ describe('useTreeOperations', () => {
       });
 
       test('synthesizes a placeholder content node for a list_item with no content child', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -3968,7 +3969,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
         expect(newDoc.children.length).toBe(1);
         const placeholder = newDoc.children[0] as ContentDocumentNode;
@@ -3980,7 +3981,7 @@ describe('useTreeOperations', () => {
       });
 
       test('preserves footnote children of the list_item content', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4023,7 +4024,7 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['list1'], 'CONTENT');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const converted = newDoc.children[0] as ContentDocumentNode;
 
         expect(converted.children.length).toBe(1);
@@ -4032,7 +4033,7 @@ describe('useTreeOperations', () => {
       });
 
       test('list -> heading is still a no-op', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4057,7 +4058,7 @@ describe('useTreeOperations', () => {
 
     describe('content -> list (number preservation, issue #80)', () => {
       test('unordered preserves the content original number on the new list_item', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4078,15 +4079,15 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'unordered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
-        const item = list.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
+        const item = list.children[0] as ListItemDocumentNode;
 
         expect((item as NumberedDocumentNode).number).toBe('Art. 5');
       });
 
       test('numbered overwrites the content number with the generated sequence', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4107,15 +4108,15 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'numbered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
-        const item = list.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
+        const item = list.children[0] as ListItemDocumentNode;
 
         expect((item as NumberedDocumentNode).number).toBe('1.');
       });
 
       test('lettered overwrites the content number with the generated sequence', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4136,15 +4137,15 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'lettered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
-        const item = list.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
+        const item = list.children[0] as ListItemDocumentNode;
 
         expect((item as NumberedDocumentNode).number).toBe('a.');
       });
 
       test('unordered with null content number stays null', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4165,9 +4166,9 @@ describe('useTreeOperations', () => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'unordered');
         });
 
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = newDoc.children[0] as ContainerDocumentNode;
-        const item = list.children[0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = newDoc.children[0] as ListDocumentNode;
+        const item = list.children[0] as ListItemDocumentNode;
 
         expect((item as NumberedDocumentNode).number).toBeNull();
       });
@@ -4175,7 +4176,7 @@ describe('useTreeOperations', () => {
 
     describe('roundtrip content <-> unordered list (issue #80)', () => {
       test('content -> unordered list -> content preserves number', () => {
-        const startDoc: ContainerDocumentNode = {
+        const startDoc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4195,9 +4196,9 @@ describe('useTreeOperations', () => {
         act(() => {
           result.current.changeNodeTypes(['p1'], 'LIST', 'unordered');
         });
-        const afterToList = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-        const list = afterToList.children[0] as ContainerDocumentNode;
-        const listItem = list.children[0] as ContainerDocumentNode;
+        const afterToList = mockCommit.mock.calls[0][0] as DocumentRootNode;
+        const list = afterToList.children[0] as ListDocumentNode;
+        const listItem = list.children[0] as ListItemDocumentNode;
         expect((listItem as NumberedDocumentNode).number).toBe('Art. 5');
 
         // Step 2: list_item -> content (rebuild hook over the new doc)
@@ -4206,7 +4207,7 @@ describe('useTreeOperations', () => {
         act(() => {
           result2.current.changeNodeTypes([listItem.id], 'CONTENT');
         });
-        const afterRoundtrip = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const afterRoundtrip = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const finalContent = afterRoundtrip.children[0] as ContentDocumentNode;
 
         expect(finalContent.type).toBe('CONTENT');
@@ -4217,7 +4218,7 @@ describe('useTreeOperations', () => {
 
   describe('changeNodeTypes (batch)', () => {
     test('changes type for multiple content nodes to heading', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -4256,14 +4257,14 @@ describe('useTreeOperations', () => {
 
       // Single commit for all three changes
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children[0].type).toBe('HEADING');
       expect(newDoc.children[1].type).toBe('HEADING');
       expect(newDoc.children[2].type).toBe('HEADING');
     });
 
     test('handles mixed node types (content + heading -> footnote)', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -4293,7 +4294,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children[0].type).toBe('FOOTNOTE');
       expect(newDoc.children[1].type).toBe('FOOTNOTE');
     });
@@ -4309,7 +4310,7 @@ describe('useTreeOperations', () => {
     });
 
     test('numbers a numbered-list batch sequentially (1., 2., 3.)', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -4346,10 +4347,10 @@ describe('useTreeOperations', () => {
         result.current.changeNodeTypes(['p1', 'p2', 'p3'], 'LIST', 'numbered');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
       expect(newDoc.children.length).toBe(1);
-      const list = newDoc.children[0] as ContainerDocumentNode;
+      const list = newDoc.children[0] as ListDocumentNode;
       expect(list.type).toBe('LIST');
       expect(list.children.length).toBe(3);
       expect((list.children[0] as NumberedDocumentNode).number).toBe('1.');
@@ -4358,7 +4359,7 @@ describe('useTreeOperations', () => {
     });
 
     test('letters a lettered-list batch sequentially (a., b., c.)', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -4395,9 +4396,9 @@ describe('useTreeOperations', () => {
         result.current.changeNodeTypes(['p1', 'p2', 'p3'], 'LIST', 'lettered');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
-      const list = newDoc.children[0] as ContainerDocumentNode;
+      const list = newDoc.children[0] as ListDocumentNode;
       expect(list.children.length).toBe(3);
       expect((list.children[0] as NumberedDocumentNode).number).toBe('a.');
       expect((list.children[1] as NumberedDocumentNode).number).toBe('b.');
@@ -4415,7 +4416,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
       // h1b should now be first, h1 second
       expect(newDoc.children.length).toBe(2);
@@ -4433,7 +4434,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
       // h1b should now be inside h1, after p1
       const h1 = newDoc.children[0] as HeadingDocumentNode;
@@ -4453,7 +4454,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       expect(h1.children.length).toBe(2);
@@ -4471,7 +4472,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
 
       // p2 should now be at root level after h1b
       expect(newDoc.children.length).toBe(3);
@@ -4517,7 +4518,7 @@ describe('useTreeOperations', () => {
 
     describe('parent-child validation', () => {
       test('rejects moving content directly into list', () => {
-        const docWithList: ContainerDocumentNode = {
+        const docWithList: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4551,7 +4552,7 @@ describe('useTreeOperations', () => {
       });
 
       test('rejects moving heading directly into list', () => {
-        const docWithList: ContainerDocumentNode = {
+        const docWithList: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4619,15 +4620,15 @@ describe('useTreeOperations', () => {
         });
 
         expect(mockCommit).toHaveBeenCalledTimes(1);
-        const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+        const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
         const h1 = newDoc.children[0] as HeadingDocumentNode;
-        const list = h1.children[0] as ContainerDocumentNode;
+        const list = h1.children[0] as ListDocumentNode;
         expect(list.children[0].id).toBe('li3');
         expect(list.children[1].id).toBe('li1');
       });
 
       test('allows moving list_item to different list', () => {
-        const docWithTwoLists: ContainerDocumentNode = {
+        const docWithTwoLists: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4658,7 +4659,7 @@ describe('useTreeOperations', () => {
       });
 
       test('allows moving content into list_item', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4691,7 +4692,7 @@ describe('useTreeOperations', () => {
       });
 
       test('allows moving nested list into list_item', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4722,7 +4723,7 @@ describe('useTreeOperations', () => {
       });
 
       test('rejects moving footnote directly into list', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4753,7 +4754,7 @@ describe('useTreeOperations', () => {
       });
 
       test('rejects moving list directly into list (must be in list_item)', () => {
-        const doc: ContainerDocumentNode = {
+        const doc: DocumentRootNode = {
           id: 'root',
           type: 'DOCUMENT',
           children: [
@@ -4817,7 +4818,7 @@ describe('useTreeOperations', () => {
     });
 
     test('returns null when move would be invalid (content to list)', () => {
-      const docWithList: ContainerDocumentNode = {
+      const docWithList: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -4876,7 +4877,7 @@ describe('useTreeOperations', () => {
     });
 
     test('returns list id for valid list_item moves between lists', () => {
-      const docWithTwoLists: ContainerDocumentNode = {
+      const docWithTwoLists: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -4912,7 +4913,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       const p1 = h1.children[0] as ContentDocumentNode;
       expect(p1.format).toBe('MARKDOWN');
@@ -4949,7 +4950,7 @@ describe('useTreeOperations', () => {
         result.current.addNodeAfter('p1');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       const newNode = h1.children[1] as ContentDocumentNode;
       expect(newNode.type).toBe('CONTENT');
@@ -4963,7 +4964,7 @@ describe('useTreeOperations', () => {
         result.current.addNodeBefore('h2');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       const newNode = h1.children[1] as ContentDocumentNode;
       expect(newNode.format).toBe('TEXT');
@@ -4977,10 +4978,10 @@ describe('useTreeOperations', () => {
         result.current.addNodeAfter('li1');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
-      const list = h1.children[0] as ContainerDocumentNode;
-      const newItem = list.children[1] as ContainerDocumentNode;
+      const list = h1.children[0] as ListDocumentNode;
+      const newItem = list.children[1] as ListItemDocumentNode;
       const inner = newItem.children[0] as ContentDocumentNode;
       expect(inner.format).toBe('TEXT');
     });
@@ -4988,7 +4989,7 @@ describe('useTreeOperations', () => {
 
   describe('changeNodeTypes — format preservation/reset', () => {
     test('preserves an allowed format when converting content → footnote (NEWLINES is allowed on both)', () => {
-      const docWithMarkdown: ContainerDocumentNode = {
+      const docWithMarkdown: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5008,14 +5009,14 @@ describe('useTreeOperations', () => {
         result.current.changeNodeTypes(['p'], 'FOOTNOTE');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const f = newDoc.children[0] as LeafDocumentNode;
       expect(f.type).toBe('FOOTNOTE');
       expect(f.format).toBe('NEWLINES');
     });
 
     test('resets to TEXT when converting content (MARKDOWN) → heading (MARKDOWN not allowed)', () => {
-      const docWithMarkdown: ContainerDocumentNode = {
+      const docWithMarkdown: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5035,7 +5036,7 @@ describe('useTreeOperations', () => {
         result.current.changeNodeTypes(['p'], 'HEADING');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h = newDoc.children[0] as HeadingDocumentNode;
       expect(h.type).toBe('HEADING');
       expect(h.format).toBe('TEXT');
@@ -5044,7 +5045,7 @@ describe('useTreeOperations', () => {
     });
 
     test('preserves NEWLINES when converting heading → content (still allowed)', () => {
-      const docWithNewlines: ContainerDocumentNode = {
+      const docWithNewlines: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5064,7 +5065,7 @@ describe('useTreeOperations', () => {
         result.current.changeNodeTypes(['h'], 'CONTENT');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const c = newDoc.children[0] as ContentDocumentNode;
       expect(c.type).toBe('CONTENT');
       expect(c.format).toBe('NEWLINES');
@@ -5073,7 +5074,7 @@ describe('useTreeOperations', () => {
 
   describe('moveNodesToBoundary', () => {
     // Flat root with four siblings, used by reordering tests.
-    const createFlatDocument = (): ContainerDocumentNode => ({
+    const createFlatDocument = (): DocumentRootNode => ({
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -5121,7 +5122,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['C', 'A', 'B', 'D']);
     });
 
@@ -5133,7 +5134,7 @@ describe('useTreeOperations', () => {
         result.current.moveNodesToBoundary(['A'], 'bottom');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['B', 'C', 'D', 'A']);
     });
 
@@ -5145,7 +5146,7 @@ describe('useTreeOperations', () => {
         result.current.moveNodesToBoundary(['B', 'C'], 'top');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['B', 'C', 'A', 'D']);
     });
 
@@ -5157,7 +5158,7 @@ describe('useTreeOperations', () => {
         result.current.moveNodesToBoundary(['B', 'C'], 'bottom');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['A', 'D', 'B', 'C']);
     });
 
@@ -5173,7 +5174,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['h1b', 'h1']);
       const h1 = newDoc.children[1] as HeadingDocumentNode;
       // p1 was already first inside h1; relative order untouched.
@@ -5220,7 +5221,7 @@ describe('useTreeOperations', () => {
         result.current.moveNodesToBoundary(['nonexistent', 'C'], 'top');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['C', 'A', 'B', 'D']);
     });
 
@@ -5233,9 +5234,9 @@ describe('useTreeOperations', () => {
         result.current.moveNodesToBoundary(['li3'], 'top');
       });
 
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
-      const list = h1.children[0] as ContainerDocumentNode;
+      const list = h1.children[0] as ListDocumentNode;
       expect(list.children.map((c) => c.id)).toEqual(['li3', 'li1', 'li2']);
     });
 
@@ -5253,7 +5254,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       // h1 moved to bottom of root.
       expect(newDoc.children.map((c) => c.id)).toEqual(['h1b', 'h1']);
       // p2 is the only child of h2, so it stays put — h1's subtree is unchanged.
@@ -5273,7 +5274,7 @@ describe('useTreeOperations', () => {
       });
 
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['h1b', 'h1']);
       // p1 is still the first child of h1 — no actual change inside h1.
       const h1 = newDoc.children[1] as HeadingDocumentNode;
@@ -5283,7 +5284,7 @@ describe('useTreeOperations', () => {
 
   describe('mergeNodes', () => {
     // Doc with two adjacent content nodes (p1, p1b) sharing parent h1, plus a heading sibling.
-    const createMergeDoc = (): ContainerDocumentNode => ({
+    const createMergeDoc = (): DocumentRootNode => ({
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -5342,7 +5343,7 @@ describe('useTreeOperations', () => {
 
     test('does nothing when selected siblings are non-contiguous', () => {
       // Build doc with three content siblings under h1 (p1, pmid, p1b) so we can pick non-adjacent ones.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5398,7 +5399,7 @@ describe('useTreeOperations', () => {
     });
 
     test('does nothing for image nodes', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5431,7 +5432,7 @@ describe('useTreeOperations', () => {
         result.current.mergeNodes(['p1', 'p1b']);
       });
       expect(mockCommit).toHaveBeenCalledTimes(1);
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       // p1b should be removed; p1 should now hold the joined content.
       expect(h1.children.map((c) => c.id)).toEqual(['p1', 'h2']);
@@ -5441,7 +5442,7 @@ describe('useTreeOperations', () => {
     });
 
     test('merging content nodes preserves per-language text — empty languages are skipped', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5467,7 +5468,7 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['pA', 'pB']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const merged = newDoc.children[0] as ContentDocumentNode;
       // de: pB is empty so result is just 'D-A' (no leading/trailing newline).
       expect(merged.contents.de).toBe('D-A');
@@ -5481,7 +5482,7 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['p1', 'p1b']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
       const merged = h1.children[0] as ContentDocumentNode;
       expect(merged.format).toBe('NEWLINES');
@@ -5490,7 +5491,7 @@ describe('useTreeOperations', () => {
     test('merging NEWLINES+MARKDOWN content nodes uses MARKDOWN and joins with a blank line', () => {
       // A single `\n` renders as a space in markdown, so paragraph breaks need
       // `\n\n` — otherwise the merge would visually concatenate the prose.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5516,14 +5517,14 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['pA', 'pB']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const merged = newDoc.children[0] as ContentDocumentNode;
       expect(merged.format).toBe('MARKDOWN');
       expect(merged.contents.de).toBe('a\n\nb');
     });
 
     test('merging content nodes concatenates footnote children in source order', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5572,13 +5573,13 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['pA', 'pB']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const merged = newDoc.children[0] as ContentDocumentNode;
       expect(merged.children.map((c) => c.id)).toEqual(['fnA1', 'fnB1', 'fnB2']);
     });
 
     test('merging two heading nodes joins contents with a single space', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5604,7 +5605,7 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['hA', 'hB']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const merged = newDoc.children[0] as HeadingDocumentNode;
       expect(merged.id).toBe('hA');
       expect(merged.number).toBe('1');
@@ -5613,7 +5614,7 @@ describe('useTreeOperations', () => {
 
     test('merging heading nodes does not promote format above its allowed set (TEXT stays TEXT)', () => {
       // Headings join with whitespace, so there's no need to floor to NEWLINES — TEXT must remain valid.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5639,13 +5640,13 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['hA', 'hB']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const merged = newDoc.children[0] as HeadingDocumentNode;
       expect(merged.format).toBe('TEXT');
     });
 
     test('merging heading nodes appends children in source order', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5689,13 +5690,13 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['hA', 'hB']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const merged = newDoc.children[0] as HeadingDocumentNode;
       expect(merged.children.map((c) => c.id)).toEqual(['pA1', 'pB1']);
     });
 
     test('merging two footnote nodes joins contents with newlines and floors format to NEWLINES', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5728,7 +5729,7 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['fnA', 'fnB']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const holder = newDoc.children[0] as ContentDocumentNode;
       expect(holder.children.map((c) => c.id)).toEqual(['fnA']);
       const merged = holder.children[0] as LeafDocumentNode;
@@ -5737,7 +5738,7 @@ describe('useTreeOperations', () => {
     });
 
     test('merging two list_items concatenates their children', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5757,16 +5758,16 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['liA', 'liB']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-      const list = newDoc.children[0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+      const list = newDoc.children[0] as ListDocumentNode;
       // liB removed; liA absorbed liB's child content.
       expect(list.children.map((c) => c.id)).toEqual(['liA', 'liC']);
-      const merged = list.children[0] as ContainerDocumentNode;
+      const merged = list.children[0] as ListItemDocumentNode;
       expect(merged.children.map((c) => c.id)).toEqual(['liA-content', 'liB-content']);
     });
 
     test('merging two lists concatenates list_item children', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5788,9 +5789,9 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['listA', 'listB']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['listA']);
-      const merged = newDoc.children[0] as ContainerDocumentNode;
+      const merged = newDoc.children[0] as ListDocumentNode;
       expect(merged.children.map((c) => c.id)).toEqual(['liA1', 'liB1', 'liB2']);
     });
 
@@ -5803,7 +5804,7 @@ describe('useTreeOperations', () => {
     });
 
     test('merges three contiguous content nodes in flat order', () => {
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5837,7 +5838,7 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(['pA', 'pB', 'pC']);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       expect(newDoc.children.map((c) => c.id)).toEqual(['pA']);
       const merged = newDoc.children[0] as ContentDocumentNode;
       expect(merged.contents.de).toBe('A\nB\nC');
@@ -5855,7 +5856,7 @@ describe('useTreeOperations', () => {
     test('tolerates descendants in the selection: merges list_items even when their content children are also selected', () => {
       // Shift-click over list_items typically picks up nested content children too.
       // Those children shouldn't block the merge — they come along inside the merged container.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5879,11 +5880,11 @@ describe('useTreeOperations', () => {
       act(() => {
         result.current.mergeNodes(selection);
       });
-      const newDoc = mockCommit.mock.calls[0][0] as ContainerDocumentNode;
-      const list = newDoc.children[0] as ContainerDocumentNode;
+      const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
+      const list = newDoc.children[0] as ListDocumentNode;
       // liB and liC are gone; liA absorbed their content children in order.
       expect(list.children.map((c) => c.id)).toEqual(['liA']);
-      const merged = list.children[0] as ContainerDocumentNode;
+      const merged = list.children[0] as ListItemDocumentNode;
       expect(merged.children.map((c) => c.id)).toEqual([
         'liA-content',
         'liB-content',
@@ -5894,7 +5895,7 @@ describe('useTreeOperations', () => {
     test('rejects when the selection has no qualifying ancestors (only descendants of different parents)', () => {
       // Selecting only content children of two different list_items should still fail —
       // those children have different parents and aren't siblings to each other.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [
@@ -5912,7 +5913,7 @@ describe('useTreeOperations', () => {
 
     test('rejects when ancestor and lone descendant collapse to a single id', () => {
       // {li, li-content} → filter drops li-content → only li remains → too few to merge.
-      const doc: ContainerDocumentNode = {
+      const doc: DocumentRootNode = {
         id: 'root',
         type: 'DOCUMENT',
         children: [

--- a/src/hooks/useTreeOperations.ts
+++ b/src/hooks/useTreeOperations.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 import type {
-  ContainerDocumentNode,
   ContentBearingNodeType,
   DocumentNode,
+  DocumentRootNode,
   HeadingDocumentNode,
   Language,
   LeafDocumentNode,
@@ -35,8 +35,8 @@ import {
 export type MoveResult = { success: true } | { success: false; reason: string };
 
 interface UseTreeOperationsProps {
-  document: ContainerDocumentNode;
-  commit: (doc: ContainerDocumentNode, saveHistory?: boolean) => void;
+  document: DocumentRootNode;
+  commit: (doc: DocumentRootNode, saveHistory?: boolean) => void;
   nodeIndex: Map<string, NodePath>;
   parentIndex: Map<string, string>;
   language: Language;

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -50,9 +50,6 @@ export type NodeFormat = 'TEXT' | 'NEWLINES' | 'MARKDOWN_MINIMAL' | 'MARKDOWN_IN
 /** Node types that carry `contents` and a `format` (i.e. anything that can hold text/an image). */
 export type ContentBearingNodeType = 'HEADING' | 'CONTENT' | 'FOOTNOTE' | 'IMAGE';
 
-/** Container-only node types: they hold `children` but no `contents`/`format` of their own. */
-export type ContainerDocumentNodeType = 'DOCUMENT' | 'LIST' | 'LIST_ITEM';
-
 /** Leaf node types: they carry `contents` but never `children`. */
 export type LeafDocumentNodeType = 'IMAGE' | 'FOOTNOTE';
 
@@ -163,20 +160,13 @@ export type ParentDocumentNode =
 export type NumberedDocumentNode = Exclude<DocumentNode, DocumentRootNode>;
 
 /**
- * Convenience grouping alias for the container-only node types (tree root + list structure);
- * matches the previous `ContainerDocumentNode` membership exactly. Prefer the specific per-type
- * interfaces in new code — consumers are migrated off this alias in the follow-up to issue #104.
- */
-export type ContainerDocumentNode = DocumentRootNode | ListDocumentNode | ListItemDocumentNode;
-
-/**
  * Convenience grouping alias for the leaf node types. Prefer {@link FootnoteDocumentNode} or
  * {@link ImageDocumentNode} directly in new code.
  */
 export type LeafDocumentNode = FootnoteDocumentNode | ImageDocumentNode;
 
 /** A node type that may legally contain children, plus `null` for the document's root level. */
-export type ParentType = ContainerDocumentNodeType | 'HEADING' | 'CONTENT' | null;
+export type ParentType = 'DOCUMENT' | 'LIST' | 'LIST_ITEM' | 'HEADING' | 'CONTENT' | null;
 
 /**
  * Versioned wrapper around an exported document tree. Lets the export format evolve (and later
@@ -189,9 +179,7 @@ export interface DocTreeMetadata {
 export interface DocTreeEnvelope {
   DocTreeVersion: typeof DOC_TREE_VERSION;
   metadata: DocTreeMetadata;
-  // The deprecated `ContainerDocumentNode` alias still includes the document root; the app-wide
-  // document type is migrated to `DocumentRootNode` as part of the deferred follow-up to #104.
-  document: ContainerDocumentNode;
+  document: DocumentRootNode;
 }
 
 /**
@@ -220,7 +208,7 @@ export const DEFAULT_FORMAT: Record<ContentBearingNodeType, NodeFormat> = {
 
 export const DOC_TREE_VERSION = 1 as const;
 
-const CONTAINER_TYPES: ContainerDocumentNodeType[] = ['DOCUMENT', 'LIST', 'LIST_ITEM'];
+const CONTAINER_TYPES: ('DOCUMENT' | 'LIST' | 'LIST_ITEM')[] = ['DOCUMENT', 'LIST', 'LIST_ITEM'];
 const LEAF_TYPES: LeafDocumentNodeType[] = ['IMAGE', 'FOOTNOTE'];
 const VALID_FORMATS: NodeFormat[] = [
   'TEXT',
@@ -240,10 +228,7 @@ const ALLOWED_CHILDREN = {
   LIST_ITEM: ['HEADING', 'LIST', 'CONTENT', 'FOOTNOTE', 'IMAGE'],
   LIST: ['LIST_ITEM'],
   CONTENT: ['FOOTNOTE'],
-} as const satisfies Record<
-  ContainerDocumentNodeType | 'HEADING' | 'CONTENT',
-  DocumentNode['type'][]
->;
+} as const satisfies Record<NonNullable<ParentType>, DocumentNode['type'][]>;
 
 /**
  * Compile-time guard: the runtime `ALLOWED_CHILDREN` table and the typed `children` unions encode
@@ -322,12 +307,12 @@ const isValidNodeInternal = (
   if (parentType !== null && !canBeChildOf(type, parentType)) return false;
 
   // Container nodes
-  if (CONTAINER_TYPES.includes(type as ContainerDocumentNodeType)) {
+  if (CONTAINER_TYPES.includes(type as 'DOCUMENT' | 'LIST' | 'LIST_ITEM')) {
     if (!Array.isArray(node.children)) return false;
     if ('contents' in node) return false;
     if ('format' in node) return false;
     return node.children.every((child) =>
-      isValidNodeInternal(child, type as ContainerDocumentNodeType, seenIds)
+      isValidNodeInternal(child, type as 'DOCUMENT' | 'LIST' | 'LIST_ITEM', seenIds)
     );
   }
 

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -1,4 +1,4 @@
-import type { ContainerDocumentNode, DocumentNode, Language } from './document';
+import type { DocumentNode, DocumentRootNode, Language } from './document';
 
 /**
  * Path from root to a node, represented as array of child indices.
@@ -32,7 +32,7 @@ export interface FlattenedNode {
  * Complete editor state for the tree-based editor.
  */
 export interface TreeEditorState {
-  document: ContainerDocumentNode;
+  document: DocumentRootNode;
   selection: EditorSelection;
   editingId: string | null;
   language: Language;

--- a/src/utils/document-storage.test.ts
+++ b/src/utils/document-storage.test.ts
@@ -1,6 +1,6 @@
 import { IDBFactory } from 'fake-indexeddb';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { ContainerDocumentNode } from '../types/document';
+import type { DocumentRootNode } from '../types/document';
 import {
   __setStorageEstimatorForTesting,
   __setWriteFailHookForTesting,
@@ -15,7 +15,7 @@ import {
   updateEntryTree,
 } from './document-storage';
 
-function makeTree(text = 'hello'): ContainerDocumentNode {
+function makeTree(text = 'hello'): DocumentRootNode {
   return {
     id: 'root',
     type: 'DOCUMENT',

--- a/src/utils/document-storage.ts
+++ b/src/utils/document-storage.ts
@@ -1,4 +1,4 @@
-import type { ContainerDocumentNode, Language } from '../types/document';
+import type { DocumentRootNode, Language } from '../types/document';
 import { migrateEntry, SCHEMA_VERSION } from './document-storage-migrations';
 
 export const MAX_RECENTS = 20;
@@ -24,7 +24,7 @@ export interface StoredDocumentEntry {
   name: string;
   subtitle: string | null;
   language: Language;
-  tree: ContainerDocumentNode;
+  tree: DocumentRootNode;
   source: StoredEntrySource;
   createdAt: number;
   updatedAt: number;
@@ -64,7 +64,7 @@ export interface CreateEntryInput {
   name: string;
   subtitle: string | null;
   language: Language;
-  tree: ContainerDocumentNode;
+  tree: DocumentRootNode;
   source: StoredEntrySource;
 }
 
@@ -202,7 +202,7 @@ export async function closeDb(): Promise<void> {
   }
 }
 
-function computeByteSize(tree: ContainerDocumentNode, source: StoredEntrySource): number {
+function computeByteSize(tree: DocumentRootNode, source: StoredEntrySource): number {
   const treeBytes = new TextEncoder().encode(JSON.stringify(tree)).byteLength;
   const sourceBytes =
     typeof source.bytes === 'string'
@@ -315,11 +315,11 @@ async function attemptCreate(entry: StoredDocumentEntry): Promise<void> {
   await awaitTransaction(tx);
 }
 
-export function updateEntryTree(id: string, tree: ContainerDocumentNode): Promise<void> {
+export function updateEntryTree(id: string, tree: DocumentRootNode): Promise<void> {
   return trackWrite(updateEntryTreeImpl(id, tree));
 }
 
-async function updateEntryTreeImpl(id: string, tree: ContainerDocumentNode): Promise<void> {
+async function updateEntryTreeImpl(id: string, tree: DocumentRootNode): Promise<void> {
   try {
     await attemptUpdate(id, tree);
   } catch (err) {
@@ -336,7 +336,7 @@ async function updateEntryTreeImpl(id: string, tree: ContainerDocumentNode): Pro
   // refreshed on the next structural change or on view transition.
 }
 
-async function attemptUpdate(id: string, tree: ContainerDocumentNode): Promise<void> {
+async function attemptUpdate(id: string, tree: DocumentRootNode): Promise<void> {
   checkWriteFailHook();
 
   const db = await openDb();
@@ -359,7 +359,7 @@ async function attemptUpdate(id: string, tree: ContainerDocumentNode): Promise<v
 
 async function projectUpdatedEntry(
   id: string,
-  tree: ContainerDocumentNode
+  tree: DocumentRootNode
 ): Promise<StoredDocumentEntry | null> {
   const db = await openDb();
   const tx = db.transaction(STORE, 'readonly');

--- a/src/utils/document-utils.test.ts
+++ b/src/utils/document-utils.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
-  type ContainerDocumentNode,
   type ContentDocumentNode,
   DOC_TREE_VERSION,
   type DocumentNode,
+  type DocumentRootNode,
   type HeadingDocumentNode,
   isValidDocTreeEnvelope,
   type LeafDocumentNode,
+  type ListDocumentNode,
+  type ListItemDocumentNode,
   type NumberedDocumentNode,
+  type ParentDocumentNode,
 } from '../types/document';
 import {
   buildDocTreeEnvelope,
@@ -34,7 +37,7 @@ describe('deriveJsonFilename', () => {
 });
 
 describe('buildDocTreeEnvelope', () => {
-  const tree: ContainerDocumentNode = {
+  const tree: DocumentRootNode = {
     id: 'root',
     type: 'DOCUMENT',
     children: [
@@ -214,10 +217,10 @@ describe('Document Utils', () => {
       const html = '<ul><li>Item 1</li><li>Item 2</li></ul>';
       const doc = parseHtmlToTree(html);
       expect(doc.children.length).toBe(1);
-      const list = doc.children[0] as ContainerDocumentNode;
+      const list = doc.children[0] as ListDocumentNode;
       expect(list.type).toBe('LIST');
       expect(list.children.length).toBe(2);
-      const item1 = list.children[0] as ContainerDocumentNode;
+      const item1 = list.children[0] as ListItemDocumentNode;
       expect(item1.type).toBe('LIST_ITEM');
       expect((item1 as NumberedDocumentNode).number).toBeNull(); // ul has no numbering
       // Content is now in a child content node
@@ -229,15 +232,15 @@ describe('Document Utils', () => {
     it('converts ol with numbering in number field', () => {
       const html = '<ol><li>First</li><li>Second</li></ol>';
       const doc = parseHtmlToTree(html);
-      const list = doc.children[0] as ContainerDocumentNode;
+      const list = doc.children[0] as ListDocumentNode;
       expect(list.type).toBe('LIST');
-      const item1 = list.children[0] as ContainerDocumentNode;
+      const item1 = list.children[0] as ListItemDocumentNode;
       expect(item1.type).toBe('LIST_ITEM');
       expect((item1 as NumberedDocumentNode).number).toBe('1.');
       // Content is now in a child content node
       const item1Content = item1.children[0] as LeafDocumentNode;
       expect(item1Content.type).toBe('CONTENT');
-      const item2 = list.children[1] as ContainerDocumentNode;
+      const item2 = list.children[1] as ListItemDocumentNode;
       expect((item2 as NumberedDocumentNode).number).toBe('2.');
     });
 
@@ -248,13 +251,13 @@ describe('Document Utils', () => {
 <li style="list-style-type: 'c) ';">Third item</li>
 </ol>`;
       const doc = parseHtmlToTree(html);
-      const list = doc.children[0] as ContainerDocumentNode;
+      const list = doc.children[0] as ListDocumentNode;
       expect(list.type).toBe('LIST');
-      const item1 = list.children[0] as ContainerDocumentNode;
+      const item1 = list.children[0] as ListItemDocumentNode;
       expect((item1 as NumberedDocumentNode).number).toBe('a)');
-      const item2 = list.children[1] as ContainerDocumentNode;
+      const item2 = list.children[1] as ListItemDocumentNode;
       expect((item2 as NumberedDocumentNode).number).toBe('b)');
-      const item3 = list.children[2] as ContainerDocumentNode;
+      const item3 = list.children[2] as ListItemDocumentNode;
       expect((item3 as NumberedDocumentNode).number).toBe('c)');
     });
 
@@ -272,12 +275,12 @@ describe('Document Utils', () => {
         <li>Er regelt zudem die schulpsychologische Versorgung im Bereich der Volksschule und die <br />ergänzenden Angebote.</li>
       </ol>`;
       const doc = parseHtmlToTree(html);
-      const list = doc.children[0] as ContainerDocumentNode;
+      const list = doc.children[0] as ListDocumentNode;
       expect(list.type).toBe('LIST');
       expect(list.children.length).toBe(3);
 
       // Second item should have content + nested list
-      const item2 = list.children[1] as ContainerDocumentNode;
+      const item2 = list.children[1] as ListItemDocumentNode;
       expect(item2.type).toBe('LIST_ITEM');
       expect(item2.children.length).toBe(2); // content + nested list
 
@@ -285,11 +288,11 @@ describe('Document Utils', () => {
       expect(item2Content.type).toBe('CONTENT');
       expect(item2Content.contents.de).toContain('Er gilt für:');
 
-      const nestedList = item2.children[1] as ContainerDocumentNode;
+      const nestedList = item2.children[1] as ListDocumentNode;
       expect(nestedList.type).toBe('LIST');
       expect(nestedList.children.length).toBe(4);
 
-      const nestedItem1 = nestedList.children[0] as ContainerDocumentNode;
+      const nestedItem1 = nestedList.children[0] as ListItemDocumentNode;
       expect(nestedItem1.type).toBe('LIST_ITEM');
       expect((nestedItem1 as NumberedDocumentNode).number).toBe('1.');
       const nestedItem1Content = nestedItem1.children[0] as ContentDocumentNode;
@@ -308,8 +311,8 @@ describe('Document Utils', () => {
     it('preserves <sup> in list item content as MARKDOWN', () => {
       const html = '<ol><li><sup>1</sup> Dieser Erlass regelt das Bildungswesen.</li></ol>';
       const doc = parseHtmlToTree(html);
-      const list = doc.children[0] as ContainerDocumentNode;
-      const item = list.children[0] as ContainerDocumentNode;
+      const list = doc.children[0] as ListDocumentNode;
+      const item = list.children[0] as ListItemDocumentNode;
       const content = item.children[0] as ContentDocumentNode;
       expect(content.type).toBe('CONTENT');
       expect(content.format).toBe('MARKDOWN');
@@ -665,9 +668,9 @@ describe('Document Utils', () => {
       const html = '<p>a. First item</p><p>b. Second item</p>';
       const doc = parseHtmlLegalToTree(html);
       // Should be converted to a list with lettered items
-      const list = doc.children[0] as ContainerDocumentNode;
+      const list = doc.children[0] as ListDocumentNode;
       expect(list.type).toBe('LIST');
-      const item1 = list.children[0] as ContainerDocumentNode;
+      const item1 = list.children[0] as ListItemDocumentNode;
       expect(item1.type).toBe('LIST_ITEM');
       expect((item1 as NumberedDocumentNode).number).toBe('a.');
       // Content is now in a child content node
@@ -693,12 +696,12 @@ describe('Document Utils', () => {
     it('accumulates multiple lettered items into single list', () => {
       const html = '<p>a. first</p><p>b. second</p><p>c. third</p>';
       const doc = parseHtmlLegalToTree(html);
-      const list = doc.children[0] as ContainerDocumentNode;
+      const list = doc.children[0] as ListDocumentNode;
       expect(list.type).toBe('LIST');
       expect(list.children.length).toBe(3);
-      expect((list.children[0] as LeafDocumentNode).number).toBe('a.');
-      expect((list.children[1] as LeafDocumentNode).number).toBe('b.');
-      expect((list.children[2] as LeafDocumentNode).number).toBe('c.');
+      expect((list.children[0] as ListItemDocumentNode).number).toBe('a.');
+      expect((list.children[1] as ListItemDocumentNode).number).toBe('b.');
+      expect((list.children[2] as ListItemDocumentNode).number).toBe('c.');
     });
 
     it('detects multiple roman numeral sections', () => {
@@ -781,11 +784,11 @@ describe('Document Utils', () => {
       expect(hasHeadings).toBe(true);
 
       // Find the ol list and verify list-style-type is preserved
-      const allLists: ContainerDocumentNode[] = [];
+      const allLists: ListDocumentNode[] = [];
       const collectLists = (node: DocumentNode) => {
-        if (node.type === 'LIST') allLists.push(node as ContainerDocumentNode);
+        if (node.type === 'LIST') allLists.push(node);
         if ('children' in node) {
-          for (const child of (node as ContainerDocumentNode).children) {
+          for (const child of node.children) {
             collectLists(child);
           }
         }
@@ -819,13 +822,11 @@ describe('Document Utils', () => {
       expect(doc.children.length).toBeGreaterThan(0);
 
       // Check that some nodes exist (headings from legal patterns)
-      const flattenNodes = (
-        node: ContainerDocumentNode | HeadingDocumentNode
-      ): (ContainerDocumentNode | HeadingDocumentNode | LeafDocumentNode)[] => {
-        const result: (ContainerDocumentNode | HeadingDocumentNode | LeafDocumentNode)[] = [node];
+      const flattenNodes = (node: ParentDocumentNode): DocumentNode[] => {
+        const result: DocumentNode[] = [node];
         for (const child of node.children) {
           if ('children' in child) {
-            result.push(...flattenNodes(child as ContainerDocumentNode | HeadingDocumentNode));
+            result.push(...flattenNodes(child));
           } else {
             result.push(child);
           }
@@ -860,12 +861,12 @@ describe('isEmptyDocument', () => {
   };
 
   it('returns true for a DOCUMENT with no children', () => {
-    const doc: ContainerDocumentNode = { id: 'root', type: 'DOCUMENT', children: [] };
+    const doc: DocumentRootNode = { id: 'root', type: 'DOCUMENT', children: [] };
     expect(isEmptyDocument(doc)).toBe(true);
   });
 
   it('returns true for a tree whose only nodes carry no text', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -899,7 +900,7 @@ describe('isEmptyDocument', () => {
   it('treats a node whose only text lives in `number` as non-empty', () => {
     // Swiss legal transforms move labels like "Art. 5" into `number`, leaving
     // `contents` empty — that is still real content, not an empty import.
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [

--- a/src/utils/document-utils.ts
+++ b/src/utils/document-utils.ts
@@ -1,7 +1,6 @@
 import DOMPurify from 'dompurify';
 import {
   type BlockDocumentNode,
-  type ContainerDocumentNode,
   type ContentDocumentNode,
   DOC_TREE_VERSION,
   type DocTreeEnvelope,
@@ -37,7 +36,7 @@ export const deriveJsonFilename = (filename: string | null | undefined): string 
  * from the source filename (extension stripped) and keyed by `language`.
  */
 export const buildDocTreeEnvelope = (
-  document: ContainerDocumentNode,
+  document: DocumentRootNode,
   options: { language: Language; filename?: string | null }
 ): DocTreeEnvelope => {
   const stripped = options.filename ? stripFileExtension(options.filename).trim() : '';
@@ -89,7 +88,7 @@ export const preserveListStyleType = (html: string): string => {
  * PDF→HTML output that is only positioned <span>s) so the UI can warn instead
  * of silently opening an empty editor.
  */
-export const isEmptyDocument = (doc: ContainerDocumentNode): boolean => {
+export const isEmptyDocument = (doc: DocumentRootNode): boolean => {
   const hasText = (node: DocumentNode): boolean => {
     // A label like "Art. 5" or "I." that legal transforms moved into `number` is
     // still real content even when `contents` is empty. (The document root has no `number`.)
@@ -115,7 +114,7 @@ export const isEmptyDocument = (doc: ContainerDocumentNode): boolean => {
 export const parseHtmlToTree = (
   html: string,
   language: Language = detectLanguage(html)
-): ContainerDocumentNode => {
+): DocumentRootNode => {
   const preprocessedHtml = preserveListStyleType(html);
   const cleanHtml = DOMPurify.sanitize(preprocessedHtml, {
     ALLOWED_TAGS: [
@@ -360,7 +359,7 @@ export const parseHtmlToTree = (
 export const parseHtmlLegalToTree = (
   html: string,
   language: Language = detectLanguage(html)
-): ContainerDocumentNode => {
+): DocumentRootNode => {
   const tree = parseHtmlToTree(html, language);
   return applySwissLegalTransforms(tree, language);
 };

--- a/src/utils/file-processing.ts
+++ b/src/utils/file-processing.ts
@@ -1,10 +1,10 @@
 import * as mammoth from 'mammoth';
-import type { ContainerDocumentNode } from '../types/document';
+import type { DocumentRootNode } from '../types/document';
 import type { StoredEntrySource } from './document-storage';
 import { generateId, parseHtmlLegalToTree } from './document-utils';
 
 export interface ProcessedDocument {
-  doc: ContainerDocumentNode;
+  doc: DocumentRootNode;
   sourceUrl: string | null;
   html?: string;
   /** Bytes + metadata needed to persist the entry and rebuild the preview later. */
@@ -33,7 +33,7 @@ export function makePastedSubtitle(text: string): string {
   return `${trimmed.slice(0, cut)} ...`;
 }
 
-export function createPlainTextDocument(text: string): ContainerDocumentNode {
+export function createPlainTextDocument(text: string): DocumentRootNode {
   const lines = text.split('\n').filter((line) => line.trim().length > 0);
   return {
     id: generateId(),

--- a/src/utils/legal-transforms/article.ts
+++ b/src/utils/legal-transforms/article.ts
@@ -1,7 +1,7 @@
 import type {
-  ContainerDocumentNode,
   ContentDocumentNode,
   DocumentNode,
+  DocumentRootNode,
   HeadingDocumentNode,
   Language,
 } from '../../types/document';
@@ -98,8 +98,8 @@ function processChildren(children: DocumentNode[], _language: Language): Documen
  *       content("Article content")
  */
 export const articleTransform: TreeTransform = (
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   language: Language
-): ContainerDocumentNode => {
+): DocumentRootNode => {
   return withMappedChildren(root, (children) => processChildren(children, language));
 };

--- a/src/utils/legal-transforms/heading-number-extract.ts
+++ b/src/utils/legal-transforms/heading-number-extract.ts
@@ -1,4 +1,4 @@
-import type { ContainerDocumentNode, DocumentNode, Language } from '../../types/document';
+import type { DocumentNode, DocumentRootNode, Language } from '../../types/document';
 import { withMappedChildren } from '../tree-utils';
 import {
   extractCleanText,
@@ -76,9 +76,9 @@ function processNode(node: DocumentNode, language: Language): DocumentNode {
  * `number` field on headings that already exist.
  */
 export const headingNumberExtractTransform: TreeTransform = (
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   language: Language
-): ContainerDocumentNode => {
+): DocumentRootNode => {
   return withMappedChildren(root, (children) =>
     children.map((child) => processNode(child, language))
   );

--- a/src/utils/legal-transforms/index.test.ts
+++ b/src/utils/legal-transforms/index.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type {
-  ContainerDocumentNode,
   ContentDocumentNode,
+  DocumentRootNode,
   HeadingDocumentNode,
+  ListDocumentNode,
   NumberedDocumentNode,
 } from '../../types/document';
 import { applySwissLegalTransforms, composeTransforms } from './index';
@@ -10,7 +11,7 @@ import { content, createDoc, heading, list } from './test-helpers';
 
 describe('composeTransforms', () => {
   it('applies transforms left to right', () => {
-    const addPrefix = (root: ContainerDocumentNode) => ({
+    const addPrefix = (root: DocumentRootNode) => ({
       ...root,
       children: root.children.map((c) =>
         c.type === 'CONTENT'
@@ -18,7 +19,7 @@ describe('composeTransforms', () => {
           : c
       ),
     });
-    const addSuffix = (root: ContainerDocumentNode) => ({
+    const addSuffix = (root: DocumentRootNode) => ({
       ...root,
       children: root.children.map((c) =>
         c.type === 'CONTENT'
@@ -45,7 +46,7 @@ describe('composeTransforms', () => {
   });
 
   it('works with single transform', () => {
-    const upper = (root: ContainerDocumentNode) => ({
+    const upper = (root: DocumentRootNode) => ({
       ...root,
       children: root.children.map((c) =>
         c.type === 'CONTENT'
@@ -94,7 +95,7 @@ describe('applySwissLegalTransforms', () => {
     expect(article.children[0].type).toBe('LIST');
 
     // List should have 2 items
-    const list = article.children[0] as ContainerDocumentNode;
+    const list = article.children[0] as ListDocumentNode;
     expect(list.children).toHaveLength(2);
     expect((list.children[0] as NumberedDocumentNode).number).toBe('a.');
     expect((list.children[1] as NumberedDocumentNode).number).toBe('b.');
@@ -136,7 +137,7 @@ describe('applySwissLegalTransforms', () => {
 
     expect(result.children).toHaveLength(1);
     expect(result.children[0].type).toBe('LIST');
-    const merged = result.children[0] as ContainerDocumentNode;
+    const merged = result.children[0] as ListDocumentNode;
     expect(merged.children).toHaveLength(2);
   });
 
@@ -171,7 +172,7 @@ describe('applySwissLegalTransforms', () => {
     const result = applySwissLegalTransforms(input, 'de');
 
     expect(result.children).toHaveLength(1);
-    const merged = result.children[0] as ContainerDocumentNode;
+    const merged = result.children[0] as ListDocumentNode;
     expect(merged.children.map((c) => (c as NumberedDocumentNode).number)).toEqual([
       'a)',
       'b)',

--- a/src/utils/legal-transforms/index.ts
+++ b/src/utils/legal-transforms/index.ts
@@ -1,4 +1,4 @@
-import type { ContainerDocumentNode, Language } from '../../types/document';
+import type { DocumentRootNode, Language } from '../../types/document';
 import { articleTransform } from './article';
 import { headingNumberExtractTransform } from './heading-number-extract';
 import { letteredItemsTransform } from './lettered-items';
@@ -40,7 +40,7 @@ export interface LegalTransformConfig {
  * Applies transforms left-to-right.
  */
 export function composeTransforms(...transforms: TreeTransform[]): TreeTransform {
-  return (root: ContainerDocumentNode, language: Language): ContainerDocumentNode =>
+  return (root: DocumentRootNode, language: Language): DocumentRootNode =>
     transforms.reduce((tree, transform) => transform(tree, language), root);
 }
 
@@ -62,10 +62,10 @@ export function composeTransforms(...transforms: TreeTransform[]): TreeTransform
  * @returns A new transformed tree
  */
 export function applySwissLegalTransforms(
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   language: Language,
   config: LegalTransformConfig = {}
-): ContainerDocumentNode {
+): DocumentRootNode {
   const {
     mergeAdjacentLists = true,
     headingNumberExtract = true,

--- a/src/utils/legal-transforms/lettered-items.test.ts
+++ b/src/utils/legal-transforms/lettered-items.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type {
-  ContainerDocumentNode,
   ContentDocumentNode,
   HeadingDocumentNode,
+  ListDocumentNode,
+  ListItemDocumentNode,
   NumberedDocumentNode,
 } from '../../types/document';
 import { letteredItemsTransform } from './lettered-items';
@@ -16,7 +17,7 @@ describe('letteredItemsTransform', () => {
 
     expect(result.children).toHaveLength(1);
     expect(result.children[0].type).toBe('LIST');
-    expect((result.children[0] as ContainerDocumentNode).children).toHaveLength(2);
+    expect((result.children[0] as ListDocumentNode).children).toHaveLength(2);
   });
 
   it('sets correct number on list items', () => {
@@ -24,7 +25,7 @@ describe('letteredItemsTransform', () => {
 
     const result = letteredItemsTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
     expect((listNode.children[0] as NumberedDocumentNode).number).toBe('a.');
   });
 
@@ -33,8 +34,8 @@ describe('letteredItemsTransform', () => {
 
     const result = letteredItemsTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
-    const listItem = listNode.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
+    const listItem = listNode.children[0] as ListItemDocumentNode;
     const contentNode = listItem.children[0] as ContentDocumentNode;
     expect(contentNode.contents.de).toBe('First item text');
   });
@@ -48,11 +49,10 @@ describe('letteredItemsTransform', () => {
 
     const result = letteredItemsTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
     expect(listNode.type).toBe('LIST');
-    const first = (listNode.children[0] as ContainerDocumentNode)
-      .children[0] as ContentDocumentNode;
-    const second = (listNode.children[1] as ContainerDocumentNode)
+    const first = (listNode.children[0] as ListItemDocumentNode).children[0] as ContentDocumentNode;
+    const second = (listNode.children[1] as ListItemDocumentNode)
       .children[0] as ContentDocumentNode;
     expect(first.contents.de).toBe('First item');
     expect(second.contents.de).toBe('Second item');
@@ -70,10 +70,10 @@ describe('letteredItemsTransform', () => {
 
     expect(result.children).toHaveLength(3);
     expect(result.children[0].type).toBe('LIST');
-    expect((result.children[0] as ContainerDocumentNode).children).toHaveLength(2);
+    expect((result.children[0] as ListDocumentNode).children).toHaveLength(2);
     expect(result.children[1].type).toBe('CONTENT');
     expect(result.children[2].type).toBe('LIST');
-    expect((result.children[2] as ContainerDocumentNode).children).toHaveLength(1);
+    expect((result.children[2] as ListDocumentNode).children).toHaveLength(1);
   });
 
   it('applies recursively to nested containers', () => {
@@ -179,7 +179,7 @@ describe('letteredItemsTransform', () => {
 
     const result = letteredItemsTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
     expect(listNode.children).toHaveLength(4);
     expect((listNode.children[0] as NumberedDocumentNode).number).toBe('a.');
     expect((listNode.children[3] as NumberedDocumentNode).number).toBe('z.');
@@ -190,11 +190,11 @@ describe('letteredItemsTransform', () => {
 
     const result = letteredItemsTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
     const listItem = listNode.children[0];
     expect(listItem.type).toBe('LIST_ITEM');
-    expect((listItem as ContainerDocumentNode).children).toHaveLength(1);
-    expect((listItem as ContainerDocumentNode).children[0].type).toBe('CONTENT');
+    expect((listItem as ListItemDocumentNode).children).toHaveLength(1);
+    expect((listItem as ListItemDocumentNode).children[0].type).toBe('CONTENT');
   });
 
   it('handles deeply nested structure', () => {
@@ -219,8 +219,8 @@ describe('letteredItemsTransform', () => {
 
     const result = letteredItemsTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
-    const listItem = listNode.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
+    const listItem = listNode.children[0] as ListItemDocumentNode;
     const contentNode = listItem.children[0] as ContentDocumentNode;
     expect(contentNode.contents.de).toBe('Bold item');
   });

--- a/src/utils/legal-transforms/lettered-items.ts
+++ b/src/utils/legal-transforms/lettered-items.ts
@@ -1,7 +1,7 @@
 import type {
-  ContainerDocumentNode,
   ContentDocumentNode,
   DocumentNode,
+  DocumentRootNode,
   Language,
   ListDocumentNode,
 } from '../../types/document';
@@ -128,8 +128,8 @@ function processChildren(children: DocumentNode[], language: Language): Document
  *     content("Regular text")
  */
 export const letteredItemsTransform: TreeTransform = (
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   language: Language
-): ContainerDocumentNode => {
+): DocumentRootNode => {
   return withMappedChildren(root, (children) => processChildren(children, language));
 };

--- a/src/utils/legal-transforms/list-number-dedup.test.ts
+++ b/src/utils/legal-transforms/list-number-dedup.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
-  type ContainerDocumentNode,
   type ContentDocumentNode,
   type HeadingDocumentNode,
   isValidDocument,
   type ListDocumentNode,
+  type ListItemDocumentNode,
   type NumberedDocumentNode,
 } from '../../types/document';
 import { generateId, parseHtmlToTree } from '../document-utils';
@@ -22,7 +22,7 @@ describe('listNumberDedupTransform', () => {
 
     const result = listNumberDedupTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
     expect((listNode.children[0] as NumberedDocumentNode).number).toBe('1');
     expect((listNode.children[1] as NumberedDocumentNode).number).toBe('2');
   });
@@ -34,8 +34,8 @@ describe('listNumberDedupTransform', () => {
 
     const result = listNumberDedupTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
-    const listItem = listNode.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
+    const listItem = listNode.children[0] as ListItemDocumentNode;
     const contentNode = listItem.children[0] as ContentDocumentNode;
     expect(contentNode.contents.de).toBe('Dieser Erlass regelt das Bildungswesen.');
   });
@@ -90,11 +90,11 @@ describe('listNumberDedupTransform', () => {
 
     const result = listNumberDedupTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
     expect((listNode.children[0] as NumberedDocumentNode).number).toBe('1.');
     expect((listNode.children[1] as NumberedDocumentNode).number).toBe('2.');
 
-    const content0 = (listNode.children[0] as ContainerDocumentNode)
+    const content0 = (listNode.children[0] as ListItemDocumentNode)
       .children[0] as ContentDocumentNode;
     expect(content0.contents.de).toBe('No leading number here');
   });
@@ -110,7 +110,7 @@ describe('listNumberDedupTransform', () => {
 
     const result = listNumberDedupTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
     expect((listNode.children[0] as NumberedDocumentNode).number).toBe('1');
     expect((listNode.children[1] as NumberedDocumentNode).number).toBe('1bis');
     expect((listNode.children[2] as NumberedDocumentNode).number).toBe('2');
@@ -129,7 +129,7 @@ describe('listNumberDedupTransform', () => {
     const result = listNumberDedupTransform(input, 'de');
 
     const h = result.children[0] as HeadingDocumentNode;
-    const listNode = h.children[0] as ContainerDocumentNode;
+    const listNode = h.children[0] as ListDocumentNode;
     expect((listNode.children[0] as NumberedDocumentNode).number).toBe('1');
     expect((listNode.children[1] as NumberedDocumentNode).number).toBe('2');
   });
@@ -156,7 +156,7 @@ describe('listNumberDedupTransform', () => {
 
     const result = listNumberDedupTransform(input, 'de');
 
-    const listNode = result.children[0] as ContainerDocumentNode;
+    const listNode = result.children[0] as ListDocumentNode;
     expect(listNode.children).toHaveLength(0);
   });
 
@@ -185,8 +185,8 @@ describe('listNumberDedupTransform', () => {
 
     const result = listNumberDedupTransform(input, 'de');
 
-    const outerList = result.children[0] as ContainerDocumentNode;
-    const outerItem = outerList.children[0] as ContainerDocumentNode;
+    const outerList = result.children[0] as ListDocumentNode;
+    const outerItem = outerList.children[0] as ListItemDocumentNode;
 
     // Outer item should be deduped
     expect((outerItem as NumberedDocumentNode).number).toBe('1');
@@ -194,15 +194,15 @@ describe('listNumberDedupTransform', () => {
     expect(outerContent.contents.de).toBe('Outer text');
 
     // Inner list should also be deduped
-    const innerList = outerItem.children[1] as ContainerDocumentNode;
+    const innerList = outerItem.children[1] as ListDocumentNode;
     expect((innerList.children[0] as NumberedDocumentNode).number).toBe('1');
     expect((innerList.children[1] as NumberedDocumentNode).number).toBe('2');
 
-    const innerContent0 = (innerList.children[0] as ContainerDocumentNode)
+    const innerContent0 = (innerList.children[0] as ListItemDocumentNode)
       .children[0] as ContentDocumentNode;
     expect(innerContent0.contents.de).toBe('Inner first');
 
-    const innerContent1 = (innerList.children[1] as ContainerDocumentNode)
+    const innerContent1 = (innerList.children[1] as ListItemDocumentNode)
       .children[0] as ContentDocumentNode;
     expect(innerContent1.contents.de).toBe('Inner second');
   });
@@ -226,12 +226,12 @@ describe('listNumberDedupTransform', () => {
 
     const result = listNumberDedupTransform(input, 'de');
 
-    const outerList = result.children[0] as ContainerDocumentNode;
-    const outerItem = outerList.children[0] as ContainerDocumentNode;
+    const outerList = result.children[0] as ListDocumentNode;
+    const outerItem = outerList.children[0] as ListItemDocumentNode;
     // Should not have undefined in children
     expect(outerItem.children.every((c) => c !== undefined)).toBe(true);
     // The nested list should still be processed
-    const innerList = outerItem.children[0] as ContainerDocumentNode;
+    const innerList = outerItem.children[0] as ListDocumentNode;
     expect(innerList.type).toBe('LIST');
     expect((innerList.children[0] as NumberedDocumentNode).number).toBe('1');
   });
@@ -372,7 +372,7 @@ describe('listNumberDedupTransform', () => {
       expect(result.children[1].type).toBe('CONTENT');
       expect(result.children[2].type).toBe('LIST');
 
-      const firstList = result.children[0] as ContainerDocumentNode;
+      const firstList = result.children[0] as ListDocumentNode;
       expect(firstList.children).toHaveLength(1);
       expect((firstList.children[0] as NumberedDocumentNode).number).toBe('1.');
 
@@ -380,7 +380,7 @@ describe('listNumberDedupTransform', () => {
       expect(absatz.number).toBe('^2^');
       expect(absatz.contents.de).toBe('Absatz text');
 
-      const secondList = result.children[2] as ContainerDocumentNode;
+      const secondList = result.children[2] as ListDocumentNode;
       expect(secondList.children).toHaveLength(1);
       expect((secondList.children[0] as NumberedDocumentNode).number).toBe('3.');
       expect(isValidDocument(result)).toBe(true);
@@ -422,9 +422,9 @@ describe('listNumberDedupTransform', () => {
 
       // Stays as list with list_item; markup stripped, number set on the list_item.
       expect(result.children).toHaveLength(1);
-      const outerList = result.children[0] as ContainerDocumentNode;
+      const outerList = result.children[0] as ListDocumentNode;
       expect(outerList.type).toBe('LIST');
-      const li = outerList.children[0] as ContainerDocumentNode;
+      const li = outerList.children[0] as ListItemDocumentNode;
       expect(li.type).toBe('LIST_ITEM');
       expect((li as NumberedDocumentNode).number).toBe('1');
       const content = li.children[0] as ContentDocumentNode;
@@ -540,7 +540,7 @@ describe('listNumberDedupTransform', () => {
       const result = listNumberDedupTransform(input, 'de');
 
       expect(result.children[0].type).toBe('LIST');
-      expect((result.children[0] as ContainerDocumentNode).id).toBe(originalId);
+      expect((result.children[0] as ListDocumentNode).id).toBe(originalId);
     });
 
     it('downgrades format to TEXT when stripping leaves no inline marks', () => {

--- a/src/utils/legal-transforms/list-number-dedup.ts
+++ b/src/utils/legal-transforms/list-number-dedup.ts
@@ -1,8 +1,9 @@
 import type {
-  ContainerDocumentNode,
   ContentDocumentNode,
   DocumentNode,
+  DocumentRootNode,
   Language,
+  ListDocumentNode,
   ListItemDocumentNode,
   NodeFormat,
 } from '../../types/document';
@@ -134,7 +135,7 @@ function processListItem(listItem: ListItemDocumentNode, language: Language): Pr
  * contiguous segments — the original list id stays on the first emitted segment, any
  * subsequent list segments get fresh ids.
  */
-function processList(listNode: ContainerDocumentNode, language: Language): DocumentNode[] {
+function processList(listNode: ListDocumentNode, language: Language): DocumentNode[] {
   const processed = listNode.children.map((item): ProcessedListItem => {
     if (item.type !== 'LIST_ITEM') {
       return { kind: 'LIST_ITEM', node: item };
@@ -222,8 +223,8 @@ function processNode(node: DocumentNode, language: Language): DocumentNode {
  *   (the list is dissolved)
  */
 export const listNumberDedupTransform: TreeTransform = (
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   language: Language
-): ContainerDocumentNode => {
+): DocumentRootNode => {
   return withMappedChildren(root, (children) => processChildren(children, language));
 };

--- a/src/utils/legal-transforms/merge-adjacent-lists.test.ts
+++ b/src/utils/legal-transforms/merge-adjacent-lists.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type {
-  ContainerDocumentNode,
   ContentDocumentNode,
   HeadingDocumentNode,
+  ListDocumentNode,
+  ListItemDocumentNode,
   NumberedDocumentNode,
 } from '../../types/document';
 import { parseHtmlLegalToTree, parseHtmlToTree } from '../document-utils';
@@ -21,10 +22,10 @@ describe('mergeAdjacentListsTransform', () => {
 
       expect(result.children).toHaveLength(1);
       expect(result.children[0].type).toBe('LIST');
-      const merged = result.children[0] as ContainerDocumentNode;
+      const merged = result.children[0] as ListDocumentNode;
       expect(merged.children).toHaveLength(2);
-      const item0 = merged.children[0] as ContainerDocumentNode;
-      const item1 = merged.children[1] as ContainerDocumentNode;
+      const item0 = merged.children[0] as ListItemDocumentNode;
+      const item1 = merged.children[1] as ListItemDocumentNode;
       expect((item0.children[0] as ContentDocumentNode).contents.de).toBe('A');
       expect((item1.children[0] as ContentDocumentNode).contents.de).toBe('B');
     });
@@ -72,7 +73,7 @@ describe('mergeAdjacentListsTransform', () => {
       const result = mergeAdjacentListsTransform(input, 'de');
 
       expect(result.children).toHaveLength(1);
-      const merged = result.children[0] as ContainerDocumentNode;
+      const merged = result.children[0] as ListDocumentNode;
       expect(merged.children).toHaveLength(3);
     });
 
@@ -88,7 +89,7 @@ describe('mergeAdjacentListsTransform', () => {
 
       const h = result.children[0] as HeadingDocumentNode;
       expect(h.children).toHaveLength(1);
-      const merged = h.children[0] as ContainerDocumentNode;
+      const merged = h.children[0] as ListDocumentNode;
       expect(merged.children).toHaveLength(2);
     });
 
@@ -105,11 +106,11 @@ describe('mergeAdjacentListsTransform', () => {
       const result = mergeAdjacentListsTransform(input, 'de');
 
       expect(result.children).toHaveLength(2);
-      const rootList = result.children[0] as ContainerDocumentNode;
+      const rootList = result.children[0] as ListDocumentNode;
       expect(rootList.children).toHaveLength(2);
 
       const h = result.children[1] as HeadingDocumentNode;
-      const nestedList = h.children[0] as ContainerDocumentNode;
+      const nestedList = h.children[0] as ListDocumentNode;
       expect(h.children).toHaveLength(1);
       expect(nestedList.children).toHaveLength(2);
     });
@@ -127,7 +128,7 @@ describe('mergeAdjacentListsTransform', () => {
 
       const result = mergeAdjacentListsTransform(input, 'de');
 
-      const merged = result.children[0] as ContainerDocumentNode;
+      const merged = result.children[0] as ListDocumentNode;
       expect(merged.children).toHaveLength(2);
       expect(merged.children[0].type).toBe('LIST_ITEM');
       expect(merged.children[1].type).toBe('LIST_ITEM');
@@ -137,7 +138,7 @@ describe('mergeAdjacentListsTransform', () => {
       // processListElement (document-utils.ts) appends every nested <ol>/<ul>
       // child of a <li> as a separate list. If Mammoth splits a sub-list
       // across a page, these adjacent sub-lists must also merge.
-      const outerListItem: ContainerDocumentNode = {
+      const outerListItem: ListItemDocumentNode = {
         id: 'outer-item',
         number: '1.',
         type: 'LIST_ITEM',
@@ -158,11 +159,11 @@ describe('mergeAdjacentListsTransform', () => {
 
       const result = mergeAdjacentListsTransform(input, 'de');
 
-      const outerList = result.children[0] as ContainerDocumentNode;
-      const item = outerList.children[0] as ContainerDocumentNode;
+      const outerList = result.children[0] as ListDocumentNode;
+      const item = outerList.children[0] as ListItemDocumentNode;
       // Outer item content + ONE merged nested list (was two).
       expect(item.children).toHaveLength(2);
-      const nestedList = item.children[1] as ContainerDocumentNode;
+      const nestedList = item.children[1] as ListDocumentNode;
       expect(nestedList.type).toBe('LIST');
       expect(nestedList.children).toHaveLength(2);
     });
@@ -199,7 +200,7 @@ describe('mergeAdjacentListsTransform', () => {
 
       const result = mergeAdjacentListsTransform(input, 'de');
 
-      const merged = result.children[0] as ContainerDocumentNode;
+      const merged = result.children[0] as ListDocumentNode;
       const numbers = merged.children.map((c) => (c as NumberedDocumentNode).number);
       expect(numbers).toEqual(['a)', 'b)', 'c)', 'd)', 'a)', 'b)', 'c)']);
     });
@@ -219,7 +220,7 @@ describe('mergeAdjacentListsTransform', () => {
 
       const result = mergeAdjacentListsTransform(input, 'de');
 
-      const merged = result.children[0] as ContainerDocumentNode;
+      const merged = result.children[0] as ListDocumentNode;
       const numbers = merged.children.map((c) => (c as NumberedDocumentNode).number);
       expect(numbers).toEqual(['1.', '2.', '3.', '1.', '2.']);
     });
@@ -235,7 +236,7 @@ describe('mergeAdjacentListsTransform', () => {
 
       const result = mergeAdjacentListsTransform(input, 'de');
 
-      const merged = result.children[0] as ContainerDocumentNode;
+      const merged = result.children[0] as ListDocumentNode;
       const numbers = merged.children.map((c) => (c as NumberedDocumentNode).number);
       expect(numbers).toEqual([null, null, null]);
     });
@@ -249,7 +250,7 @@ describe('mergeAdjacentListsTransform', () => {
       const result = mergeAdjacentListsTransform(tree, 'de');
 
       expect(result.children).toHaveLength(1);
-      const merged = result.children[0] as ContainerDocumentNode;
+      const merged = result.children[0] as ListDocumentNode;
       expect(merged.children).toHaveLength(2);
       // position-derived numbers are preserved as-is (no renumbering)
       expect(merged.children.map((c) => (c as NumberedDocumentNode).number)).toEqual(['1.', '1.']);
@@ -284,7 +285,7 @@ describe('mergeAdjacentListsTransform', () => {
       const tree = parseHtmlLegalToTree(html, 'de');
 
       expect(tree.children).toHaveLength(1);
-      const merged = tree.children[0] as ContainerDocumentNode;
+      const merged = tree.children[0] as ListDocumentNode;
       expect(merged.children).toHaveLength(2);
       // Explicit list-style-type markers preserved exactly — restart kept.
       expect(merged.children.map((c) => (c as NumberedDocumentNode).number)).toEqual(['a)', 'a)']);

--- a/src/utils/legal-transforms/merge-adjacent-lists.ts
+++ b/src/utils/legal-transforms/merge-adjacent-lists.ts
@@ -1,4 +1,4 @@
-import type { ContainerDocumentNode, DocumentNode, Language } from '../../types/document';
+import type { DocumentNode, DocumentRootNode, Language } from '../../types/document';
 import { withMappedChildren } from '../tree-utils';
 import type { TreeTransform } from './types';
 
@@ -45,8 +45,8 @@ function recurseIntoContainer(node: DocumentNode): DocumentNode {
 }
 
 export const mergeAdjacentListsTransform: TreeTransform = (
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   _language: Language
-): ContainerDocumentNode => {
-  return recurseIntoContainer(root) as ContainerDocumentNode;
+): DocumentRootNode => {
+  return recurseIntoContainer(root) as DocumentRootNode;
 };

--- a/src/utils/legal-transforms/roman-section.test.ts
+++ b/src/utils/legal-transforms/roman-section.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { ContainerDocumentNode, HeadingDocumentNode } from '../../types/document';
+import type { DocumentRootNode, HeadingDocumentNode } from '../../types/document';
 import { romanSectionTransform } from './roman-section';
 import { content, createDoc, heading, list } from './test-helpers';
 
@@ -53,7 +53,7 @@ describe('romanSectionTransform', () => {
     const input = heading('Some heading', [content('I. This should not become heading')]);
 
     // HeadingDocumentNode is a valid input but transform should only affect document roots
-    const result = romanSectionTransform(input as unknown as ContainerDocumentNode, 'de');
+    const result = romanSectionTransform(input as unknown as DocumentRootNode, 'de');
 
     expect(result.children[0].type).toBe('CONTENT');
   });

--- a/src/utils/legal-transforms/roman-section.ts
+++ b/src/utils/legal-transforms/roman-section.ts
@@ -1,8 +1,8 @@
 import type {
   BlockDocumentNode,
-  ContainerDocumentNode,
   ContentDocumentNode,
   DocumentNode,
+  DocumentRootNode,
   HeadingDocumentNode,
   Language,
 } from '../../types/document';
@@ -46,9 +46,9 @@ function getRomanSectionMatch(node: DocumentNode): { number: string; rest: strin
  *     heading(number: "II.", "Second Section")
  */
 export const romanSectionTransform: TreeTransform = (
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   _language: Language
-): ContainerDocumentNode => {
+): DocumentRootNode => {
   // Only process document roots
   if (root.type !== 'DOCUMENT') {
     return root;

--- a/src/utils/legal-transforms/test-helpers.ts
+++ b/src/utils/legal-transforms/test-helpers.ts
@@ -1,7 +1,7 @@
 import type {
   BlockDocumentNode,
-  ContainerDocumentNode,
   ContentDocumentNode,
+  DocumentRootNode,
   HeadingDocumentNode,
   Language,
   ListDocumentNode,
@@ -11,7 +11,7 @@ import { generateId } from '../document-utils';
 /**
  * Create a document root node for testing
  */
-export function createDoc(children: BlockDocumentNode[]): ContainerDocumentNode {
+export function createDoc(children: BlockDocumentNode[]): DocumentRootNode {
   return {
     id: generateId(),
     type: 'DOCUMENT',

--- a/src/utils/legal-transforms/types.ts
+++ b/src/utils/legal-transforms/types.ts
@@ -1,4 +1,4 @@
-import type { ContainerDocumentNode, Language } from '../../types/document';
+import type { DocumentRootNode, Language } from '../../types/document';
 
 /**
  * Tree transformation function type.
@@ -6,7 +6,4 @@ import type { ContainerDocumentNode, Language } from '../../types/document';
  * A TreeTransform takes a document tree and returns a new transformed tree.
  * Transforms are composable and should be pure functions.
  */
-export type TreeTransform = (
-  root: ContainerDocumentNode,
-  language: Language
-) => ContainerDocumentNode;
+export type TreeTransform = (root: DocumentRootNode, language: Language) => DocumentRootNode;

--- a/src/utils/outline-utils.test.ts
+++ b/src/utils/outline-utils.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest';
-import type { BlockDocumentNode, ContainerDocumentNode } from '../types/document';
+import type { BlockDocumentNode, DocumentRootNode } from '../types/document';
 import { getDocumentOutline } from './outline-utils';
 
-const makeDoc = (...children: BlockDocumentNode[]): ContainerDocumentNode => ({
+const makeDoc = (...children: BlockDocumentNode[]): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children,

--- a/src/utils/outline-utils.ts
+++ b/src/utils/outline-utils.ts
@@ -1,4 +1,4 @@
-import type { ContainerDocumentNode, DocumentNode, Language } from '../types/document';
+import type { DocumentNode, DocumentRootNode, Language } from '../types/document';
 
 export interface OutlineEntry {
   id: string;
@@ -19,10 +19,7 @@ function getTextContent(
   return stripHtml(text);
 }
 
-export function getDocumentOutline(
-  root: ContainerDocumentNode,
-  language: Language
-): OutlineEntry[] {
+export function getDocumentOutline(root: DocumentRootNode, language: Language): OutlineEntry[] {
   const result: OutlineEntry[] = [];
 
   function walk(node: DocumentNode, depth: number) {

--- a/src/utils/tree-mutations.test.ts
+++ b/src/utils/tree-mutations.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest';
 import type {
   BlockDocumentNode,
-  ContainerDocumentNode,
   ContentDocumentNode,
+  DocumentRootNode,
   FootnoteDocumentNode,
   HeadingDocumentNode,
   LeafDocumentNode,
@@ -74,13 +74,13 @@ const list = (id: string, children: ListItemDocumentNode[]): ListDocumentNode =>
   children,
 });
 
-const doc = (children: BlockDocumentNode[]): ContainerDocumentNode => ({
+const doc = (children: BlockDocumentNode[]): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children,
 });
 
-const idx = (d: ContainerDocumentNode): Map<string, NodePath> => buildIndices(d).nodeIndex;
+const idx = (d: DocumentRootNode): Map<string, NodePath> => buildIndices(d).nodeIndex;
 
 describe('keepOutermostIds', () => {
   test('drops a descendant id when its ancestor is also present, preserving order', () => {
@@ -130,7 +130,7 @@ describe('resolveMergeTargets', () => {
   });
 
   test('filters out descendant ids (outermost wins) without blocking the merge', () => {
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -170,7 +170,7 @@ describe('carryFormatOrDefault', () => {
 
 describe('flattenListToContents', () => {
   test('turns each list_item into a content node carrying its number', () => {
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -184,7 +184,7 @@ describe('flattenListToContents', () => {
   });
 
   test('synthesizes a placeholder content node when a list_item has no content child', () => {
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -196,13 +196,13 @@ describe('flattenListToContents', () => {
   });
 
   test('recursively flattens nested lists after the carrying content node', () => {
-    const nested: ContainerDocumentNode = {
+    const nested: ListDocumentNode = {
       id: 'nested',
       number: null,
       type: 'LIST',
       children: [listItem('li1a', 'inner', 'a.')],
     };
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -224,8 +224,8 @@ describe('flattenListToContents', () => {
 
 describe('createNewSiblingNode', () => {
   test('creates a LIST_ITEM with a CONTENT child when the parent is a LIST', () => {
-    const parent: ContainerDocumentNode = { id: 'l', number: null, type: 'LIST', children: [] };
-    const node = createNewSiblingNode(parent, 'de') as ContainerDocumentNode;
+    const parent: ListDocumentNode = { id: 'l', number: null, type: 'LIST', children: [] };
+    const node = createNewSiblingNode(parent, 'de') as ListItemDocumentNode;
     expect(node.type).toBe('LIST_ITEM');
     expect(node.children[0].type).toBe('CONTENT');
     expect((node.children[0] as ContentDocumentNode).contents).toEqual({ de: '' });
@@ -241,7 +241,7 @@ describe('createNewSiblingNode', () => {
 
 describe('findPreviousSiblingTarget', () => {
   test('returns the nearest preceding HEADING', () => {
-    const parent: ContainerDocumentNode = {
+    const parent: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [heading('h1', 'A'), content('p1', 'x'), content('p2', 'y')],
@@ -251,7 +251,7 @@ describe('findPreviousSiblingTarget', () => {
   });
 
   test('returns a preceding CONTENT node for a FOOTNOTE', () => {
-    const parent: ContainerDocumentNode = {
+    const parent: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [content('p1', 'x'), heading('hh', 'H')],
@@ -262,7 +262,7 @@ describe('findPreviousSiblingTarget', () => {
   });
 
   test('returns null when nothing qualifies', () => {
-    const parent: ContainerDocumentNode = {
+    const parent: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [content('p1', 'x'), content('p2', 'y')],
@@ -282,7 +282,7 @@ describe('indentNodeInDoc', () => {
   });
 
   test('nests a list_item under the preceding list_item via a new nested list', () => {
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -291,8 +291,8 @@ describe('indentNodeInDoc', () => {
     const d = doc([list]);
     const result = indentNodeInDoc(d, idx(d), 'li2');
     expect(result).not.toBeNull();
-    const li1 = getNodeAtPath(result!, [0, 0]) as ContainerDocumentNode;
-    const nested = li1.children.find((c) => c.type === 'LIST') as ContainerDocumentNode;
+    const li1 = getNodeAtPath(result!, [0, 0]) as ListItemDocumentNode;
+    const nested = li1.children.find((c) => c.type === 'LIST') as ListDocumentNode;
     expect(nested).toBeDefined();
     expect(nested.children.map((c) => c.id)).toEqual(['li2']);
   });
@@ -314,7 +314,7 @@ describe('outdentNodeInDoc', () => {
   });
 
   test('lifts a node out of a list_item, splitting the list around it (issue #101)', () => {
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -345,7 +345,7 @@ describe('outdentNodeInDoc', () => {
     // outer list > li1 [content, inner list > [li1a]] , li2
     // Outdenting li1a makes it a sibling of li1; the emptied inner list is removed.
     const inner = list('inner', [listItem('li1a', 'nested')]);
-    const li1: ContainerDocumentNode = {
+    const li1: ListItemDocumentNode = {
       id: 'li1',
       number: '1.',
       type: 'LIST_ITEM',
@@ -354,11 +354,11 @@ describe('outdentNodeInDoc', () => {
     const d = doc([list('outer', [li1, listItem('li2', 'two', '2.')])]);
     const result = outdentNodeInDoc(d, idx(d), 'li1a');
     expect(result).not.toBeNull();
-    const outer = getNodeAtPath(result!, [0]) as ContainerDocumentNode;
+    const outer = getNodeAtPath(result!, [0]) as ListDocumentNode;
     // li1a is now a sibling of li1, between it and li2
     expect(outer.children.map((c) => c.id)).toEqual(['li1', 'li1a', 'li2']);
     // the emptied nested list inside li1 was dropped
-    const li1After = outer.children[0] as ContainerDocumentNode;
+    const li1After = outer.children[0] as ListItemDocumentNode;
     expect(li1After.children.some((c) => c.type === 'LIST')).toBe(false);
   });
 
@@ -370,7 +370,7 @@ describe('outdentNodeInDoc', () => {
 
 describe('liftNodeOutOfListItem', () => {
   test('splits the list_item and list around the lifted node, preserving order', () => {
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -424,14 +424,14 @@ describe('changeNodeTypeInDoc', () => {
     const d = doc([content('p1', 'x')]);
     const result = changeNodeTypeInDoc(d, idx(d), 'p1', 'LIST', 'numbered');
     expect(result).not.toBeNull();
-    const list = getNodeAtPath(result!, [0]) as ContainerDocumentNode;
+    const list = getNodeAtPath(result!, [0]) as ListDocumentNode;
     expect(list.type).toBe('LIST');
     expect(list.children[0].type).toBe('LIST_ITEM');
     expect((list.children[0] as NumberedDocumentNode).number).toBe('1.');
   });
 
   test('flattens a list to content nodes', () => {
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -445,7 +445,7 @@ describe('changeNodeTypeInDoc', () => {
   });
 
   test('extracts a list_item to a content node, preserving its number', () => {
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -481,7 +481,7 @@ describe('changeNodeTypeInDoc', () => {
     const result = changeNodeTypeInDoc(d, idx(d), 'p1', 'LIST', 'numbered');
     expect(result).not.toBeNull();
     expect(result!.children).toHaveLength(1);
-    const merged = result!.children[0] as ContainerDocumentNode;
+    const merged = result!.children[0] as ListDocumentNode;
     expect(merged.type).toBe('LIST');
     expect(merged.children.map((c) => (c as NumberedDocumentNode).number)).toEqual([
       '1.',
@@ -498,7 +498,7 @@ describe('changeNodeTypeInDoc', () => {
 
 describe('extractAndConvertListItemInDoc', () => {
   test('replaces a single-item list with the converted node', () => {
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -513,7 +513,7 @@ describe('extractAndConvertListItemInDoc', () => {
   });
 
   test('inserts the converted first item before the surviving list', () => {
-    const list: ContainerDocumentNode = {
+    const list: ListDocumentNode = {
       id: 'list1',
       number: null,
       type: 'LIST',
@@ -525,7 +525,7 @@ describe('extractAndConvertListItemInDoc', () => {
     expect(result).not.toBeNull();
     expect(result!.children[0]).toMatchObject({ id: 'li1', type: 'HEADING', number: '1.' });
     expect(result!.children[1].type).toBe('LIST');
-    expect((result!.children[1] as ContainerDocumentNode).children).toHaveLength(1);
+    expect((result!.children[1] as ListDocumentNode).children).toHaveLength(1);
   });
 });
 
@@ -596,7 +596,7 @@ describe('mergeNodesInDoc', () => {
     const result = mergeNodesInDoc(['l1', 'l2'], d, idx(d));
     expect(result).not.toBeNull();
     expect(result!.children).toHaveLength(1);
-    const merged = result!.children[0] as ContainerDocumentNode;
+    const merged = result!.children[0] as ListDocumentNode;
     expect(merged.type).toBe('LIST');
     expect(merged.id).toBe('l1');
     expect(merged.children.map((c) => c.id)).toEqual(['a', 'b', 'c']);

--- a/src/utils/tree-mutations.ts
+++ b/src/utils/tree-mutations.ts
@@ -1,8 +1,8 @@
 import type {
-  ContainerDocumentNode,
   ContentBearingNodeType,
   ContentDocumentNode,
   DocumentNode,
+  DocumentRootNode,
   HeadingDocumentNode,
   Language,
   LeafDocumentNode,
@@ -85,7 +85,7 @@ export const keepOutermostIds = (ids: string[], nodeIndex: Map<string, NodePath>
  */
 export const resolveMergeTargets = (
   ids: readonly string[],
-  doc: ContainerDocumentNode,
+  doc: DocumentRootNode,
   nodeIndex: Map<string, NodePath>
 ): NodePath[] | null => {
   if (ids.length < 2) return null;
@@ -130,7 +130,7 @@ export const resolveMergeTargets = (
  */
 export const canMergeIdsInDoc = (
   ids: readonly string[],
-  doc: ContainerDocumentNode,
+  doc: DocumentRootNode,
   nodeIndex: Map<string, NodePath>
 ): boolean => resolveMergeTargets(ids, doc, nodeIndex) !== null;
 
@@ -209,7 +209,7 @@ export const carryFormatOrDefault = (
  * after that content node. Other list_item children (extra content nodes,
  * headings, leaves) are lifted in source order.
  */
-export function flattenListToContents(list: ContainerDocumentNode): DocumentNode[] {
+export function flattenListToContents(list: ListDocumentNode): DocumentNode[] {
   const out: DocumentNode[] = [];
   for (const item of list.children) {
     if (item.type !== 'LIST_ITEM') continue;
@@ -275,9 +275,9 @@ export function flattenListToContents(list: ContainerDocumentNode): DocumentNode
  * (e.g. a malformed list_item not inside a list), so odd inputs are left alone.
  */
 export function liftNodeOutOfListItem(
-  doc: ContainerDocumentNode,
+  doc: DocumentRootNode,
   path: NodePath
-): ContainerDocumentNode | null {
+): DocumentRootNode | null {
   const itemPath = path.slice(0, -1);
   const listPath = itemPath.slice(0, -1);
 
@@ -362,7 +362,7 @@ export function createNewSiblingNode(parent: DocumentNode, language: Language): 
           children: [],
         } as ContentDocumentNode,
       ],
-    } as ContainerDocumentNode;
+    } as ListItemDocumentNode;
   }
 
   return {
@@ -405,10 +405,10 @@ export const findPreviousSiblingTarget = (
  * Returns the new document, or null if the operation can't be performed.
  */
 export const indentNodeInDoc = (
-  doc: ContainerDocumentNode,
+  doc: DocumentRootNode,
   idx: Map<string, NodePath>,
   id: string
-): ContainerDocumentNode | null => {
+): DocumentRootNode | null => {
   const path = idx.get(id);
   if (!path || path.length === 0) return null;
 
@@ -476,10 +476,10 @@ export const indentNodeInDoc = (
  * Returns the new document, or null if the operation can't be performed.
  */
 export const outdentNodeInDoc = (
-  doc: ContainerDocumentNode,
+  doc: DocumentRootNode,
   idx: Map<string, NodePath>,
   id: string
-): ContainerDocumentNode | null => {
+): DocumentRootNode | null => {
   const path = idx.get(id);
   if (!path || path.length <= 1) {
     return null;
@@ -580,14 +580,14 @@ const hasContents = (
  * Returns the new document, or null if the operation can't be performed.
  */
 export const extractAndConvertListItemInDoc = (
-  doc: ContainerDocumentNode,
+  doc: DocumentRootNode,
   itemPath: NodePath,
   item: ListItemDocumentNode,
   targetType: 'HEADING' | 'CONTENT'
-): ContainerDocumentNode | null => {
+): DocumentRootNode | null => {
   const listPath = itemPath.slice(0, -1);
   const itemIndexInList = itemPath[itemPath.length - 1];
-  const list = getNodeAtPath(doc, listPath) as ContainerDocumentNode;
+  const list = getNodeAtPath(doc, listPath) as ListDocumentNode;
 
   if (!list || list.type !== 'LIST') return null;
 
@@ -649,12 +649,12 @@ export const extractAndConvertListItemInDoc = (
  * Returns the new document, or null if the operation can't be performed.
  */
 export const changeNodeTypeInDoc = (
-  doc: ContainerDocumentNode,
+  doc: DocumentRootNode,
   idx: Map<string, NodePath>,
   id: string,
   targetType: 'HEADING' | 'CONTENT' | 'LIST' | 'FOOTNOTE',
   listStyle?: ListStyle
-): ContainerDocumentNode | null => {
+): DocumentRootNode | null => {
   const path = idx.get(id);
   if (!path || path.length === 0) return null; // Can't change root
 
@@ -872,9 +872,9 @@ export const changeNodeTypeInDoc = (
  */
 export const mergeNodesInDoc = (
   ids: readonly string[],
-  doc: ContainerDocumentNode,
+  doc: DocumentRootNode,
   nodeIndex: Map<string, NodePath>
-): ContainerDocumentNode | null => {
+): DocumentRootNode | null => {
   const paths = resolveMergeTargets(ids, doc, nodeIndex);
   if (!paths) return null;
 

--- a/src/utils/tree-utils.test.ts
+++ b/src/utils/tree-utils.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from 'vitest';
 import type {
-  ContainerDocumentNode,
   ContentDocumentNode,
+  DocumentRootNode,
   HeadingDocumentNode,
   LeafDocumentNode,
+  ListDocumentNode,
   ListItemDocumentNode,
 } from '../types/document';
 import {
@@ -40,7 +41,7 @@ const createListItem = (
 });
 
 // Helper to create test documents
-const createTestDocument = (): ContainerDocumentNode => ({
+const createTestDocument = (): DocumentRootNode => ({
   id: 'root',
   type: 'DOCUMENT',
   children: [
@@ -340,7 +341,7 @@ describe('buildIndices', () => {
   });
 
   test('handles deeply nested structure', () => {
-    const deepDoc: ContainerDocumentNode = {
+    const deepDoc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -449,7 +450,7 @@ describe('flattenForRendering', () => {
   });
 
   test('includes list_item children in flattening', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -475,7 +476,7 @@ describe('flattenForRendering', () => {
 
 describe('mergeAdjacentLists', () => {
   test('merges two adjacent lists into one', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -498,14 +499,14 @@ describe('mergeAdjacentLists', () => {
 
     expect(result.children.length).toBe(1);
     expect(result.children[0].type).toBe('LIST');
-    const mergedList = result.children[0] as ContainerDocumentNode;
+    const mergedList = result.children[0] as ListDocumentNode;
     expect(mergedList.children.length).toBe(2);
     expect(mergedList.children[0].id).toBe('item1');
     expect(mergedList.children[1].id).toBe('item2');
   });
 
   test('merges three adjacent lists into one', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -533,12 +534,12 @@ describe('mergeAdjacentLists', () => {
     const result = mergeAdjacentLists(doc, []);
 
     expect(result.children.length).toBe(1);
-    const mergedList = result.children[0] as ContainerDocumentNode;
+    const mergedList = result.children[0] as ListDocumentNode;
     expect(mergedList.children.length).toBe(3);
   });
 
   test('does not merge non-adjacent lists', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -571,7 +572,7 @@ describe('mergeAdjacentLists', () => {
   });
 
   test('returns unchanged document when no lists to merge', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -600,7 +601,7 @@ describe('mergeAdjacentLists', () => {
   });
 
   test('merges lists within nested container', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -632,12 +633,12 @@ describe('mergeAdjacentLists', () => {
 
     const heading = result.children[0] as HeadingDocumentNode;
     expect(heading.children.length).toBe(1);
-    const mergedList = heading.children[0] as ContainerDocumentNode;
+    const mergedList = heading.children[0] as ListDocumentNode;
     expect(mergedList.children.length).toBe(2);
   });
 
   test('preserves first list id when merging', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -693,7 +694,7 @@ describe('nested lists', () => {
   });
 
   test('supports nested lists (list inside list_item)', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -739,7 +740,7 @@ describe('nested lists', () => {
   });
 
   test('flattens nested lists correctly', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -774,7 +775,7 @@ describe('nested lists', () => {
   });
 
   test('computes correct depth for nested list items', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -803,7 +804,7 @@ describe('nested lists', () => {
   });
 
   test('can access and update nested list items', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -840,7 +841,7 @@ describe('nested lists', () => {
   });
 
   test('can remove nested list items', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -861,13 +862,13 @@ describe('nested lists', () => {
     // Remove first nested item
     const updated = removeNodeAtPath(doc, [0, 0, 1, 0]);
 
-    const nestedList = getNodeAtPath(updated, [0, 0, 1]) as ContainerDocumentNode;
+    const nestedList = getNodeAtPath(updated, [0, 0, 1]) as ListDocumentNode;
     expect(nestedList.children.length).toBe(1);
     expect(nestedList.children[0].id).toBe('sub2');
   });
 
   test('can insert items into nested list', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -887,13 +888,13 @@ describe('nested lists', () => {
     const newItem = createListItem('sub2', 'b.', 'Sub B');
     const updated = insertNodeAtPath(doc, [0, 0, 1], 1, newItem);
 
-    const nestedList = getNodeAtPath(updated, [0, 0, 1]) as ContainerDocumentNode;
+    const nestedList = getNodeAtPath(updated, [0, 0, 1]) as ListDocumentNode;
     expect(nestedList.children.length).toBe(2);
     expect(nestedList.children[1].id).toBe('sub2');
   });
 
   test('can move nested list item to parent list', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [
@@ -916,12 +917,12 @@ describe('nested lists', () => {
     const updated = moveNode(doc, [0, 1, 1, 0], [0], 2);
 
     // sub1 should now be in parent list at index 2
-    const parentList = getNodeAtPath(updated, [0]) as ContainerDocumentNode;
+    const parentList = getNodeAtPath(updated, [0]) as ListDocumentNode;
     expect(parentList.children.length).toBe(3);
     expect(parentList.children[2].id).toBe('sub1');
 
     // nested list should only have sub2 now
-    const nestedList = getNodeAtPath(updated, [0, 1, 1]) as ContainerDocumentNode;
+    const nestedList = getNodeAtPath(updated, [0, 1, 1]) as ListDocumentNode;
     expect(nestedList.children.length).toBe(1);
     expect(nestedList.children[0].id).toBe('sub2');
   });
@@ -972,7 +973,7 @@ describe('changeNodeFormat', () => {
   });
 
   test('no-ops when target node is a container (no format)', () => {
-    const doc: ContainerDocumentNode = {
+    const doc: DocumentRootNode = {
       id: 'root',
       type: 'DOCUMENT',
       children: [

--- a/src/utils/tree-utils.ts
+++ b/src/utils/tree-utils.ts
@@ -1,9 +1,9 @@
 import {
   type BlockDocumentNode,
-  type ContainerDocumentNode,
   type ContentBearingNodeType,
   canHaveFormat,
   type DocumentNode,
+  type DocumentRootNode,
   type FootnoteDocumentNode,
   type ListItemDocumentNode,
   type NodeFormat,
@@ -58,13 +58,13 @@ export function getNodeAtPath(root: DocumentNode, path: NodePath): DocumentNode 
  * Uses structural sharing for efficiency.
  */
 export function updateNodeAtPath(
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   path: NodePath,
   updater: (node: DocumentNode) => DocumentNode
-): ContainerDocumentNode {
+): DocumentRootNode {
   // The root passed in is always a container; the recursion below descends through any parent
   // node (headings/content carry children too), so the single boundary cast restores that fact.
-  return updateParentAtPath(root, path, updater) as ContainerDocumentNode;
+  return updateParentAtPath(root, path, updater) as DocumentRootNode;
 }
 
 /**
@@ -101,10 +101,10 @@ function updateParentAtPath(
  * children })` shape — the per-type child cast is handled by {@link withMappedChildren}.
  */
 export function updateChildrenAtPath(
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   path: NodePath,
   map: (children: DocumentNode[]) => DocumentNode[]
-): ContainerDocumentNode {
+): DocumentRootNode {
   return updateNodeAtPath(root, path, (node) =>
     'children' in node ? withMappedChildren(node, map) : node
   );
@@ -118,10 +118,10 @@ const CONTENT_BEARING_TYPES: ContentBearingNodeType[] = ['HEADING', 'CONTENT', '
  * contents untouched. Returns the same root reference if no change was applied.
  */
 export function changeNodeFormat(
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   path: NodePath,
   format: NodeFormat
-): ContainerDocumentNode {
+): DocumentRootNode {
   const node = getNodeAtPath(root, path);
   if (!node) return root;
   if (!CONTENT_BEARING_TYPES.includes(node.type as ContentBearingNodeType)) return root;
@@ -133,11 +133,11 @@ export function changeNodeFormat(
  * Insert a node at a specific position.
  */
 export function insertNodeAtPath(
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   parentPath: NodePath,
   index: number,
   newNode: DocumentNode
-): ContainerDocumentNode {
+): DocumentRootNode {
   return updateNodeAtPath(root, parentPath, (parent) => {
     if (!('children' in parent)) {
       throw new Error('Cannot insert into leaf node');
@@ -153,10 +153,7 @@ export function insertNodeAtPath(
 /**
  * Remove a node at path.
  */
-export function removeNodeAtPath(
-  root: ContainerDocumentNode,
-  path: NodePath
-): ContainerDocumentNode {
+export function removeNodeAtPath(root: DocumentRootNode, path: NodePath): DocumentRootNode {
   if (path.length === 0) {
     throw new Error('Cannot remove root');
   }
@@ -180,11 +177,11 @@ export function removeNodeAtPath(
  * Move a node from one location to another.
  */
 export function moveNode(
-  root: ContainerDocumentNode,
+  root: DocumentRootNode,
   fromPath: NodePath,
   toParentPath: NodePath,
   toIndex: number
-): ContainerDocumentNode {
+): DocumentRootNode {
   const node = getNodeAtPath(root, fromPath);
   if (!node) {
     throw new Error('Source node not found');
@@ -237,7 +234,7 @@ export function moveNode(
 /**
  * Build lookup indices for efficient tree operations.
  */
-export function buildIndices(root: ContainerDocumentNode): {
+export function buildIndices(root: DocumentRootNode): {
   nodeIndex: Map<string, NodePath>;
   parentIndex: Map<string, string>;
 } {
@@ -265,10 +262,7 @@ export function buildIndices(root: ContainerDocumentNode): {
  * Merge adjacent list siblings within a parent container.
  * Combines consecutive lists into a single list.
  */
-export function mergeAdjacentLists(
-  root: ContainerDocumentNode,
-  parentPath: NodePath
-): ContainerDocumentNode {
+export function mergeAdjacentLists(root: DocumentRootNode, parentPath: NodePath): DocumentRootNode {
   const parent = parentPath.length === 0 ? root : getNodeAtPath(root, parentPath);
   if (!parent || !('children' in parent)) return root;
 
@@ -303,7 +297,7 @@ export function mergeAdjacentLists(
 /**
  * Flatten tree to array for rendering, computing connector line metadata.
  */
-export function flattenForRendering(root: ContainerDocumentNode): FlattenedNode[] {
+export function flattenForRendering(root: DocumentRootNode): FlattenedNode[] {
   const result: FlattenedNode[] = [];
 
   function walk(


### PR DESCRIPTION
## Summary
Deferred cleanup split out from #114. Migrates the app-wide *document* type off the imprecise `ContainerDocumentNode` alias to the precise `DocumentRootNode` — a whole document is always a `DOCUMENT` root. Pure **type-level refactor with no runtime behaviour change**.

- Deleted the node-union alias `ContainerDocumentNode` (`DocumentRootNode | ListDocumentNode | ListItemDocumentNode`). Every "the document" usage across ~25 files now uses `DocumentRootNode`; the handful of values that are genuinely a `LIST`/`LIST_ITEM` were narrowed to `ListDocumentNode`/`ListItemDocumentNode` instead (`flattenListToContents`, `createNewSiblingNode`, `extractAndConvertListItemInDoc`, `processList`, `DocumentPreview`'s `ListNode`).
- `DocTreeEnvelope.document` is now `DocumentRootNode`, consistent with the `isValidDocument`/`isValidDocTreeEnvelope` runtime validators (which already require `type: 'DOCUMENT'`).
- Deleted the discriminant-string alias `ContainerDocumentNodeType`: inlined `'DOCUMENT' | 'LIST' | 'LIST_ITEM'` at the container-only sites (`CONTAINER_TYPES`, the two validator casts), and typed the `ALLOWED_CHILDREN` record key as `NonNullable<ParentType>` so it can't drift from `ParentType`.
- `ParentDocumentNode`, `withMappedChildren`, and `LeafDocumentNode` left untouched per the issue.
- No new broad `as any`/`as unknown` casts; test changes are type-token swaps only (no logic/assertion changes), each cast narrowed to its precise node type.

## Test plan
This is a pure type refactor with no new behaviour, so no new tests were added — the existing suite + `tsc` + lint are the regression net (the issue's stated acceptance criteria).

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test:run` — 1196 passed
- [x] `npm run lint` — clean
- [x] `grep -rE "\bContainerDocumentNode(Type)?\b" src/` — empty (both aliases fully removed)

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)