### PR TITLE
Refactor #91: split TreeEditor into focused hooks (keyboard, marks, drag-drop)

### DIFF
--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -1,53 +1,20 @@
 import { Plus } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
-import { useActiveTextSelection } from '../hooks/useActiveTextSelection';
+import { useDragDrop } from '../hooks/useDragDrop';
+import { useInlineMarks } from '../hooks/useInlineMarks';
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import type { TreeEditorHandle } from '../hooks/useTreeEditor';
 import type { Language, NodeFormat } from '../types/document';
-import { type InlineMark, isMarkActive, toggleMark } from '../utils/inline-mark';
-import { FloatingToolbar, FORMATS_WITH_MARKS } from './FloatingToolbar';
+import { FloatingToolbar } from './FloatingToolbar';
 import { RecursiveTreeNode } from './RecursiveTreeNode';
 import { TreeCallbacksContext, TreeUIStoreContext } from './TreeNodeContext';
-
-const ALL_MARKS: readonly InlineMark[] = ['bold', 'italic', 'strike', 'sup', 'sub'];
-
-// Native value setter for HTMLInputElement — required to mutate a React-managed
-// input's value while still firing React's synthetic onChange. Falls back to
-// direct assignment for environments without a descriptor.
-const INPUT_VALUE_SETTER = Object.getOwnPropertyDescriptor(
-  HTMLInputElement.prototype,
-  'value'
-)?.set;
-function setInputValue(el: HTMLInputElement, value: string) {
-  if (INPUT_VALUE_SETTER) INPUT_VALUE_SETTER.call(el, value);
-  else el.value = value;
-  el.dispatchEvent(new Event('input', { bubbles: true }));
-}
 
 interface TreeEditorProps {
   editor: TreeEditorHandle;
   language: Language;
   onScrollToNode?: (scrollFn: (nodeId: string) => void) => void;
 }
-
-/** Check whether the collapsed cursor is at the start or end of `el`. */
-const isCursorAtBoundary = (el: HTMLElement, boundary: 'start' | 'end') => {
-  const sel = window.getSelection();
-  if (!sel || sel.rangeCount === 0) return false;
-  const range = sel.getRangeAt(0);
-  if (!range.collapsed) return false;
-  const testRange = range.cloneRange();
-  testRange.selectNodeContents(el);
-  if (boundary === 'start') {
-    testRange.setEnd(range.endContainer, range.endOffset);
-  } else {
-    testRange.setStart(range.endContainer, range.endOffset);
-  }
-  return testRange.toString().trim().length === 0;
-};
-
-const isCursorAtStart = (el: HTMLElement) => isCursorAtBoundary(el, 'start');
-const isCursorAtEnd = (el: HTMLElement) => isCursorAtBoundary(el, 'end');
 
 export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -71,25 +38,17 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
     handleNodeDoubleClick,
     handleNumberDoubleClick,
     clearSelection,
-    moveSelection,
     addNodeAfter,
     addNodeBefore,
-    removeNodes,
     updateNodeContents,
     updateNodeNumber,
-    changeNodeTypes,
     changeNodeFormat,
     moveNodeById,
-    indentSelected,
-    outdentSelected,
     deleteSelected,
     moveSelectedToTop,
     moveSelectedToBottom,
     mergeSelected,
     canMergeIds,
-    undo,
-    redo,
-    lastSelectedId,
     getReceivingParentId,
   } = editor;
 
@@ -164,134 +123,13 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
     if (selectedId) changeNodeFormat(selectedId, format);
   };
 
-  const activeSelection = useActiveTextSelection();
-  const inlineMarksDerived = useMemo(() => {
-    // Recomputed whenever activeSelection.version bumps (selectionchange / focus).
-    void activeSelection.version;
-    const sel = activeSelection.get();
-    if (!sel) {
-      return {
-        target: null as null | 'contenteditable' | 'input-number',
-        format: undefined as NodeFormat | undefined,
-        active: {} as Partial<Record<InlineMark, boolean>>,
-      };
-    }
-    const target = sel.kind === 'input' ? 'input-number' : 'contenteditable';
-    const format: NodeFormat = sel.kind === 'input' ? 'MARKDOWN_MINIMAL' : sel.format;
-    const active: Partial<Record<InlineMark, boolean>> = {};
-    for (const mark of ALL_MARKS) {
-      active[mark] = isMarkActive(sel.text, sel.start, sel.end, mark);
-    }
-    return { target, format, active };
-  }, [activeSelection]);
+  const { inlineMarks, handleToggleMark } = useInlineMarks({ updateNodeNumber });
 
