### PR TITLE
Refactor: remove the LeafDocumentNode alias

### DIFF
--- a/src/components/RecursiveTreeNode.test.tsx
+++ b/src/components/RecursiveTreeNode.test.tsx
@@ -4,8 +4,8 @@ import { describe, expect, test, vi } from 'vitest';
 import { TreeUIStore } from '../stores/TreeUIStore';
 import type {
   ContentDocumentNode,
+  FootnoteDocumentNode,
   HeadingDocumentNode,
-  LeafDocumentNode,
   ListDocumentNode,
   ListItemDocumentNode,
 } from '../types/document';
@@ -199,7 +199,7 @@ describe('RecursiveTreeNode', () => {
     });
 
     test('footnote with null number renders a dashed placeholder badge', () => {
-      const node: LeafDocumentNode = {
+      const node: FootnoteDocumentNode = {
         id: 'fn-no-num',
         number: null,
         type: 'FOOTNOTE',
@@ -284,7 +284,7 @@ describe('RecursiveTreeNode', () => {
 
     test('footnote with a number renders a solid badge that is double-clickable', () => {
       const onNumberDoubleClick = vi.fn();
-      const node: LeafDocumentNode = {
+      const node: FootnoteDocumentNode = {
         id: 'fn-with-num',
         number: 'i.',
         type: 'FOOTNOTE',

--- a/src/hooks/useTreeEditor.test.ts
+++ b/src/hooks/useTreeEditor.test.ts
@@ -4,7 +4,6 @@ import type {
   ContentDocumentNode,
   DocumentRootNode,
   HeadingDocumentNode,
-  LeafDocumentNode,
   ListDocumentNode,
 } from '../types/document';
 import { isValidDocument } from '../types/document';
@@ -189,7 +188,7 @@ describe('useTreeEditor', () => {
     });
 
     const h1 = result.current.document.children[0] as HeadingDocumentNode;
-    const p1 = h1.children[0] as LeafDocumentNode;
+    const p1 = h1.children[0] as ContentDocumentNode;
     expect(p1.contents.de).toBe('Updated content');
 
     // Should be able to undo

--- a/src/hooks/useTreeOperations.test.ts
+++ b/src/hooks/useTreeOperations.test.ts
@@ -4,8 +4,8 @@ import type {
   BlockDocumentNode,
   ContentDocumentNode,
   DocumentRootNode,
+  FootnoteDocumentNode,
   HeadingDocumentNode,
-  LeafDocumentNode,
   ListDocumentNode,
   ListItemDocumentNode,
   NumberedDocumentNode,
@@ -153,7 +153,7 @@ describe('useTreeOperations', () => {
       expect(h1.children[0].id).toBe('p1');
       expect(h1.children[2].id).toBe('h2');
       // New node is in the middle
-      const newNode = h1.children[1] as LeafDocumentNode;
+      const newNode = h1.children[1] as ContentDocumentNode;
       expect(newNode.type).toBe('CONTENT');
       expect(newNode.contents.de).toBe('');
     });
@@ -167,7 +167,7 @@ describe('useTreeOperations', () => {
 
       const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
-      const newNode = h1.children[1] as LeafDocumentNode;
+      const newNode = h1.children[1] as ContentDocumentNode;
       expect(newNode.type).toBe('CONTENT');
     });
 
@@ -206,7 +206,7 @@ describe('useTreeOperations', () => {
       expect(h1.children[0].id).toBe('p1');
       expect(h1.children[2].id).toBe('h2');
       // New node is in the middle
-      const newNode = h1.children[1] as LeafDocumentNode;
+      const newNode = h1.children[1] as ContentDocumentNode;
       expect(newNode.type).toBe('CONTENT');
       expect(newNode.contents.de).toBe('');
     });
@@ -220,7 +220,7 @@ describe('useTreeOperations', () => {
 
       const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const h1 = newDoc.children[0] as HeadingDocumentNode;
-      const newNode = h1.children[0] as LeafDocumentNode;
+      const newNode = h1.children[0] as ContentDocumentNode;
       expect(newNode.type).toBe('CONTENT');
       expect(newNode.contents.de).toBe('');
     });
@@ -329,7 +329,7 @@ describe('useTreeOperations', () => {
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
-      const p1 = getNodeAtPath(newDoc, [0, 0]) as LeafDocumentNode;
+      const p1 = getNodeAtPath(newDoc, [0, 0]) as ContentDocumentNode;
       expect(p1.contents.de).toBe('Updated content');
     });
 
@@ -357,7 +357,7 @@ describe('useTreeOperations', () => {
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
-      const p1 = newDoc.children[0] as LeafDocumentNode;
+      const p1 = newDoc.children[0] as ContentDocumentNode;
       expect(p1.contents.de).toBe('Neuer Text');
       expect(p1.contents.en).toBe('English'); // Preserved
     });
@@ -1746,7 +1746,7 @@ describe('useTreeOperations', () => {
                     type: 'FOOTNOTE',
                     format: 'TEXT',
                     contents: { de: 'note' },
-                  } as LeafDocumentNode,
+                  } as FootnoteDocumentNode,
                 ],
               },
             ],
@@ -1984,7 +1984,7 @@ describe('useTreeOperations', () => {
             type: 'FOOTNOTE',
             format: 'TEXT',
             contents: { de: 'Footnote text' },
-          } as LeafDocumentNode,
+          } as FootnoteDocumentNode,
         ],
       };
 
@@ -2015,14 +2015,14 @@ describe('useTreeOperations', () => {
             type: 'FOOTNOTE',
             format: 'TEXT',
             contents: { de: 'First footnote' },
-          } as LeafDocumentNode,
+          } as FootnoteDocumentNode,
           {
             id: 'fn2',
             number: 'ii.',
             type: 'FOOTNOTE',
             format: 'TEXT',
             contents: { de: 'Second footnote' },
-          } as LeafDocumentNode,
+          } as FootnoteDocumentNode,
         ],
       };
 
@@ -2055,7 +2055,7 @@ describe('useTreeOperations', () => {
             type: 'FOOTNOTE',
             format: 'TEXT',
             contents: { de: 'Footnote text' },
-          } as LeafDocumentNode,
+          } as FootnoteDocumentNode,
         ],
       };
 
@@ -2095,7 +2095,7 @@ describe('useTreeOperations', () => {
                 type: 'FOOTNOTE',
                 format: 'TEXT',
                 contents: { de: 'Footnote text' },
-              } as LeafDocumentNode,
+              } as FootnoteDocumentNode,
             ],
           } as ContentDocumentNode,
         ],
