### PR TITLE
Refactor #94: extract shared NumberBadge component

### DIFF
--- a/src/components/NumberBadge.test.tsx
+++ b/src/components/NumberBadge.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { NumberBadge, NumberBadgeDisplay } from './NumberBadge';
+
+describe('NumberBadge', () => {
+  const baseProps = {
+    nodeId: 'n1',
+    isEditing: false,
+    onUpdateNumber: vi.fn(),
+    onDoubleClick: vi.fn(),
+  };
+
+  describe('edit mode', () => {
+    test('renders an input carrying the inline-mark targeting attributes', () => {
+      const { container } = render(
+        <NumberBadge {...baseProps} value="1" isEditing nodeId="h-attr" />
+      );
+      const input = container.querySelector('input[type="text"]') as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      expect(input?.getAttribute('data-structedit-field')).toBe('number');
+      expect(input?.getAttribute('data-structedit-node-id')).toBe('h-attr');
+    });
+
+    test('shows the raw markdown source (not rendered) so it can be edited', () => {
+      const { container } = render(<NumberBadge {...baseProps} value="**1**" isEditing />);
+      const input = container.querySelector('input[type="text"]') as HTMLInputElement | null;
+      expect(input?.value).toBe('**1**');
+    });
+
+    test('commits the trimmed value on blur', () => {
+      const onUpdateNumber = vi.fn();
+      const { container } = render(
+        <NumberBadge {...baseProps} value="1" isEditing onUpdateNumber={onUpdateNumber} />
+      );
+      const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+      input.value = '  2.  ';
+      fireEvent.blur(input);
+      expect(onUpdateNumber).toHaveBeenCalledWith('n1', '2.');
+    });
+
+    test('commits null when blurred empty', () => {
+      const onUpdateNumber = vi.fn();
+      const { container } = render(
+        <NumberBadge {...baseProps} value="1" isEditing onUpdateNumber={onUpdateNumber} />
+      );
+      const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+      input.value = '   ';
+      fireEvent.blur(input);
+      expect(onUpdateNumber).toHaveBeenCalledWith('n1', null);
+    });
+
+    test('clicks inside the input do not bubble to the surrounding tree row', () => {
+      const onParentClick = vi.fn();
+      const onParentDoubleClick = vi.fn();
+      const { container } = render(
+        <div onClick={onParentClick} onDoubleClick={onParentDoubleClick}>
+          <NumberBadge {...baseProps} value="1" isEditing />
+        </div>
+      );
+      const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+      fireEvent.click(input);
+      fireEvent.doubleClick(input);
+      expect(onParentClick).not.toHaveBeenCalled();
+      expect(onParentDoubleClick).not.toHaveBeenCalled();
+    });
+
+    test('Escape reverts to the original value', () => {
+      const onUpdateNumber = vi.fn();
+      const { container } = render(
+        <NumberBadge {...baseProps} value="1" isEditing onUpdateNumber={onUpdateNumber} />
+      );
+      const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+      input.value = 'edited';
+      fireEvent.keyDown(input, { key: 'Escape' });
+      expect(onUpdateNumber).toHaveBeenCalledWith('n1', '1');
+    });
+  });
+
+  describe('display mode with a value', () => {
+    test('renders a solid (non-dashed) bordered box', () => {
+      const { container } = render(
+        <NumberBadge {...baseProps} value="2." className="border-gray-300" />
+      );
+      const badge = container.querySelector('.border-gray-300');
+      expect(badge).not.toBeNull();
+      expect(badge?.textContent).toBe('2.');
+      expect(badge?.classList.contains('border-dashed')).toBe(false);
+    });
+
+    test('renders the value as MARKDOWN_MINIMAL', () => {
+      const { container } = render(
+        <NumberBadge {...baseProps} value="**1**" className="border-blue-200" />
+      );
+      const badge = container.querySelector('.border-blue-200');
+      expect(badge?.textContent).toBe('1');
+      expect(badge?.querySelector('strong')?.textContent).toBe('1');
+    });
+
+    test('double-click invokes onDoubleClick with the node id', () => {
+      const onDoubleClick = vi.fn();
+      const { container } = render(
+        <NumberBadge
+          {...baseProps}
+          value="2."
+          className="border-gray-300"
+          onDoubleClick={onDoubleClick}
+        />
+      );
+      fireEvent.doubleClick(container.querySelector('.border-gray-300')!);
+      expect(onDoubleClick).toHaveBeenCalledWith(expect.anything(), 'n1');
+    });
+  });
+
+  describe('display mode without a value', () => {
+    test('placeholder="dashed" renders a dashed box, double-clickable', () => {
+      const onDoubleClick = vi.fn();
+      const { container } = render(
+        <NumberBadge
+          {...baseProps}
+          value={null}
+          placeholder="dashed"
+          onDoubleClick={onDoubleClick}
+        />
+      );
+      const badge = container.querySelector('.border-dashed');
+      expect(badge).not.toBeNull();
+      fireEvent.doubleClick(badge!);
+      expect(onDoubleClick).toHaveBeenCalledWith(expect.anything(), 'n1');
+    });
+
+    test('placeholder="bullet" renders a bullet dot, double-clickable', () => {
+      const onDoubleClick = vi.fn();
+      const { container } = render(
+        <NumberBadge
+          {...baseProps}
+          value={null}
+          placeholder="bullet"
+          onDoubleClick={onDoubleClick}
+        />
+      );
+      const dot = container.querySelector('.rounded-full');
+      expect(dot).not.toBeNull();
+      fireEvent.doubleClick(dot!.parentElement!);
+      expect(onDoubleClick).toHaveBeenCalledWith(expect.anything(), 'n1');
+    });
+
+    test('defaults to the dashed placeholder when none is given', () => {
+      const { container } = render(<NumberBadge {...baseProps} value={null} />);
+      expect(container.querySelector('.border-dashed')).not.toBeNull();
+    });
+  });
+});
+
+describe('NumberBadgeDisplay', () => {
+  test('renders the value as markup and applies the className', () => {
+    const { container } = render(<NumberBadgeDisplay value="**1**" className="font-bold mr-1" />);
+    expect(container.querySelector('.font-bold')?.querySelector('strong')?.textContent).toBe('1');
+  });
+
+  test('renders nothing when there is no value and bullet is off', () => {
+    const { container } = render(<NumberBadgeDisplay value={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('renders a bullet when there is no value and bullet is on', () => {
+    render(<NumberBadgeDisplay value={null} bullet />);
+    expect(screen.getByText('•')).toBeInTheDocument();
+  });
+});

--- a/src/components/NumberBadge.tsx
+++ b/src/components/NumberBadge.tsx
@@ -1,0 +1,117 @@
+import type React from 'react';
+import { NumberMarkup } from './NumberMarkup';
+
+interface NumberBadgeProps {
+  /** The raw number source (markdown), or null when the node has no number. */
+  value: string | null;
+  /** Node id, forwarded to the edit/double-click callbacks and the inline-mark attributes. */
+  nodeId: string;
+  /** When true the badge becomes a focused text input editing the raw source. */
+  isEditing: boolean;
+  /** Per-type colour/typography classes applied to the input and the numbered box. */
+  className?: string;
+  /** What to show when there is no number: a dashed box (default) or a list bullet. */
+  placeholder?: 'dashed' | 'bullet';
+  onUpdateNumber: (nodeId: string, value: string | null) => void;
+  onDoubleClick: (e: React.MouseEvent, nodeId: string) => void;
+}
+
+/**
+ * The editable number badge used in the document tree. Renders one of three states:
+ * a text input while editing, a bordered box around the rendered number, or a
+ * placeholder (dashed box or bullet) when the node has no number yet.
+ *
+ * The display-only counterpart used by the preview pane is {@link NumberBadgeDisplay}.
+ */
+export function NumberBadge({
+  value,
+  nodeId,
+  isEditing,
+  className = '',
+  placeholder = 'dashed',
+  onUpdateNumber,
+  onDoubleClick,
+}: NumberBadgeProps) {
+  if (isEditing) {
+    return (
+      <input
+        type="text"
+        defaultValue={value || ''}
+        ref={(el) => el?.focus()}
+        data-structedit-field="number"
+        data-structedit-node-id={nodeId}
+        className={`w-12 text-sm border border-blue-400 rounded px-1 py-0.5 outline-none bg-white flex-shrink-0 mr-2 mt-0.5 z-10 relative ${className}`}
+        onBlur={(e) => {
+          const val = e.target.value.trim();
+          onUpdateNumber(nodeId, val || null);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            (e.target as HTMLInputElement).blur();
+          }
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            onUpdateNumber(nodeId, value);
+          }
+          e.stopPropagation();
+        }}
+        onClick={(e) => e.stopPropagation()}
+        onDoubleClick={(e) => e.stopPropagation()}
+      />
+    );
+  }
+
+  if (value) {
+    return (
+      <div
+        className={`w-auto min-w-[1.5rem] h-6 flex items-center justify-end flex-shrink-0 mr-2 select-none text-sm mt-0.5 z-10 relative border rounded px-1 cursor-pointer ${className}`}
+        onDoubleClick={(e) => onDoubleClick(e, nodeId)}
+        title="Double-click to edit number"
+      >
+        <NumberMarkup value={value} />
+      </div>
+    );
+  }
+
+  if (placeholder === 'bullet') {
+    return (
+      <div
+        className="w-6 h-6 flex items-center justify-center flex-shrink-0 mr-1 select-none mt-0.5 z-10 relative cursor-pointer"
+        onDoubleClick={(e) => onDoubleClick(e, nodeId)}
+        title="Double-click to add number"
+      >
+        <span className="w-1.5 h-1.5 bg-gray-800 rounded-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`w-auto min-w-[1.5rem] h-6 flex items-center justify-end flex-shrink-0 mr-2 select-none text-sm mt-0.5 z-10 relative border border-dashed rounded px-1 cursor-pointer ${className}`}
+      onDoubleClick={(e) => onDoubleClick(e, nodeId)}
+      title="Double-click to add number"
+    >
+      {'\u200B'}
+    </div>
+  );
+}
+
+/**
+ * The display-only number marker used in the preview pane: the rendered number
+ * (via {@link NumberMarkup}) when present, an optional list bullet otherwise.
+ */
+interface NumberBadgeDisplayProps {
+  /** The raw number source (markdown), or null when the node has no number. */
+  value: string | null;
+  /** Typography classes applied to the rendered number. */
+  className?: string;
+  /** When true, render a list bullet in place of an absent number. */
+  bullet?: boolean;
+}
+
+export function NumberBadgeDisplay({ value, className, bullet = false }: NumberBadgeDisplayProps) {
+  if (value) return <NumberMarkup value={value} className={className} />;
+  if (bullet) return <span className="mr-2">•</span>;
+  return null;
+}

--- a/src/components/PreviewNodeRenderers.tsx
+++ b/src/components/PreviewNodeRenderers.tsx
@@ -6,7 +6,7 @@ import type {
   NodeFormat,
 } from '../types/document';
 import { renderContent } from '../utils/format-render';
-import { NumberMarkup } from './NumberMarkup';
+import { NumberBadgeDisplay } from './NumberBadge';
 
 /**
  * MARKDOWN is the only format whose rendered output may contain block-level tags
@@ -87,7 +87,7 @@ export function HeadingNode({
   return (
     <section id={node.id} className="mb-2">
       <Tag className={className}>
-        {node.number && <NumberMarkup value={node.number} className="mr-2" />}
+        <NumberBadgeDisplay value={node.number} className="mr-2" />
         <MarkupSpan source={text} format={node.format} />
       </Tag>
       {otherChildren.map((child) => (
@@ -107,9 +107,7 @@ export function ContentNode({
 }) {
   const text = node.contents[language] ?? '';
   const footnotes = node.children.filter((c) => c.type === 'FOOTNOTE');
-  const numberBadge = node.number && (
-    <NumberMarkup value={node.number} className="font-bold mr-1" />
-  );
+  const numberBadge = <NumberBadgeDisplay value={node.number} className="font-bold mr-1" />;
 
   return (
     <div className="my-1">
@@ -169,11 +167,7 @@ export function ListItemNode({
     : [];
   const firstContentIsBlock = firstContent ? isBlockFormat(firstContent.format) : false;
 
-  const marker = node.number ? (
-    <NumberMarkup value={node.number} className="font-bold mr-1" />
-  ) : (
-    <span className="mr-2">•</span>
-  );
+  const marker = <NumberBadgeDisplay value={node.number} className="font-bold mr-1" bullet />;
 
   return (
     <div className="my-1">
@@ -223,9 +217,7 @@ export function FootnoteSection({
         {footnotes.map((fn) => {
           if (fn.type !== 'FOOTNOTE') return null;
           const text = fn.contents[language] ?? '';
-          const numberBadge = fn.number && (
-            <NumberMarkup value={fn.number} className="font-bold mr-1" />
-          );
+          const numberBadge = <NumberBadgeDisplay value={fn.number} className="font-bold mr-1" />;
           if (isBlockFormat(fn.format)) {
             return (
               <div key={fn.id} className="text-sm">

--- a/src/components/RecursiveTreeNode.tsx
+++ b/src/components/RecursiveTreeNode.tsx
@@ -5,7 +5,7 @@ import { useNodeState } from '../hooks/useNodeState';
 import { useSelectionAttribute } from '../hooks/useSelectionAttribute';
 import type { DocumentNode, NodeFormat } from '../types/document';
 import { ContentBlock } from './ContentBlock';
-import { NumberMarkup } from './NumberMarkup';
+import { NumberBadge } from './NumberBadge';
 import { useTreeCallbacks, useTreeUIStore } from './TreeNodeContext';
 
 interface RecursiveTreeNodeProps {
@@ -159,76 +159,22 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
     };
 
     // Render an editable number badge (shared by list items and headings).
-    // When currentNumber is null and not editing, renders a placeholder (dashed box or bullet).
+    // When the number is null and not editing, renders a placeholder (dashed box or bullet).
     const renderNumberBadge = (
       currentNumber: string | null,
       baseClassName: string,
       placeholder: 'dashed' | 'bullet' = 'dashed'
-    ) => {
-      if (isEditingNumber) {
-        return (
-          <input
-            type="text"
-            defaultValue={currentNumber || ''}
-            ref={(el) => el?.focus()}
-            data-structedit-field="number"
-            data-structedit-node-id={node.id}
-            className={`w-12 text-sm border border-blue-400 rounded px-1 py-0.5 outline-none bg-white flex-shrink-0 mr-2 mt-0.5 z-10 relative ${baseClassName}`}
-            onBlur={(e) => {
-              const val = e.target.value.trim();
-              onUpdateNumber(node.id, val || null);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                (e.target as HTMLInputElement).blur();
-              }
-              if (e.key === 'Escape') {
-                e.preventDefault();
-                onUpdateNumber(node.id, currentNumber);
-              }
-              e.stopPropagation();
-            }}
-            onClick={(e) => e.stopPropagation()}
-            onDoubleClick={(e) => e.stopPropagation()}
-          />
-        );
-      }
-
-      if (currentNumber) {
-        return (
-          <div
-            className={`w-auto min-w-[1.5rem] h-6 flex items-center justify-end flex-shrink-0 mr-2 select-none text-sm mt-0.5 z-10 relative border rounded px-1 cursor-pointer ${baseClassName}`}
-            onDoubleClick={(e) => onNumberDoubleClick(e, node.id)}
-            title="Double-click to edit number"
-          >
-            <NumberMarkup value={currentNumber} />
-          </div>
-        );
-      }
-
-      if (placeholder === 'bullet') {
-        return (
-          <div
-            className="w-6 h-6 flex items-center justify-center flex-shrink-0 mr-1 select-none mt-0.5 z-10 relative cursor-pointer"
-            onDoubleClick={(e) => onNumberDoubleClick(e, node.id)}
-            title="Double-click to add number"
-          >
-            <span className="w-1.5 h-1.5 bg-gray-800 rounded-full" />
-          </div>
-        );
-      }
-
-      return (
-        <div
-          className={`w-auto min-w-[1.5rem] h-6 flex items-center justify-end flex-shrink-0 mr-2 select-none text-sm mt-0.5 z-10 relative border border-dashed rounded px-1 cursor-pointer ${baseClassName}`}
-          onDoubleClick={(e) => onNumberDoubleClick(e, node.id)}
-          title="Double-click to add number"
-        >
-          {'\u200B'}
-        </div>
-      );
-    };
+    ) => (
+      <NumberBadge
+        value={currentNumber}
+        nodeId={node.id}
+        isEditing={isEditingNumber}
+        className={baseClassName}
+        placeholder={placeholder}
+        onUpdateNumber={onUpdateNumber}
+        onDoubleClick={onNumberDoubleClick}
+      />
+    );
 
     // Render node content (the actual text/editable part)
     const renderContent = () => {


### PR DESCRIPTION
## Summary
- Extract the number-badge rendering pattern into a shared `NumberBadge.tsx` module
- `NumberBadge` — the tree's editable badge (input / numbered box / dashed-or-bullet placeholder)
- `NumberBadgeDisplay` — the preview's inline number marker (rendered number or bullet)
- Both build on the existing `NumberMarkup` primitive; `RecursiveTreeNode` and `PreviewNodeRenderers` now consume them
- No behavior change — rendered DOM is byte-identical

## Test plan
- [x] New `NumberBadge.test.tsx` (15 cases) covering both components' modes (edit commit/null/Escape, propagation guard, markdown rendering, dashed/bullet placeholders, display outcomes)
- [x] Existing `RecursiveTreeNode` / `PreviewNodeRenderers` tests pass unchanged (regression guard)
- [x] Full suite: 1271 passing
- [x] `npm run build` clean

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)