-  // Google Docs–style keyboard shortcuts: Cmd/Ctrl+B/I/./, and Alt+Shift+5.
-  // Returns the matched mark, or null if no shortcut applies.
-  const matchInlineMarkShortcut = (e: KeyboardEvent): InlineMark | null => {
-    const mod = e.ctrlKey || e.metaKey;
-    const key = e.key.toLowerCase();
-    if (mod && !e.shiftKey && !e.altKey) {
-      if (key === 'b') return 'bold';
-      if (key === 'i') return 'italic';
-      if (key === '.') return 'sup';
-      if (key === ',') return 'sub';
-    }
-    // Strikethrough: Alt+Shift+5. Use `code` so non-US keyboard layouts still
-    // match the digit-5 key (Alt+Shift can produce non-digit `key` values).
-    if (e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey && e.code === 'Digit5') {
-      return 'strike';
-    }
-    return null;
-  };
-
-  const handleToggleMark = useCallback(
-    (mark: InlineMark) => {
-      const sel = activeSelection.get();
-      if (!sel) return;
-      const next = toggleMark(sel.text, sel.start, sel.end, mark);
-      if (next.action === 'noop') return;
-      if (sel.kind === 'input') {
-        setInputValue(sel.el, next.text);
-        sel.el.setSelectionRange(next.selectionStart, next.selectionEnd);
-        // The number input is uncontrolled (defaultValue + onBlur). Commit the
-        // change to the tree directly so a toggle doesn't get lost if the user
-        // takes a non-blurring action next (e.g. undo, click another button).
-        updateNodeNumber(sel.nodeId, next.text === '' ? null : next.text);
-      } else {
-        sel.el.textContent = next.text;
-        sel.el.dispatchEvent(new Event('input', { bubbles: true }));
-        const textNode = sel.el.firstChild;
-        if (textNode) {
-          const range = window.document.createRange();
-          range.setStart(textNode, Math.min(next.selectionStart, next.text.length));
-          range.setEnd(textNode, Math.min(next.selectionEnd, next.text.length));
-          const winSel = window.getSelection();
-          winSel?.removeAllRanges();
-          winSel?.addRange(range);
-        }
-      }
-    },
-    [activeSelection, updateNodeNumber]
-  );
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      const mark = matchInlineMarkShortcut(e);
-      if (!mark) return;
-      const sel = activeSelection.get();
-      if (!sel) return;
-      const format: NodeFormat = sel.kind === 'input' ? 'MARKDOWN_MINIMAL' : sel.format;
-      if (!FORMATS_WITH_MARKS.includes(format)) return;
-      e.preventDefault();
-      e.stopPropagation();
-      handleToggleMark(mark);
-    };
-    document.addEventListener('keydown', handler, { capture: true });
-    return () => {
-      document.removeEventListener('keydown', handler, { capture: true });
-    };
-  }, [activeSelection, handleToggleMark]);
-
-  const handleDragStart = (e: React.DragEvent, id: string) => {
-    store.setDraggedNodeId(id);
-    e.dataTransfer.effectAllowed = 'move';
-  };
-
-  const handleDragOver = (e: React.DragEvent, id: string) => {
-    e.preventDefault();
-    const draggedNodeId = store.getDraggedNodeId();
-    if (draggedNodeId === id) return;
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    store.setDropTarget({
-      id,
-      position: e.clientY < rect.top + rect.height / 2 ? 'top' : 'bottom',
-    });
-
-    // Compute receiving parent for visual feedback
-    if (draggedNodeId) {
-      const parentId = getReceivingParentId(draggedNodeId, id);
-      store.setReceivingParentId(parentId);
-    }
-  };
-
-  const handleDragEnd = () => {
-    store.batch(() => {
-      store.setDraggedNodeId(null);
-      store.setDropTarget(null);
-      store.setHoveredHandleId(null);
-      store.setReceivingParentId(null);
-    });
-  };
-
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    const draggedNodeId = store.getDraggedNodeId();
-    const dropTarget = store.getDropTarget();
-    if (draggedNodeId && dropTarget) {
-      moveNodeById(draggedNodeId, dropTarget.id, dropTarget.position);
-    }
-    handleDragEnd();
-  };
+  const { handleDragStart, handleDragOver, handleDragEnd, handleDrop } = useDragDrop({
+    store,
+    moveNodeById,
+    getReceivingParentId,
+  });
 
   const handleAddNodeBefore = (id: string) => {
     const newId = addNodeBefore(id);
@@ -309,190 +147,13 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
     }
   };
 