@@ -2138,14 +2138,14 @@ describe('useTreeOperations', () => {
                 type: 'FOOTNOTE',
                 format: 'TEXT',
                 contents: { de: 'First footnote' },
-              } as LeafDocumentNode,
+              } as FootnoteDocumentNode,
               {
                 id: 'fn2',
                 number: 'ii.',
                 type: 'FOOTNOTE',
                 format: 'TEXT',
                 contents: { de: 'Second footnote' },
-              } as LeafDocumentNode,
+              } as FootnoteDocumentNode,
             ],
           } as ContentDocumentNode,
         ],
@@ -2414,7 +2414,7 @@ describe('useTreeOperations', () => {
         const item = list.children[0] as ListItemDocumentNode;
         expect(item.type).toBe('LIST_ITEM');
         // The original content node becomes a child with its id preserved
-        const itemContent = item.children[0] as LeafDocumentNode;
+        const itemContent = item.children[0] as ContentDocumentNode;
         expect(itemContent.type).toBe('CONTENT');
         expect(itemContent.id).toBe('p1');
         expect(itemContent.contents.de).toBe('Item text');
@@ -2549,7 +2549,7 @@ describe('useTreeOperations', () => {
         const item = list.children[0] as ListItemDocumentNode;
         expect(item.type).toBe('LIST_ITEM');
         // The original heading content is now in the child content node
-        const itemContent = item.children[0] as LeafDocumentNode;
+        const itemContent = item.children[0] as ContentDocumentNode;
         expect(itemContent.id).toBe('h1');
 
         // Lifted child
@@ -2582,7 +2582,7 @@ describe('useTreeOperations', () => {
 
         // List should be replaced with content node
         expect(newDoc.children.length).toBe(1);
-        const converted = newDoc.children[0] as LeafDocumentNode;
+        const converted = newDoc.children[0] as ContentDocumentNode;
         expect(converted.type).toBe('CONTENT');
         expect(converted.id).toBe('li1');
         expect(converted.contents.de).toBe('Only item');
@@ -2623,7 +2623,7 @@ describe('useTreeOperations', () => {
         expect(list.children[0].id).toBe('li1');
 
         // Converted item should be after the list
-        const converted = newDoc.children[1] as LeafDocumentNode;
+        const converted = newDoc.children[1] as ContentDocumentNode;
         expect(converted.type).toBe('CONTENT');
         expect(converted.id).toBe('li2');
       });
@@ -2983,7 +2983,7 @@ describe('useTreeOperations', () => {
         expect(mergedList.children[0].id).toBe('li1');
         // The converted content's id is now in the child content node
         const newItem = mergedList.children[1] as ListItemDocumentNode;
-        expect((newItem.children[0] as LeafDocumentNode).id).toBe('p1');
+        expect((newItem.children[0] as ContentDocumentNode).id).toBe('p1');
       });
 
       test('merges with following list when converting to list', () => {
@@ -3023,7 +3023,7 @@ describe('useTreeOperations', () => {
         expect(mergedList.children.length).toBe(2);
         // The converted content's id is now in the child content node
         const newItem = mergedList.children[0] as ListItemDocumentNode;
-        expect((newItem.children[0] as LeafDocumentNode).id).toBe('p1');
+        expect((newItem.children[0] as ContentDocumentNode).id).toBe('p1');
         expect(mergedList.children[1].id).toBe('li1');
       });
 
@@ -3071,7 +3071,7 @@ describe('useTreeOperations', () => {
         expect(mergedList.children[0].id).toBe('li1');
         // The converted content's id is now in the child content node
         const newItem = mergedList.children[1] as ListItemDocumentNode;
-        expect((newItem.children[0] as LeafDocumentNode).id).toBe('p1');
+        expect((newItem.children[0] as ContentDocumentNode).id).toBe('p1');
         expect(mergedList.children[2].id).toBe('li2');
       });
 
@@ -3146,7 +3146,7 @@ describe('useTreeOperations', () => {
 
         expect(mockCommit).toHaveBeenCalledTimes(1);
         const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
-        const converted = newDoc.children[0] as LeafDocumentNode;
+        const converted = newDoc.children[0] as FootnoteDocumentNode;
 
         expect(converted.type).toBe('FOOTNOTE');
         expect(converted.id).toBe('p1');
@@ -3178,7 +3178,7 @@ describe('useTreeOperations', () => {
         });
 
         const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
-        const converted = newDoc.children[0] as LeafDocumentNode;
+        const converted = newDoc.children[0] as FootnoteDocumentNode;
 
         expect(converted.id).toBe('p1');
         expect(converted.number).toBe('i.');
@@ -3204,14 +3204,14 @@ describe('useTreeOperations', () => {
                   type: 'FOOTNOTE',
                   format: 'TEXT',
                   contents: { de: 'First footnote' },
-                } as LeafDocumentNode,
+                } as FootnoteDocumentNode,
                 {
                   id: 'fn2',
                   number: 'ii.',
                   type: 'FOOTNOTE',
                   format: 'TEXT',
                   contents: { de: 'Second footnote' },
-                } as LeafDocumentNode,
+                } as FootnoteDocumentNode,
               ],
             } as ContentDocumentNode,
             {
@@ -3253,7 +3253,7 @@ describe('useTreeOperations', () => {
               type: 'FOOTNOTE',
               format: 'TEXT',
               contents: { de: 'Already a footnote' },
-            } as LeafDocumentNode,
+            } as FootnoteDocumentNode,
           ],
         };
 
@@ -3350,7 +3350,7 @@ describe('useTreeOperations', () => {
         });
 
         const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
-        const converted = newDoc.children[0] as LeafDocumentNode;
+        const converted = newDoc.children[0] as FootnoteDocumentNode;
 
         expect(converted.type).toBe('FOOTNOTE');
         expect(converted.id).toBe('h1');
@@ -3372,7 +3372,7 @@ describe('useTreeOperations', () => {
               type: 'FOOTNOTE',
               format: 'TEXT',
               contents: { de: 'Footnote text' },
-            } as LeafDocumentNode,
+            } as FootnoteDocumentNode,
           ],
         };
 
@@ -3404,7 +3404,7 @@ describe('useTreeOperations', () => {
               type: 'FOOTNOTE',
               format: 'TEXT',
               contents: { de: 'German', en: 'English', fr: 'French' },
-            } as LeafDocumentNode,
+            } as FootnoteDocumentNode,
           ],
         };
 
@@ -4008,7 +4008,7 @@ describe('useTreeOperations', () => {
                           type: 'FOOTNOTE',
                           format: 'TEXT',
                           contents: { de: 'Note text' },
-                        } as LeafDocumentNode,
+                        } as FootnoteDocumentNode,
                       ],
                     } as ContentDocumentNode,
                   ],
@@ -4733,7 +4733,7 @@ describe('useTreeOperations', () => {
               type: 'FOOTNOTE',
               format: 'TEXT',
               contents: { de: 'Note' },
-            } as LeafDocumentNode,
+            } as FootnoteDocumentNode,
             {
               id: 'list1',
               number: null,
@@ -5010,7 +5010,7 @@ describe('useTreeOperations', () => {
       });
 
       const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
-      const f = newDoc.children[0] as LeafDocumentNode;
+      const f = newDoc.children[0] as FootnoteDocumentNode;
       expect(f.type).toBe('FOOTNOTE');
       expect(f.format).toBe('NEWLINES');
     });
@@ -5732,7 +5732,7 @@ describe('useTreeOperations', () => {
       const newDoc = mockCommit.mock.calls[0][0] as DocumentRootNode;
       const holder = newDoc.children[0] as ContentDocumentNode;
       expect(holder.children.map((c) => c.id)).toEqual(['fnA']);
-      const merged = holder.children[0] as LeafDocumentNode;
+      const merged = holder.children[0] as FootnoteDocumentNode;
       expect(merged.contents.de).toBe('first\nsecond');
       expect(merged.format).toBe('NEWLINES');
     });

--- a/src/hooks/useTreeOperations.ts
+++ b/src/hooks/useTreeOperations.ts
@@ -1,11 +1,13 @@
 import { useCallback } from 'react';
 import type {
   ContentBearingNodeType,
+  ContentDocumentNode,
   DocumentNode,
   DocumentRootNode,
+  FootnoteDocumentNode,
   HeadingDocumentNode,
+  ImageDocumentNode,
   Language,
-  LeafDocumentNode,
   NodeFormat,
   ParentType,
 } from '../types/document';