-  const handleBlockKeyDown = (e: React.KeyboardEvent, id: string) => {
-    if (e.key === 'Enter') {
-      // Sibling creation moves to the global (selected, non-editing) handler.
-      // In edit mode Enter never creates a sibling; behaviour depends on the node's format.
-      e.preventDefault();
-      const node = flattenedNodes.find((fn) => fn.node.id === id)?.node;
-      const format = node && 'format' in node ? (node as { format: NodeFormat }).format : 'TEXT';
-      // TEXT and MARKDOWN_MINIMAL are single-line — Enter is a no-op. The other formats
-      // accept a literal `\n`; execCommand is the only reliable cross-browser path inside
-      // contentEditable, and its onInput propagates the new text via ContentBlock.
-      const NEWLINE_FORMATS: NodeFormat[] = ['NEWLINES', 'MARKDOWN_INLINE', 'MARKDOWN'];
-      if (NEWLINE_FORMATS.includes(format)) {
-        window.document.execCommand?.('insertText', false, '\n');
-      }
-      return;
-    }
-    if (e.key === 'Backspace') {
-      const node = flattenedNodes.find((fn) => fn.node.id === id);
-      const content = node && 'contents' in node.node ? node.node.contents[language] || '' : '';
-      if (content.trim() === '') {
-        if (flattenedNodes.length > 0) {
-          e.preventDefault();
-          removeNodes([id]);
-        }
-      }
-    } else if (e.key === 'Tab') {
-      e.preventDefault();
-      if (e.shiftKey) {
-        outdentSelected();
-      } else {
-        indentSelected();
-      }
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      e.stopPropagation(); // Prevent global handler from also clearing selection
-      // Exit edit mode but keep the node selected
-      store.setEditingId(null);
-      containerRef.current?.focus();
-    } else if (e.key === 'ArrowUp' && isCursorAtStart(e.currentTarget as HTMLElement)) {
-      const index = flattenedNodes.findIndex((fn) => fn.node.id === id);
-      if (index > 0) {
-        e.preventDefault();
-        const prevId = flattenedNodes[index - 1].node.id;
-        store.setEditingId(prevId);
-        setTimeout(() => {
-          const el = blockRefs.current[prevId];
-          if (el) {
-            el.focus();
-            const r = window.document.createRange();
-            r.selectNodeContents(el);
-            r.collapse(false);
-            window.getSelection()?.removeAllRanges();
-            window.getSelection()?.addRange(r);
-          }
-        }, 0);
-      }
-    } else if (e.key === 'ArrowDown' && isCursorAtEnd(e.currentTarget as HTMLElement)) {
-      const index = flattenedNodes.findIndex((fn) => fn.node.id === id);
-      if (index < flattenedNodes.length - 1) {
-        e.preventDefault();
-        const nextId = flattenedNodes[index + 1].node.id;
-        store.setEditingId(nextId);
-        setTimeout(() => blockRefs.current[nextId]?.focus(), 0);
-      }
-    }
-  };
-
-  const handleBulkUpdateType = (toolbarType: string) => {
-    const currentSelectedIds = store.getSelectedIds();
-    if (currentSelectedIds.size === 0) return;
-
-    // Sort IDs by flat order for consistent processing
-    const ids = flattenedNodes
-      .filter((fn) => currentSelectedIds.has(fn.node.id))
-      .map((fn) => fn.node.id);
-
-    // Map toolbar type to target type and list style
-    type ListStyle = 'unordered' | 'numbered' | 'lettered';
-    let targetType: 'HEADING' | 'CONTENT' | 'LIST' | 'FOOTNOTE';
-    let listStyle: ListStyle | undefined;
-
-    switch (toolbarType) {
-      case 'HEADING':
-        targetType = 'HEADING';
-        break;
-      case 'CONTENT':
-        targetType = 'CONTENT';
-        break;
-      case 'ul':
-        targetType = 'LIST';
-        listStyle = 'unordered';
-        break;
-      case 'ol':
-        targetType = 'LIST';
-        listStyle = 'numbered';
-        break;
-      case 'abc':
-        targetType = 'LIST';
-        listStyle = 'lettered';
-        break;
-      case 'FOOTNOTE':
-        targetType = 'FOOTNOTE';
-        break;
-      default:
-        return;
-    }
-
-    changeNodeTypes(ids, targetType, listStyle);
-  };
-
-  const handleGlobalKeyDown = (e: React.KeyboardEvent) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
-      e.preventDefault();
-      e.shiftKey ? redo() : undo();
-      return;
-    }
-    if ((e.metaKey || e.ctrlKey) && e.key === 'y') {
-      e.preventDefault();
-      redo();
-      return;
-    }
-    const currentEditingId = store.getEditingId();
-    if (currentEditingId) return;
-
-    const currentSelectedIds = store.getSelectedIds();
-    if (currentSelectedIds.size === 0) {
-      if (flattenedNodes.length > 0 && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
-        e.preventDefault();
-        moveSelection(e.key === 'ArrowDown' ? 'down' : 'up', false);
-      } else if (e.key === 'Tab') {
-        // Nothing to indent, but stop the browser's native focus-move, which
-        // otherwise scrolls the pane (issue #101).
-        e.preventDefault();
-      }
-      return;
-    }
-
-    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-      e.preventDefault();
-      moveSelection(e.key === 'ArrowDown' ? 'down' : 'up', e.shiftKey);
-    } else if (e.key === 'Enter' && lastSelectedId.current) {
-      e.preventDefault();
-      addNodeAfter(lastSelectedId.current);
-    } else if (e.key === 'Backspace' || e.key === 'Delete') {
-      e.preventDefault();
-      deleteSelected();
-    } else if (e.key === 'Tab') {
-      e.preventDefault();
-      if (e.shiftKey) {
-        outdentSelected();
-      } else {
-        indentSelected();
-      }
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      clearSelection();
-    } else if (!e.ctrlKey && !e.metaKey && !e.altKey) {
-      const key = e.key.toLowerCase();
-      if (key === 'm') {
-        // Swallow `m` whether or not the merge runs: prevents accidental
-        // fallthrough into the type-change shortcut map (where it has no entry)
-        // and reserves the key for this operation.
-        if (canMergeSelected) {
-          e.preventDefault();
-          mergeSelected();
-        }
-        return;
-      }
-      const shortcutMap: Record<string, string> = {
-        h: 'HEADING',
-        t: 'CONTENT',
-        c: 'CONTENT',
-        u: 'ul',
-        o: 'ol',
-        a: 'abc',
-        f: 'FOOTNOTE',
-      };
-      const toolbarType = shortcutMap[key];
-      if (toolbarType) {
-        e.preventDefault();
-        handleBulkUpdateType(toolbarType);
-      }
-    }
-  };
+  const { handleGlobalKeyDown, handleBlockKeyDown, handleBulkUpdateType } = useKeyboardShortcuts({
+    editor,
+    language,
+    containerRef,
+    blockRefs,
+    canMergeSelected,
+  });
 
   const handleClick = (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
@@ -656,9 +317,9 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
         onMoveSelectedToBottom={moveSelectedToBottom}
         canMerge={canMergeSelected}
         onMerge={mergeSelected}
-        inlineMarksTarget={inlineMarksDerived.target}
-        inlineMarksFormat={inlineMarksDerived.format}
-        markActiveState={inlineMarksDerived.active}
+        inlineMarksTarget={inlineMarks.target}
+        inlineMarksFormat={inlineMarks.format}
+        markActiveState={inlineMarks.active}
         onToggleMark={handleToggleMark}
       />
     </div>

--- a/src/hooks/useDragDrop.test.ts
+++ b/src/hooks/useDragDrop.test.ts
@@ -1,0 +1,108 @@
+import { renderHook } from '@testing-library/react';
+import type React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { TreeUIStore } from '../stores/TreeUIStore';
+import { useDragDrop } from './useDragDrop';
+
+/** Minimal stand-in for a React.DragEvent — only the fields the handlers read. */
+const makeDragEvent = (
+  opts: { clientY?: number; rect?: { top: number; height: number } } = {}
+): React.DragEvent => {
+  const rect = opts.rect ?? { top: 0, height: 100 };
+  return {
+    preventDefault: vi.fn(),
+    clientY: opts.clientY ?? 0,
+    dataTransfer: { effectAllowed: '' } as unknown as DataTransfer,
+    currentTarget: {
+      getBoundingClientRect: () => rect as DOMRect,
+    } as HTMLElement,
+  } as unknown as React.DragEvent;
+};
+
+const setup = () => {
+  const store = new TreeUIStore();
+  const moveNodeById = vi.fn();
+  const getReceivingParentId = vi.fn().mockReturnValue('parent-1');
+  const { result } = renderHook(() => useDragDrop({ store, moveNodeById, getReceivingParentId }));
+  return { store, moveNodeById, getReceivingParentId, result };
+};
+
+describe('useDragDrop', () => {
+  test('handleDragStart records the dragged node and sets the move effect', () => {
+    const { store, result } = setup();
+    const e = makeDragEvent();
+
+    result.current.handleDragStart(e, 'a');
+
+    expect(store.getDraggedNodeId()).toBe('a');
+    expect(e.dataTransfer.effectAllowed).toBe('move');
+  });
+
+  test('handleDragOver sets a drop target and computes the receiving parent', () => {
+    const { store, getReceivingParentId, result } = setup();
+    result.current.handleDragStart(makeDragEvent(), 'a');
+
+    // clientY in the bottom half of the target → position 'bottom'.
+    const e = makeDragEvent({ clientY: 80, rect: { top: 0, height: 100 } });
+    result.current.handleDragOver(e, 'b');
+
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(store.getDropTarget()).toEqual({ id: 'b', position: 'bottom' });
+    expect(getReceivingParentId).toHaveBeenCalledWith('a', 'b');
+    expect(store.getReceivingParentId()).toBe('parent-1');
+  });
+
+  test('handleDragOver in the top half of the target picks position "top"', () => {
+    const { store, result } = setup();
+    result.current.handleDragStart(makeDragEvent(), 'a');
+
+    const e = makeDragEvent({ clientY: 10, rect: { top: 0, height: 100 } });
+    result.current.handleDragOver(e, 'b');
+
+    expect(store.getDropTarget()).toEqual({ id: 'b', position: 'top' });
+  });
+
+  test('handleDragOver over the dragged node itself is a no-op', () => {
+    const { store, getReceivingParentId, result } = setup();
+    result.current.handleDragStart(makeDragEvent(), 'a');
+
+    result.current.handleDragOver(makeDragEvent(), 'a');
+
+    expect(store.getDropTarget()).toBeNull();
+    expect(getReceivingParentId).not.toHaveBeenCalled();
+  });
+
+  test('handleDragEnd clears all drag-related state', () => {
+    const { store, result } = setup();
+    result.current.handleDragStart(makeDragEvent(), 'a');
+    result.current.handleDragOver(makeDragEvent(), 'b');
+    store.setHoveredHandleId('a');
+
+    result.current.handleDragEnd();
+
+    expect(store.getDraggedNodeId()).toBeNull();
+    expect(store.getDropTarget()).toBeNull();
+    expect(store.getHoveredHandleId()).toBeNull();
+    expect(store.getReceivingParentId()).toBeNull();
+  });
+
+  test('handleDrop moves the dragged node to the drop target, then clears state', () => {
+    const { store, moveNodeById, result } = setup();
+    result.current.handleDragStart(makeDragEvent(), 'a');
+    result.current.handleDragOver(makeDragEvent({ clientY: 80 }), 'b');
+
+    result.current.handleDrop(makeDragEvent());
+
+    expect(moveNodeById).toHaveBeenCalledWith('a', 'b', 'bottom');
+    expect(store.getDraggedNodeId()).toBeNull();
+    expect(store.getDropTarget()).toBeNull();
+  });
+
+  test('handleDrop with nothing dragged does not move anything', () => {
+    const { moveNodeById, result } = setup();
+
+    result.current.handleDrop(makeDragEvent());
+
+    expect(moveNodeById).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDragDrop.ts
+++ b/src/hooks/useDragDrop.ts
@@ -1,0 +1,60 @@
+import type React from 'react';
+import type { TreeUIStore } from '../stores/TreeUIStore';
+
+interface UseDragDropParams {
+  store: TreeUIStore;
+  /** Reparent/reorder the dragged node relative to a target node. */
+  moveNodeById: (draggedId: string, targetId: string, position: 'top' | 'bottom') => void;
+  /** Resolve the parent the dragged node would land under, for visual feedback. */
+  getReceivingParentId: (draggedId: string, targetId: string) => string | null;
+}
+
+/**
+ * Drag-and-drop handlers for tree nodes. Tracks the dragged node, the hovered
+ * drop target (top/bottom half of the target row), and the receiving parent in
+ * the non-reactive {@link TreeUIStore}; performs the move on drop.
+ */
+export function useDragDrop({ store, moveNodeById, getReceivingParentId }: UseDragDropParams) {
+  const handleDragStart = (e: React.DragEvent, id: string) => {
+    store.setDraggedNodeId(id);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e: React.DragEvent, id: string) => {
+    e.preventDefault();
+    const draggedNodeId = store.getDraggedNodeId();
+    if (draggedNodeId === id) return;
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    store.setDropTarget({
+      id,
+      position: e.clientY < rect.top + rect.height / 2 ? 'top' : 'bottom',
+    });
+
+    // Compute receiving parent for visual feedback
+    if (draggedNodeId) {
+      const parentId = getReceivingParentId(draggedNodeId, id);
+      store.setReceivingParentId(parentId);
+    }
+  };
+
+  const handleDragEnd = () => {
+    store.batch(() => {
+      store.setDraggedNodeId(null);
+      store.setDropTarget(null);
+      store.setHoveredHandleId(null);
+      store.setReceivingParentId(null);
+    });
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const draggedNodeId = store.getDraggedNodeId();
+    const dropTarget = store.getDropTarget();
+    if (draggedNodeId && dropTarget) {
+      moveNodeById(draggedNodeId, dropTarget.id, dropTarget.position);
+    }
+    handleDragEnd();
+  };
+
+  return { handleDragStart, handleDragOver, handleDragEnd, handleDrop };
+}

--- a/src/hooks/useInlineMarks.test.ts
+++ b/src/hooks/useInlineMarks.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { matchInlineMarkShortcut, useInlineMarks } from './useInlineMarks';
+
+describe('matchInlineMarkShortcut', () => {
+  const ev = (init: KeyboardEventInit) => new KeyboardEvent('keydown', init);
+
+  test('maps Cmd/Ctrl+B/I/./, to the right marks', () => {
+    expect(matchInlineMarkShortcut(ev({ key: 'b', ctrlKey: true }))).toBe('bold');
+    expect(matchInlineMarkShortcut(ev({ key: 'i', metaKey: true }))).toBe('italic');
+    expect(matchInlineMarkShortcut(ev({ key: '.', ctrlKey: true }))).toBe('sup');
+    expect(matchInlineMarkShortcut(ev({ key: ',', metaKey: true }))).toBe('sub');
+  });
+
+  test('maps Alt+Shift+Digit5 to strike (layout-independent via code)', () => {
+    expect(
+      matchInlineMarkShortcut(ev({ key: '5', code: 'Digit5', altKey: true, shiftKey: true }))
+    ).toBe('strike');
+  });
+
+  test('returns null when no shortcut matches', () => {
+    expect(matchInlineMarkShortcut(ev({ key: 'a', ctrlKey: true }))).toBeNull();
+    expect(matchInlineMarkShortcut(ev({ key: 'b' }))).toBeNull();
+  });
+
+  test('returns null when extra modifiers are pressed', () => {
+    // Shift+Cmd+B is not a bold shortcut.
+    expect(matchInlineMarkShortcut(ev({ key: 'b', ctrlKey: true, shiftKey: true }))).toBeNull();
+    // Strike requires no ctrl/meta.
+    expect(
+      matchInlineMarkShortcut(
+        ev({ key: '5', code: 'Digit5', altKey: true, shiftKey: true, ctrlKey: true })
+      )
+    ).toBeNull();
+  });
+});
+
+/** Focus a contenteditable carrying the structedit dataset, with a selection. */
+const focusEditable = (text: string, format: string, selStart = 0, selEnd = text.length) => {
+  const el = document.createElement('div');
+  el.setAttribute('contenteditable', 'true');
+  el.dataset.structeditNodeId = 'n1';
+  el.dataset.structeditFormat = format;
+  el.textContent = text;
+  document.body.appendChild(el);
+  el.focus();
+  const range = document.createRange();
+  range.setStart(el.firstChild as Text, selStart);
+  range.setEnd(el.firstChild as Text, selEnd);
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+  document.dispatchEvent(new Event('selectionchange'));
+  return el;
+};
+
+describe('useInlineMarks', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('derives the contenteditable target, format, and active marks from the selection', () => {
+    const updateNodeNumber = vi.fn();
+    const { result } = renderHook(() => useInlineMarks({ updateNodeNumber }));
+
+    act(() => {
+      focusEditable('**hello**', 'MARKDOWN_MINIMAL');
+    });
+
+    expect(result.current.inlineMarks.target).toBe('contenteditable');
+    expect(result.current.inlineMarks.format).toBe('MARKDOWN_MINIMAL');
+    // The whole `**hello**` is selected, so bold reads as active.
+    expect(result.current.inlineMarks.active.bold).toBe(true);
+  });
+
+  test('reports a null target when nothing is focused', () => {
+    const updateNodeNumber = vi.fn();
+    const { result } = renderHook(() => useInlineMarks({ updateNodeNumber }));
+
+    expect(result.current.inlineMarks.target).toBeNull();
+  });
+
+  test('handleToggleMark wraps the selected text and fires an input event', () => {
+    const updateNodeNumber = vi.fn();
+    const { result } = renderHook(() => useInlineMarks({ updateNodeNumber }));
+
+    let el: HTMLElement | undefined;
+    act(() => {
+      el = focusEditable('hello', 'MARKDOWN_MINIMAL');
+    });
+
+    const onInput = vi.fn();
+    el!.addEventListener('input', onInput);
+
+    act(() => {
+      result.current.handleToggleMark('bold');
+    });
+
+    expect(el!.textContent).toBe('**hello**');
+    expect(onInput).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useInlineMarks.ts
+++ b/src/hooks/useInlineMarks.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { FORMATS_WITH_MARKS } from '../components/FloatingToolbar';
+import type { NodeFormat } from '../types/document';
+import { type InlineMark, isMarkActive, toggleMark } from '../utils/inline-mark';
+import { useActiveTextSelection } from './useActiveTextSelection';
+
+const ALL_MARKS: readonly InlineMark[] = ['bold', 'italic', 'strike', 'sup', 'sub'];
+
+// Native value setter for HTMLInputElement — required to mutate a React-managed
+// input's value while still firing React's synthetic onChange. Falls back to
+// direct assignment for environments without a descriptor.
+const INPUT_VALUE_SETTER = Object.getOwnPropertyDescriptor(
+  HTMLInputElement.prototype,
+  'value'
+)?.set;
+function setInputValue(el: HTMLInputElement, value: string) {
+  if (INPUT_VALUE_SETTER) INPUT_VALUE_SETTER.call(el, value);
+  else el.value = value;
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+/**
+ * Google Docs–style keyboard shortcuts: Cmd/Ctrl+B/I/./, and Alt+Shift+5.
+ * Returns the matched mark, or null if no shortcut applies. Pure — exported so
+ * it can be unit-tested without a DOM.
+ */
+export const matchInlineMarkShortcut = (e: KeyboardEvent): InlineMark | null => {
+  const mod = e.ctrlKey || e.metaKey;
+  const key = e.key.toLowerCase();
+  if (mod && !e.shiftKey && !e.altKey) {
+    if (key === 'b') return 'bold';
+    if (key === 'i') return 'italic';
+    if (key === '.') return 'sup';
+    if (key === ',') return 'sub';
+  }
+  // Strikethrough: Alt+Shift+5. Use `code` so non-US keyboard layouts still
+  // match the digit-5 key (Alt+Shift can produce non-digit `key` values).
+  if (e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey && e.code === 'Digit5') {
+    return 'strike';
+  }
+  return null;
+};
+
+interface UseInlineMarksParams {
+  /** Commit a node's number change directly (the number input is uncontrolled). */
+  updateNodeNumber: (id: string, number: string | null) => void;
+}
+
+/** Derived inline-mark state, shaped for the FloatingToolbar props. */
+export interface InlineMarksState {
+  target: null | 'contenteditable' | 'input-number';
+  format: NodeFormat | undefined;
+  active: Partial<Record<InlineMark, boolean>>;
+}
+
+/**
+ * The inline-mark subsystem: tracks the active text selection (contenteditable
+ * or number input), derives toolbar state, toggles marks, and installs the
+ * global keyboard-shortcut listener (Cmd+B etc.). Marks are applied only for
+ * formats in {@link FORMATS_WITH_MARKS}.
+ */
+export function useInlineMarks({ updateNodeNumber }: UseInlineMarksParams) {
+  const activeSelection = useActiveTextSelection();
+
+  const inlineMarks = useMemo<InlineMarksState>(() => {
+    // Recomputed whenever activeSelection.version bumps (selectionchange / focus).
+    void activeSelection.version;
+    const sel = activeSelection.get();
+    if (!sel) {
+      return { target: null, format: undefined, active: {} };
+    }
+    const target = sel.kind === 'input' ? 'input-number' : 'contenteditable';
+    const format: NodeFormat = sel.kind === 'input' ? 'MARKDOWN_MINIMAL' : sel.format;
+    const active: Partial<Record<InlineMark, boolean>> = {};
+    for (const mark of ALL_MARKS) {
+      active[mark] = isMarkActive(sel.text, sel.start, sel.end, mark);
+    }
+    return { target, format, active };
+  }, [activeSelection]);
+
+  const handleToggleMark = useCallback(
+    (mark: InlineMark) => {
+      const sel = activeSelection.get();
+      if (!sel) return;
+      const next = toggleMark(sel.text, sel.start, sel.end, mark);
+      if (next.action === 'noop') return;
+      if (sel.kind === 'input') {
+        setInputValue(sel.el, next.text);
+        sel.el.setSelectionRange(next.selectionStart, next.selectionEnd);
+        // The number input is uncontrolled (defaultValue + onBlur). Commit the
+        // change to the tree directly so a toggle doesn't get lost if the user
+        // takes a non-blurring action next (e.g. undo, click another button).
+        updateNodeNumber(sel.nodeId, next.text === '' ? null : next.text);
+      } else {
+        sel.el.textContent = next.text;
+        sel.el.dispatchEvent(new Event('input', { bubbles: true }));
+        const textNode = sel.el.firstChild;
+        if (textNode) {
+          const range = window.document.createRange();
+          range.setStart(textNode, Math.min(next.selectionStart, next.text.length));
+          range.setEnd(textNode, Math.min(next.selectionEnd, next.text.length));
+          const winSel = window.getSelection();
+          winSel?.removeAllRanges();
+          winSel?.addRange(range);
+        }
+      }
+    },
+    [activeSelection, updateNodeNumber]
+  );
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const mark = matchInlineMarkShortcut(e);
+      if (!mark) return;
+      const sel = activeSelection.get();
+      if (!sel) return;
+      const format: NodeFormat = sel.kind === 'input' ? 'MARKDOWN_MINIMAL' : sel.format;
+      if (!FORMATS_WITH_MARKS.includes(format)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      handleToggleMark(mark);
+    };
+    document.addEventListener('keydown', handler, { capture: true });
+    return () => {
+      document.removeEventListener('keydown', handler, { capture: true });
+    };
+  }, [activeSelection, handleToggleMark]);
+
+  return { inlineMarks, handleToggleMark };
+}

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,281 @@
+import { act, renderHook } from '@testing-library/react';
+import type React from 'react';
+import { useRef } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import type { DocumentRootNode } from '../types/document';
+import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+import { useTreeEditor } from './useTreeEditor';
+
+/** Two headings, each with no children (flat order: h1, h2). */
+const twoHeadings = (): DocumentRootNode => ({
+  id: 'root',
+  type: 'DOCUMENT',
+  children: [
+    {
+      id: 'h1',
+      number: '1',
+      type: 'HEADING',
+      format: 'TEXT',
+      contents: { de: 'One' },
+      children: [],
+    },
+    {
+      id: 'h2',
+      number: '2',
+      type: 'HEADING',
+      format: 'TEXT',
+      contents: { de: 'Two' },
+      children: [],
+    },
+  ],
+});
+
+/** A heading followed by a sibling content node (for indent/outdent). */
+const headingThenContent = (): DocumentRootNode => ({
+  id: 'root',
+  type: 'DOCUMENT',
+  children: [
+    {
+      id: 'h1',
+      number: '1',
+      type: 'HEADING',
+      format: 'TEXT',
+      contents: { de: 'Head' },
+      children: [],
+    },
+    {
+      id: 'c1',
+      number: null,
+      type: 'CONTENT',
+      format: 'TEXT',
+      contents: { de: 'Body' },
+      children: [],
+    },
+  ],
+});
+
+const makeKbd = (init: Partial<KeyboardEvent>): React.KeyboardEvent =>
+  ({
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...init,
+  }) as unknown as React.KeyboardEvent;
+
+const setup = (doc: DocumentRootNode, canMergeSelected = false) => {
+  const { result } = renderHook(() => {
+    const editor = useTreeEditor(doc, 'de');
+    const containerRef = useRef<HTMLDivElement>(null);
+    const blockRefs = useRef<{ [key: string]: HTMLElement | null }>({});
+    const handlers = useKeyboardShortcuts({
+      editor,
+      language: 'de',
+      containerRef,
+      blockRefs,
+      canMergeSelected,
+    });
+    return { editor, handlers };
+  });
+  return result;
+};
+
+const select = (
+  result: ReturnType<typeof setup>,
+  id: string,
+  mods: Partial<{ shiftKey: boolean; ctrlKey: boolean; metaKey: boolean }> = {}
+) => {
+  act(() => {
+    result.current.editor.handleNodeClick(id, {
+      shiftKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      ...mods,
+    });
+  });
+};
+
+describe('useKeyboardShortcuts — global handler', () => {
+  test('ArrowDown with no selection selects the first node', () => {
+    const result = setup(twoHeadings());
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'ArrowDown' })));
+
+    expect([...result.current.editor.store.getSelectedIds()]).toEqual(['h1']);
+  });
+
+  test('ArrowDown with a selection moves it to the next node', () => {
+    const result = setup(twoHeadings());
+    select(result, 'h1');
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'ArrowDown' })));
+
+    expect([...result.current.editor.store.getSelectedIds()]).toEqual(['h2']);
+  });
+
+  test('Enter on a selected node creates a sibling after it', () => {
+    const result = setup(twoHeadings());
+    select(result, 'h1');
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'Enter' })));
+
+    expect(result.current.editor.document.children.length).toBe(3);
+  });
+
+  test('Delete removes the selected node', () => {
+    const result = setup(twoHeadings());
+    select(result, 'h1');
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'Delete' })));
+
+    const ids = result.current.editor.document.children.map((c) => c.id);
+    expect(ids).toEqual(['h2']);
+  });
+
+  test('the "c" shortcut converts the selected heading to content', () => {
+    const result = setup(twoHeadings());
+    select(result, 'h1');
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'c' })));
+
+    expect(result.current.editor.document.children[0].type).toBe('CONTENT');
+  });
+
+  test('type shortcuts do not fire with a Ctrl/Meta modifier', () => {
+    const result = setup(twoHeadings());
+    select(result, 'h1');
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'c', ctrlKey: true })));
+
+    expect(result.current.editor.document.children[0].type).toBe('HEADING');
+  });
+
+  test('"m" merges contiguous same-type siblings when merging is allowed', () => {
+    const result = setup(twoHeadings(), true);
+    act(() => result.current.editor.store.setSelection(new Set(['h1', 'h2'])));
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'm' })));
+
+    expect(result.current.editor.document.children.length).toBe(1);
+  });
+
+  test('"m" is a no-op when merging is not allowed', () => {
+    const result = setup(twoHeadings(), false);
+    act(() => result.current.editor.store.setSelection(new Set(['h1', 'h2'])));
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'm' })));
+
+    expect(result.current.editor.document.children.length).toBe(2);
+  });
+
+  test('Cmd+Z undoes the previous operation', () => {
+    const result = setup(twoHeadings());
+    select(result, 'h1');
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'Delete' })));
+    expect(result.current.editor.document.children.length).toBe(1);
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'z', metaKey: true })));
+
+    expect(result.current.editor.document.children.length).toBe(2);
+  });
+});
+
+describe('useKeyboardShortcuts — block handler', () => {
+  test('Tab indents the selected node under its previous sibling', () => {
+    const result = setup(headingThenContent());
+    select(result, 'c1');
+
+    act(() => result.current.handlers.handleBlockKeyDown(makeKbd({ key: 'Tab' }), 'c1'));
+
+    expect(result.current.editor.document.children.length).toBe(1);
+    expect(result.current.editor.document.children[0].children.length).toBe(1);
+  });
+
+  test('Shift+Tab outdents a nested node', () => {
+    const nested: DocumentRootNode = {
+      id: 'root',
+      type: 'DOCUMENT',
+      children: [
+        {
+          id: 'h1',
+          number: '1',
+          type: 'HEADING',
+          format: 'TEXT',
+          contents: { de: 'Head' },
+          children: [
+            {
+              id: 'c1',
+              number: null,
+              type: 'CONTENT',
+              format: 'TEXT',
+              contents: { de: 'Body' },
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+    const result = setup(nested);
+    select(result, 'c1');
+
+    act(() =>
+      result.current.handlers.handleBlockKeyDown(makeKbd({ key: 'Tab', shiftKey: true }), 'c1')
+    );
+
+    expect(result.current.editor.document.children.length).toBe(2);
+  });
+
+  test('Backspace on an empty node removes it', () => {
+    const doc: DocumentRootNode = {
+      id: 'root',
+      type: 'DOCUMENT',
+      children: [
+        {
+          id: 'h1',
+          number: '1',
+          type: 'HEADING',
+          format: 'TEXT',
+          contents: { de: 'Head' },
+          children: [],
+        },
+        {
+          id: 'empty',
+          number: null,
+          type: 'CONTENT',
+          format: 'TEXT',
+          contents: { de: '' },
+          children: [],
+        },
+      ],
+    };
+    const result = setup(doc);
+    select(result, 'empty');
+
+    act(() => result.current.handlers.handleBlockKeyDown(makeKbd({ key: 'Backspace' }), 'empty'));
+
+    const ids = result.current.editor.document.children.map((c) => c.id);
+    expect(ids).toEqual(['h1']);
+  });
+});
+
+describe('useKeyboardShortcuts — handleBulkUpdateType', () => {
+  test('maps "CONTENT" to a content type change for the selection', () => {
+    const result = setup(twoHeadings());
+    select(result, 'h1');
+
+    act(() => result.current.handlers.handleBulkUpdateType('CONTENT'));
+
+    expect(result.current.editor.document.children[0].type).toBe('CONTENT');
+  });
+
+  test('an unrecognized toolbar type is a no-op', () => {
+    const result = setup(twoHeadings());
+    select(result, 'h1');
+
+    act(() => result.current.handlers.handleBulkUpdateType('nonsense'));
+
+    expect(result.current.editor.document.children[0].type).toBe('HEADING');
+  });
+});

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,251 @@
+import type React from 'react';
+import type { Language, NodeFormat } from '../types/document';
+import type { TreeEditorHandle } from './useTreeEditor';
+
+/** Check whether the collapsed cursor is at the start or end of `el`. */
+const isCursorAtBoundary = (el: HTMLElement, boundary: 'start' | 'end') => {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return false;
+  const range = sel.getRangeAt(0);
+  if (!range.collapsed) return false;
+  const testRange = range.cloneRange();
+  testRange.selectNodeContents(el);
+  if (boundary === 'start') {
+    testRange.setEnd(range.endContainer, range.endOffset);
+  } else {
+    testRange.setStart(range.endContainer, range.endOffset);
+  }
+  return testRange.toString().trim().length === 0;
+};
+
+const isCursorAtStart = (el: HTMLElement) => isCursorAtBoundary(el, 'start');
+const isCursorAtEnd = (el: HTMLElement) => isCursorAtBoundary(el, 'end');
+
+interface UseKeyboardShortcutsParams {
+  /** The full editor handle — the handlers touch ~13 of its operations, so we
+   * consume it whole rather than threading each one as a separate param. */
+  editor: TreeEditorHandle;
+  language: Language;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  blockRefs: React.RefObject<{ [key: string]: HTMLElement | null }>;
+  /** Whether the current selection qualifies for the merge operation. */
+  canMergeSelected: boolean;
+}
+
+/**
+ * Keyboard behavior for the tree editor: the global (selection-mode) handler,
+ * the per-block (edit-mode) handler, and the bulk type-change helper they share.
+ * Handlers are plain functions recreated each render so they always read fresh
+ * editor/store state.
+ */
+export function useKeyboardShortcuts({
+  editor,
+  language,
+  containerRef,
+  blockRefs,
+  canMergeSelected,
+}: UseKeyboardShortcutsParams) {
+  const {
+    flattenedNodes,
+    store,
+    moveSelection,
+    addNodeAfter,
+    removeNodes,
+    changeNodeTypes,
+    indentSelected,
+    outdentSelected,
+    deleteSelected,
+    mergeSelected,
+    clearSelection,
+    undo,
+    redo,
+    lastSelectedId,
+  } = editor;
+
+  const handleBlockKeyDown = (e: React.KeyboardEvent, id: string) => {
+    if (e.key === 'Enter') {
+      // Sibling creation moves to the global (selected, non-editing) handler.
+      // In edit mode Enter never creates a sibling; behaviour depends on the node's format.
+      e.preventDefault();
+      const node = flattenedNodes.find((fn) => fn.node.id === id)?.node;
+      const format = node && 'format' in node ? (node as { format: NodeFormat }).format : 'TEXT';
+      // TEXT and MARKDOWN_MINIMAL are single-line — Enter is a no-op. The other formats
+      // accept a literal `\n`; execCommand is the only reliable cross-browser path inside
+      // contentEditable, and its onInput propagates the new text via ContentBlock.
+      const NEWLINE_FORMATS: NodeFormat[] = ['NEWLINES', 'MARKDOWN_INLINE', 'MARKDOWN'];
+      if (NEWLINE_FORMATS.includes(format)) {
+        window.document.execCommand?.('insertText', false, '\n');
+      }
+      return;
+    }
+    if (e.key === 'Backspace') {
+      const node = flattenedNodes.find((fn) => fn.node.id === id);
+      const content = node && 'contents' in node.node ? node.node.contents[language] || '' : '';
+      if (content.trim() === '') {
+        if (flattenedNodes.length > 0) {
+          e.preventDefault();
+          removeNodes([id]);
+        }
+      }
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+      if (e.shiftKey) {
+        outdentSelected();
+      } else {
+        indentSelected();
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation(); // Prevent global handler from also clearing selection
+      // Exit edit mode but keep the node selected
+      store.setEditingId(null);
+      containerRef.current?.focus();
+    } else if (e.key === 'ArrowUp' && isCursorAtStart(e.currentTarget as HTMLElement)) {
+      const index = flattenedNodes.findIndex((fn) => fn.node.id === id);
+      if (index > 0) {
+        e.preventDefault();
+        const prevId = flattenedNodes[index - 1].node.id;
+        store.setEditingId(prevId);
+        setTimeout(() => {
+          const el = blockRefs.current[prevId];
+          if (el) {
+            el.focus();
+            const r = window.document.createRange();
+            r.selectNodeContents(el);
+            r.collapse(false);
+            window.getSelection()?.removeAllRanges();
+            window.getSelection()?.addRange(r);
+          }
+        }, 0);
+      }
+    } else if (e.key === 'ArrowDown' && isCursorAtEnd(e.currentTarget as HTMLElement)) {
+      const index = flattenedNodes.findIndex((fn) => fn.node.id === id);
+      if (index < flattenedNodes.length - 1) {
+        e.preventDefault();
+        const nextId = flattenedNodes[index + 1].node.id;
+        store.setEditingId(nextId);
+        setTimeout(() => blockRefs.current[nextId]?.focus(), 0);
+      }
+    }
+  };
+
+  const handleBulkUpdateType = (toolbarType: string) => {
+    const currentSelectedIds = store.getSelectedIds();
+    if (currentSelectedIds.size === 0) return;
+
+    // Sort IDs by flat order for consistent processing
+    const ids = flattenedNodes
+      .filter((fn) => currentSelectedIds.has(fn.node.id))
+      .map((fn) => fn.node.id);
+
+    // Map toolbar type to target type and list style
+    type ListStyle = 'unordered' | 'numbered' | 'lettered';
+    let targetType: 'HEADING' | 'CONTENT' | 'LIST' | 'FOOTNOTE';
+    let listStyle: ListStyle | undefined;
+
+    switch (toolbarType) {
+      case 'HEADING':
+        targetType = 'HEADING';
+        break;
+      case 'CONTENT':
+        targetType = 'CONTENT';
+        break;
+      case 'ul':
+        targetType = 'LIST';
+        listStyle = 'unordered';
+        break;
+      case 'ol':
+        targetType = 'LIST';
+        listStyle = 'numbered';
+        break;
+      case 'abc':
+        targetType = 'LIST';
+        listStyle = 'lettered';
+        break;
+      case 'FOOTNOTE':
+        targetType = 'FOOTNOTE';
+        break;
+      default:
+        return;
+    }
+
+    changeNodeTypes(ids, targetType, listStyle);
+  };
+
+  const handleGlobalKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
+      e.preventDefault();
+      e.shiftKey ? redo() : undo();
+      return;
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key === 'y') {
+      e.preventDefault();
+      redo();
+      return;
+    }
+    const currentEditingId = store.getEditingId();
+    if (currentEditingId) return;
+
+    const currentSelectedIds = store.getSelectedIds();
+    if (currentSelectedIds.size === 0) {
+      if (flattenedNodes.length > 0 && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+        e.preventDefault();
+        moveSelection(e.key === 'ArrowDown' ? 'down' : 'up', false);
+      } else if (e.key === 'Tab') {
+        // Nothing to indent, but stop the browser's native focus-move, which
+        // otherwise scrolls the pane (issue #101).
+        e.preventDefault();
+      }
+      return;
+    }
+
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      moveSelection(e.key === 'ArrowDown' ? 'down' : 'up', e.shiftKey);
+    } else if (e.key === 'Enter' && lastSelectedId.current) {
+      e.preventDefault();
+      addNodeAfter(lastSelectedId.current);
+    } else if (e.key === 'Backspace' || e.key === 'Delete') {
+      e.preventDefault();
+      deleteSelected();
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+      if (e.shiftKey) {
+        outdentSelected();
+      } else {
+        indentSelected();
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      clearSelection();
+    } else if (!e.ctrlKey && !e.metaKey && !e.altKey) {
+      const key = e.key.toLowerCase();
+      if (key === 'm') {
+        // Swallow `m` whether or not the merge runs: prevents accidental
+        // fallthrough into the type-change shortcut map (where it has no entry)
+        // and reserves the key for this operation.
+        if (canMergeSelected) {
+          e.preventDefault();
+          mergeSelected();
+        }
+        return;
+      }
+      const shortcutMap: Record<string, string> = {
+        h: 'HEADING',
+        t: 'CONTENT',
+        c: 'CONTENT',
+        u: 'ul',
+        o: 'ol',
+        a: 'abc',
+        f: 'FOOTNOTE',
+      };
+      const toolbarType = shortcutMap[key];
+      if (toolbarType) {
+        e.preventDefault();
+        handleBulkUpdateType(toolbarType);
+      }
+    }
+  };
+
+  return { handleGlobalKeyDown, handleBlockKeyDown, handleBulkUpdateType };
+}


### PR DESCRIPTION
## Summary
- Extract drag-drop, inline-marks, and keyboard-shortcut logic from `TreeEditor.tsx` into three focused hooks (`useDragDrop`, `useInlineMarks`, `useKeyboardShortcuts`); `TreeEditor` shrinks **666 → 327 lines** and becomes a thin layout shell.
- Pure refactor: no behavior changes. Each subsystem is now unit-testable without rendering the whole editor tree.
- `useInlineMarks` owns the active-selection tracking, toolbar mark state, mark toggling, and the global mark-shortcut listener, and exposes a pure `matchInlineMarkShortcut`.
- `useKeyboardShortcuts` owns the global + per-block key handlers and the shared `handleBulkUpdateType`.

## Test plan
- [x] 28 new behavior-focused hook tests (incl. the pure `matchInlineMarkShortcut` matcher and drag top/bottom resolution the integration suite can't reach in jsdom)
- [x] Existing `TreeEditor.test.tsx` integration suite passes unchanged
- [x] Full suite: 1224 passed
- [x] `npm run typecheck`, `npm run build`, and `npm run lint` all clean

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)