@@ -144,7 +146,13 @@ export const useTreeOperations = ({
       const newDoc = updateNodeAtPath(document, path, (n) => ({
         ...n,
         contents: {
-          ...(n as LeafDocumentNode | HeadingDocumentNode).contents,
+          ...(
+            n as
+              | FootnoteDocumentNode
+              | ImageDocumentNode
+              | HeadingDocumentNode
+              | ContentDocumentNode
+          ).contents,
           [language]: contents,
         },
       }));

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -159,12 +159,6 @@ export type ParentDocumentNode =
  */
 export type NumberedDocumentNode = Exclude<DocumentNode, DocumentRootNode>;
 
-/**
- * Convenience grouping alias for the leaf node types. Prefer {@link FootnoteDocumentNode} or
- * {@link ImageDocumentNode} directly in new code.
- */
-export type LeafDocumentNode = FootnoteDocumentNode | ImageDocumentNode;
-
 /** A node type that may legally contain children, plus `null` for the document's root level. */
 export type ParentType = 'DOCUMENT' | 'LIST' | 'LIST_ITEM' | 'HEADING' | 'CONTENT' | null;
 

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -50,9 +50,6 @@ export type NodeFormat = 'TEXT' | 'NEWLINES' | 'MARKDOWN_MINIMAL' | 'MARKDOWN_IN
 /** Node types that carry `contents` and a `format` (i.e. anything that can hold text/an image). */
 export type ContentBearingNodeType = 'HEADING' | 'CONTENT' | 'FOOTNOTE' | 'IMAGE';
 
-/** Leaf node types: they carry `contents` but never `children`. */
-export type LeafDocumentNodeType = 'IMAGE' | 'FOOTNOTE';
-
 /**
  * The tree root. There is exactly one per document, and — unlike every other node type — it
  * carries no `number` (it is not a numbered element of the document) and no `contents`/`format`.
@@ -203,7 +200,7 @@ export const DEFAULT_FORMAT: Record<ContentBearingNodeType, NodeFormat> = {
 export const DOC_TREE_VERSION = 1 as const;
 
 const CONTAINER_TYPES: ('DOCUMENT' | 'LIST' | 'LIST_ITEM')[] = ['DOCUMENT', 'LIST', 'LIST_ITEM'];
-const LEAF_TYPES: LeafDocumentNodeType[] = ['IMAGE', 'FOOTNOTE'];
+const LEAF_TYPES: ('IMAGE' | 'FOOTNOTE')[] = ['IMAGE', 'FOOTNOTE'];
 const VALID_FORMATS: NodeFormat[] = [
   'TEXT',
   'NEWLINES',
@@ -318,7 +315,7 @@ const isValidNodeInternal = (
   };
 
   // Leaf nodes
-  if (LEAF_TYPES.includes(type as LeafDocumentNodeType)) {
+  if (LEAF_TYPES.includes(type as 'IMAGE' | 'FOOTNOTE')) {
     if (!isValidContents(node.contents)) return false;
     if ('children' in node) return false;
     if (!isValidFormatForType(type as ContentBearingNodeType)) return false;

--- a/src/utils/document-utils.test.ts
+++ b/src/utils/document-utils.test.ts
@@ -6,7 +6,6 @@ import {
   type DocumentRootNode,
   type HeadingDocumentNode,
   isValidDocTreeEnvelope,
-  type LeafDocumentNode,
   type ListDocumentNode,
   type ListItemDocumentNode,
   type NumberedDocumentNode,
@@ -198,7 +197,7 @@ describe('Document Utils', () => {
       const html = '<p>Some text</p>';
       const doc = parseHtmlToTree(html);
       expect(doc.children.length).toBe(1);
-      const content = doc.children[0] as LeafDocumentNode;
+      const content = doc.children[0] as ContentDocumentNode;
       expect(content.type).toBe('CONTENT');
       expect(content.contents.de).toBe('Some text');
     });
@@ -208,7 +207,7 @@ describe('Document Utils', () => {
       const doc = parseHtmlToTree(html);
       const h1 = doc.children[0] as HeadingDocumentNode;
       expect(h1.children.length).toBe(1);
-      const content = h1.children[0] as LeafDocumentNode;
+      const content = h1.children[0] as ContentDocumentNode;
       expect(content.type).toBe('CONTENT');
       expect(content.contents.de).toBe('Paragraph under title');
     });
@@ -224,7 +223,7 @@ describe('Document Utils', () => {
       expect(item1.type).toBe('LIST_ITEM');
       expect((item1 as NumberedDocumentNode).number).toBeNull(); // ul has no numbering
       // Content is now in a child content node
-      const item1Content = item1.children[0] as LeafDocumentNode;
+      const item1Content = item1.children[0] as ContentDocumentNode;
       expect(item1Content.type).toBe('CONTENT');
       expect(item1Content.contents.de).toBe('Item 1');
     });
@@ -238,7 +237,7 @@ describe('Document Utils', () => {
       expect(item1.type).toBe('LIST_ITEM');
       expect((item1 as NumberedDocumentNode).number).toBe('1.');
       // Content is now in a child content node
-      const item1Content = item1.children[0] as LeafDocumentNode;
+      const item1Content = item1.children[0] as ContentDocumentNode;
       expect(item1Content.type).toBe('CONTENT');
       const item2 = list.children[1] as ListItemDocumentNode;
       expect((item2 as NumberedDocumentNode).number).toBe('2.');
@@ -536,7 +535,7 @@ describe('Document Utils', () => {
     it('uses de language by default', () => {
       const html = '<p>German text</p>';
       const doc = parseHtmlToTree(html);
-      const content = doc.children[0] as LeafDocumentNode;
+      const content = doc.children[0] as ContentDocumentNode;
       expect(content.contents.de).toBe('German text');
       expect(content.contents.en).toBeUndefined();
     });
@@ -608,13 +607,13 @@ describe('Document Utils', () => {
     describe('special characters', () => {
       it('preserves HTML entities', () => {
         const doc = parseHtmlToTree('<p>&amp; &lt; &gt;</p>');
-        const content = doc.children[0] as LeafDocumentNode;
+        const content = doc.children[0] as ContentDocumentNode;
         expect(content.contents.de).toContain('&');
       });
 
       it('handles unicode content', () => {
         const doc = parseHtmlToTree('<p>日本語 🎉 Ñoño</p>');
-        const content = doc.children[0] as LeafDocumentNode;
+        const content = doc.children[0] as ContentDocumentNode;
         expect(content.contents.de).toContain('日本語');
         expect(content.contents.de).toContain('🎉');
       });
@@ -624,13 +623,13 @@ describe('Document Utils', () => {
       it('handles very long paragraph content', () => {
         const longContent = 'a'.repeat(10000);
         const doc = parseHtmlToTree(`<p>${longContent}</p>`);
-        const content = doc.children[0] as LeafDocumentNode;
+        const content = doc.children[0] as ContentDocumentNode;
         expect(content.contents.de.length).toBe(10000);
       });
 
       it('handles single character content', () => {
         const doc = parseHtmlToTree('<p>X</p>');
-        const content = doc.children[0] as LeafDocumentNode;
+        const content = doc.children[0] as ContentDocumentNode;
         expect(content.contents.de).toBe('X');
       });
 
@@ -674,7 +673,7 @@ describe('Document Utils', () => {
       expect(item1.type).toBe('LIST_ITEM');
       expect((item1 as NumberedDocumentNode).number).toBe('a.');
       // Content is now in a child content node
-      const item1Content = item1.children[0] as LeafDocumentNode;
+      const item1Content = item1.children[0] as ContentDocumentNode;
       expect(item1Content.type).toBe('CONTENT');
     });
 
@@ -719,7 +718,7 @@ describe('Document Utils', () => {
       const heading = doc.children[0] as HeadingDocumentNode;
       expect(heading.type).toBe('HEADING');
       expect(heading.children.length).toBe(1);
-      expect((heading.children[0] as LeafDocumentNode).type).toBe('CONTENT');
+      expect((heading.children[0] as ContentDocumentNode).type).toBe('CONTENT');
     });
 
     it('handles mixed legal document structure', () => {

--- a/src/utils/tree-mutations.test.ts
+++ b/src/utils/tree-mutations.test.ts
@@ -5,7 +5,6 @@ import type {
   DocumentRootNode,
   FootnoteDocumentNode,
   HeadingDocumentNode,
-  LeafDocumentNode,
   ListDocumentNode,
   ListItemDocumentNode,
   NodeFormat,
@@ -581,7 +580,7 @@ describe('mergeNodesInDoc', () => {
     expect(result).not.toBeNull();
     const parent = getNodeAtPath(result!, [0]) as HeadingDocumentNode;
     expect(parent.children).toHaveLength(1);
-    const merged = parent.children[0] as LeafDocumentNode;
+    const merged = parent.children[0] as FootnoteDocumentNode;
     expect(merged.type).toBe('FOOTNOTE');
     expect(merged.id).toBe('f1');
     expect(merged.contents.de).toBe('a\nb');

--- a/src/utils/tree-mutations.ts
+++ b/src/utils/tree-mutations.ts
@@ -3,9 +3,10 @@ import type {
   ContentDocumentNode,
   DocumentNode,
   DocumentRootNode,
+  FootnoteDocumentNode,
   HeadingDocumentNode,
+  ImageDocumentNode,
   Language,
-  LeafDocumentNode,
   ListDocumentNode,
   ListItemDocumentNode,
   NodeFormat,
@@ -136,7 +137,9 @@ export const canMergeIdsInDoc = (
 
 /** Per-language join. Empty strings on either side don't introduce stray separators. */
 const mergeContentsFromNodes = (
-  nodes: ReadonlyArray<HeadingDocumentNode | ContentDocumentNode | LeafDocumentNode>,
+  nodes: ReadonlyArray<
+    HeadingDocumentNode | ContentDocumentNode | FootnoteDocumentNode | ImageDocumentNode
+  >,
   separator: string
 ): Partial<Record<Language, string>> => {
   const languages = new Set<Language>();
@@ -571,7 +574,7 @@ export const getNumberForStyle = (style: ListStyle, index: number): string | nul
 /** Check if a node has contents (is leaf, heading, or content - not pure container). */
 const hasContents = (
   node: DocumentNode
-): node is LeafDocumentNode | HeadingDocumentNode | ContentDocumentNode => {
+): node is FootnoteDocumentNode | ImageDocumentNode | HeadingDocumentNode | ContentDocumentNode => {
   return 'contents' in node;
 };
 
@@ -723,7 +726,7 @@ export const changeNodeTypeInDoc = (
     const carryFormat = carryFormatOrDefault((node as { format?: NodeFormat }).format, 'FOOTNOTE');
 
     // Create footnote node (leaf - no children)
-    const footnoteNode: LeafDocumentNode = {
+    const footnoteNode: FootnoteDocumentNode = {
       id: node.id,
       number: node.number,
       type: 'FOOTNOTE',
@@ -912,7 +915,7 @@ export const mergeNodesInDoc = (
       children: contents.flatMap((n) => n.children),
     };
   } else if (firstNode.type === 'FOOTNOTE') {
-    const footnotes = nodes as LeafDocumentNode[];
+    const footnotes = nodes as FootnoteDocumentNode[];
     const format = mergeFormatOf(
       footnotes.map((n) => n.format),
       'FOOTNOTE'

--- a/src/utils/tree-utils.test.ts
+++ b/src/utils/tree-utils.test.ts
@@ -3,7 +3,6 @@ import type {
   ContentDocumentNode,
   DocumentRootNode,
   HeadingDocumentNode,
-  LeafDocumentNode,
   ListDocumentNode,
   ListItemDocumentNode,
 } from '../types/document';
@@ -132,15 +131,15 @@ describe('updateNodeAtPath', () => {
         ({
           ...node,
           contents: { de: 'Updated paragraph' },
-        }) as LeafDocumentNode
+        }) as ContentDocumentNode
     );
 
     // Original unchanged
-    const originalP1 = getNodeAtPath(doc, [0, 0]) as LeafDocumentNode;
+    const originalP1 = getNodeAtPath(doc, [0, 0]) as ContentDocumentNode;
     expect(originalP1.contents.de).toBe('First paragraph');
 
     // New document has update
-    const updatedP1 = getNodeAtPath(newDoc, [0, 0]) as LeafDocumentNode;
+    const updatedP1 = getNodeAtPath(newDoc, [0, 0]) as ContentDocumentNode;
     expect(updatedP1.contents.de).toBe('Updated paragraph');
   });
 
@@ -153,7 +152,7 @@ describe('updateNodeAtPath', () => {
         ({
           ...node,
           contents: { de: 'Updated' },
-        }) as LeafDocumentNode
+        }) as ContentDocumentNode
     );
 
     // Sibling h2 should be preserved
@@ -171,10 +170,10 @@ describe('updateNodeAtPath', () => {
         ({
           ...node,
           contents: { de: 'Deep update' },
-        }) as LeafDocumentNode
+        }) as ContentDocumentNode
     );
 
-    const updated = getNodeAtPath(newDoc, [0, 1, 0]) as LeafDocumentNode;
+    const updated = getNodeAtPath(newDoc, [0, 1, 0]) as ContentDocumentNode;
     expect(updated.contents.de).toBe('Deep update');
   });
 
@@ -822,7 +821,7 @@ describe('nested lists', () => {
     };
 
     // Access nested list item's content
-    const nestedContent = getNodeAtPath(doc, [0, 0, 1, 0, 0]) as LeafDocumentNode;
+    const nestedContent = getNodeAtPath(doc, [0, 0, 1, 0, 0]) as ContentDocumentNode;
     expect(nestedContent.contents.de).toBe('Original');
 
     // Update nested content
@@ -833,10 +832,10 @@ describe('nested lists', () => {
         ({
           ...node,
           contents: { de: 'Updated' },
-        }) as LeafDocumentNode
+        }) as ContentDocumentNode
     );
 
-    const updatedContent = getNodeAtPath(updated, [0, 0, 1, 0, 0]) as LeafDocumentNode;
+    const updatedContent = getNodeAtPath(updated, [0, 0, 1, 0, 0]) as ContentDocumentNode;
     expect(updatedContent.contents.de).toBe('Updated');
   });
 


### PR DESCRIPTION
## Summary
Follow-up to #116. Removes the `LeafDocumentNode` node-union alias (`FootnoteDocumentNode | ImageDocumentNode`) **and** the parallel `LeafDocumentNodeType` discriminant-string alias (`'IMAGE' | 'FOOTNOTE'`), migrating all consumers to precise types. Pure **type-level refactor with no runtime behaviour change**.

### `LeafDocumentNode` (node union)
- **Production** (`tree-mutations.ts`, `useTreeOperations.ts`):
  - Sites that genuinely construct/hold a footnote tightened to `FootnoteDocumentNode` (`footnoteNode`, the merge `as FootnoteDocumentNode[]`) — a precision gain.
  - The content-bearing union (`mergeContentsFromNodes`, the `hasContents` guard) inlines the explicit members `FootnoteDocumentNode | ImageDocumentNode`, preserving the exact prior meaning.
  - The edit-contents cast now also includes `ContentDocumentNode`, which the surrounding `'contents' in node` guard already admits (closes a small pre-existing imprecision flagged in review).
- **Tests** (6 files): the alias was largely used as a loose escape-hatch cast `as LeafDocumentNode` to read fields off nodes that are frequently **not** leaves (commonly CONTENT). Each was narrowed to the precise interface the test actually asserts/uses (`ContentDocumentNode`, `FootnoteDocumentNode`, …) — type-token swaps only, no logic/assertion changes.

### `LeafDocumentNodeType` (discriminant strings)
Deleted and inlined `'IMAGE' | 'FOOTNOTE'` at its two local use-sites (the `LEAF_TYPES` annotation and the validator cast), mirroring the `ContainerDocumentNodeType` removal from #116. The heavily-used `ContentBearingNodeType` is kept.

## Test plan
Pure type refactor with no new behaviour, so no new tests — existing suite + `tsc` + lint are the regression net.

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test:run` — 1196 passed
- [x] `npm run lint` — clean
- [x] `grep -rE "\bLeafDocumentNode(Type)?\b" src/` — empty (both leaf aliases gone)
- [x] No new `as any` / `as unknown` casts

🤖 Generated with [Claude Code](https://claude.com/claude-code)