### PR TITLE
Refactor #93: extract useSelection hook from useTreeEditor

### DIFF
--- a/src/hooks/useSelection.test.ts
+++ b/src/hooks/useSelection.test.ts
@@ -1,0 +1,315 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { TreeUIStore } from '../stores/TreeUIStore';
+import type { DocumentRootNode } from '../types/document';
+import type { FlattenedNode } from '../types/editor';
+import { flattenForRendering } from '../utils/tree-utils';
+import { useSelection } from './useSelection';
+
+const createTestDocument = (): DocumentRootNode => ({
+  id: 'root',
+  type: 'DOCUMENT',
+  children: [
+    {
+      id: 'h1',
+      number: '1',
+      type: 'HEADING',
+      format: 'TEXT',
+      contents: { de: 'First Heading' },
+      children: [
+        {
+          id: 'p1',
+          number: null,
+          type: 'CONTENT',
+          format: 'TEXT',
+          contents: { de: 'First paragraph' },
+          children: [],
+        },
+        {
+          id: 'p2',
+          number: null,
+          type: 'CONTENT',
+          format: 'TEXT',
+          contents: { de: 'Second paragraph' },
+          children: [],
+        },
+      ],
+    },
+    {
+      id: 'h2',
+      number: '2',
+      type: 'HEADING',
+      format: 'TEXT',
+      contents: { de: 'Second Heading' },
+      children: [],
+    },
+  ],
+});
+
+// Flat order of the test document: h1, p1, p2, h2.
+
+interface Harness {
+  store: TreeUIStore;
+  flattenedNodes: FlattenedNode[];
+  nodeIdToFlatIndex: Map<string, number>;
+}
+
+const createHarness = (doc: DocumentRootNode = createTestDocument()): Harness => {
+  const store = new TreeUIStore();
+  const flattenedNodes = flattenForRendering(doc);
+  const nodeIdToFlatIndex = new Map<string, number>();
+  flattenedNodes.forEach((fn, idx) => {
+    nodeIdToFlatIndex.set(fn.node.id, idx);
+  });
+  return { store, flattenedNodes, nodeIdToFlatIndex };
+};
+
+describe('useSelection', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = createHarness();
+  });
+
+  const render = () => renderHook(() => useSelection(harness));
+
+  test('single click selects one node and sets anchor + lastSelected', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeClick('p1', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+
+    expect([...harness.store.getSelectedIds()]).toEqual(['p1']);
+    expect(result.current.anchorId.current).toBe('p1');
+    expect(result.current.lastSelectedId.current).toBe('p1');
+  });
+
+  test('ctrl-click toggles a node into and out of the selection', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeClick('p1', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+    act(() => {
+      result.current.handleNodeClick('p2', { shiftKey: false, ctrlKey: true, metaKey: false });
+    });
+
+    expect(harness.store.getSelectedIds().size).toBe(2);
+    expect(harness.store.getSelectedIds().has('p1')).toBe(true);
+    expect(harness.store.getSelectedIds().has('p2')).toBe(true);
+
+    // Ctrl-click p1 again removes it.
+    act(() => {
+      result.current.handleNodeClick('p1', { shiftKey: false, ctrlKey: true, metaKey: false });
+    });
+
+    expect([...harness.store.getSelectedIds()]).toEqual(['p2']);
+  });
+
+  test('meta-click toggles a node into the selection', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeClick('p1', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+    act(() => {
+      result.current.handleNodeClick('p2', { shiftKey: false, ctrlKey: false, metaKey: true });
+    });
+
+    expect(harness.store.getSelectedIds().size).toBe(2);
+    expect(harness.store.getSelectedIds().has('p2')).toBe(true);
+  });
+
+  test('shift-click selects the flat range between anchor and target', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeClick('h1', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+    act(() => {
+      result.current.handleNodeClick('p2', { shiftKey: true, ctrlKey: false, metaKey: false });
+    });
+
+    expect([...harness.store.getSelectedIds()].sort()).toEqual(['h1', 'p1', 'p2']);
+    expect(result.current.lastSelectedId.current).toBe('p2');
+    // Anchor is unchanged by shift-click.
+    expect(result.current.anchorId.current).toBe('h1');
+  });
+
+  test('shift-click with no anchor falls back to single selection', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeClick('p2', { shiftKey: true, ctrlKey: false, metaKey: false });
+    });
+
+    expect([...harness.store.getSelectedIds()]).toEqual(['p2']);
+    expect(result.current.anchorId.current).toBe('p2');
+  });
+
+  test('moveSelection down from empty selection seeds the first node', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.moveSelection('down', false);
+    });
+
+    expect([...harness.store.getSelectedIds()]).toEqual(['h1']);
+    expect(result.current.anchorId.current).toBe('h1');
+  });
+
+  test('moveSelection up from empty selection seeds the last node', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.moveSelection('up', false);
+    });
+
+    expect([...harness.store.getSelectedIds()]).toEqual(['h2']);
+  });
+
+  test('moveSelection without extend collapses to a single node and resets anchor', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeClick('h1', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+    act(() => {
+      result.current.moveSelection('down', false);
+    });
+
+    expect([...harness.store.getSelectedIds()]).toEqual(['p1']);
+    expect(result.current.anchorId.current).toBe('p1');
+    expect(result.current.lastSelectedId.current).toBe('p1');
+  });
+
+  test('moveSelection with extend grows the range from the anchor', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeClick('h1', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+    act(() => {
+      result.current.moveSelection('down', true);
+    });
+    act(() => {
+      result.current.moveSelection('down', true);
+    });
+
+    expect([...harness.store.getSelectedIds()].sort()).toEqual(['h1', 'p1', 'p2']);
+    // Anchor stays put while extending.
+    expect(result.current.anchorId.current).toBe('h1');
+    expect(result.current.lastSelectedId.current).toBe('p2');
+  });
+
+  test('moveSelection no-ops at the bottom boundary', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeClick('h2', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+    act(() => {
+      result.current.moveSelection('down', false);
+    });
+
+    expect([...harness.store.getSelectedIds()]).toEqual(['h2']);
+  });
+
+  test('moveSelection no-ops at the top boundary', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeClick('h1', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+    act(() => {
+      result.current.moveSelection('up', false);
+    });
+
+    expect([...harness.store.getSelectedIds()]).toEqual(['h1']);
+  });
+
+  test('moveSelection no-ops when lastSelectedId points at a node no longer in the tree', () => {
+    const { result } = render();
+
+    // Simulate a stale ref left behind after the selected node was removed.
+    act(() => {
+      result.current.handleNodeClick('p1', { shiftKey: false, ctrlKey: false, metaKey: false });
+      result.current.lastSelectedId.current = 'gone';
+    });
+    act(() => {
+      result.current.moveSelection('down', false);
+    });
+
+    // Selection is untouched: the guard for an unknown current index bails early.
+    expect([...harness.store.getSelectedIds()]).toEqual(['p1']);
+  });
+
+  test('clearSelection empties selection and nulls both refs + editing ids', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeDoubleClick('p1');
+    });
+    expect(harness.store.getEditingId()).toBe('p1');
+
+    act(() => {
+      result.current.clearSelection();
+    });
+
+    expect(harness.store.getSelectedIds().size).toBe(0);
+    expect(harness.store.getEditingId()).toBeNull();
+    expect(harness.store.getEditingNumberId()).toBeNull();
+    expect(result.current.anchorId.current).toBeNull();
+    expect(result.current.lastSelectedId.current).toBeNull();
+  });
+
+  test('handleNodeDoubleClick enters content edit mode and sets refs', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeDoubleClick('p1');
+    });
+
+    expect(harness.store.getEditingId()).toBe('p1');
+    expect(harness.store.getEditingNumberId()).toBeNull();
+    expect(harness.store.getSelectedIds().has('p1')).toBe(true);
+    expect(result.current.anchorId.current).toBe('p1');
+    expect(result.current.lastSelectedId.current).toBe('p1');
+  });
+
+  test('handleNumberDoubleClick enters number edit mode and clears editingId', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeDoubleClick('p1');
+    });
+    expect(harness.store.getEditingId()).toBe('p1');
+
+    act(() => {
+      result.current.handleNumberDoubleClick('h1');
+    });
+
+    expect(harness.store.getEditingNumberId()).toBe('h1');
+    expect(harness.store.getEditingId()).toBeNull();
+    expect(harness.store.getSelectedIds().has('h1')).toBe(true);
+    expect(result.current.anchorId.current).toBe('h1');
+    expect(result.current.lastSelectedId.current).toBe('h1');
+  });
+
+  test('clicking a different node while editing clears editing mode', () => {
+    const { result } = render();
+
+    act(() => {
+      result.current.handleNodeDoubleClick('p1');
+    });
+    expect(harness.store.getEditingId()).toBe('p1');
+
+    act(() => {
+      result.current.handleNodeClick('p2', { shiftKey: false, ctrlKey: false, metaKey: false });
+    });
+
+    expect(harness.store.getEditingId()).toBeNull();
+    expect([...harness.store.getSelectedIds()]).toEqual(['p2']);
+  });
+});

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -1,0 +1,194 @@
+import { useCallback, useRef } from 'react';
+import type { TreeUIStore } from '../stores/TreeUIStore';
+import type { FlattenedNode } from '../types/editor';
+
+export interface ClickModifiers {
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+}
+
+interface UseSelectionProps {
+  store: TreeUIStore;
+  flattenedNodes: FlattenedNode[];
+  nodeIdToFlatIndex: Map<string, number>;
+}
+
+/**
+ * Owns node selection: click modifiers (single / ctrl-toggle / shift-range),
+ * keyboard move-selection, edit-mode entry, and anchor tracking. Decoupled from
+ * tree operations so the range math is testable on its own.
+ *
+ * `anchorId` is the fixed end of a range selection; `lastSelectedId` is the most
+ * recently touched node (the moving end). Both are returned so the orchestrating
+ * hook can reset them after operations that reshape the selection.
+ */
+export const useSelection = ({ store, flattenedNodes, nodeIdToFlatIndex }: UseSelectionProps) => {
+  // Refs for selection anchoring
+  const anchorId = useRef<string | null>(null);
+  const lastSelectedId = useRef<string | null>(null);
+
+  /**
+   * Handle single click on a node.
+   * Supports shift-click for range selection and ctrl/meta-click for multi-select.
+   */
+  const handleNodeClick = useCallback(
+    (id: string, modifiers: ClickModifiers) => {
+      const { shiftKey, ctrlKey, metaKey } = modifiers;
+
+      if (shiftKey && anchorId.current) {
+        // Range selection from anchor to clicked node
+        const anchorIndex = nodeIdToFlatIndex.get(anchorId.current);
+        const clickedIndex = nodeIdToFlatIndex.get(id);
+
+        if (anchorIndex !== undefined && clickedIndex !== undefined) {
+          const start = Math.min(anchorIndex, clickedIndex);
+          const end = Math.max(anchorIndex, clickedIndex);
+
+          const rangeIds = new Set<string>();
+          for (let i = start; i <= end; i++) {
+            rangeIds.add(flattenedNodes[i].node.id);
+          }
+
+          store.setSelection(rangeIds);
+          lastSelectedId.current = id;
+        }
+      } else if (ctrlKey || metaKey) {
+        // Toggle selection
+        const prev = store.getSelectedIds();
+        const next = new Set(prev);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        store.setSelection(next);
+        lastSelectedId.current = id;
+        anchorId.current = id;
+      } else {
+        // Single selection
+        store.setSelection(new Set([id]));
+        lastSelectedId.current = id;
+        anchorId.current = id;
+      }
+
+      // Clear edit mode on click (unless double-click handles it)
+      const currentEditingId = store.getEditingId();
+      if (currentEditingId && currentEditingId !== id) {
+        store.setEditingId(null);
+      }
+    },
+    [flattenedNodes, nodeIdToFlatIndex, store]
+  );
+
+  /**
+   * Handle double click to enter edit mode.
+   */
+  const handleNodeDoubleClick = useCallback(
+    (id: string) => {
+      store.batch(() => {
+        store.setEditingNumberId(null);
+        store.setSelection(new Set([id]));
+        store.setEditingId(id);
+      });
+      lastSelectedId.current = id;
+      anchorId.current = id;
+    },
+    [store]
+  );
+
+  /**
+   * Handle double click on a node's number to enter number edit mode.
+   */
+  const handleNumberDoubleClick = useCallback(
+    (id: string) => {
+      store.batch(() => {
+        store.setEditingId(null);
+        store.setEditingNumberId(id);
+        store.setSelection(new Set([id]));
+      });
+      lastSelectedId.current = id;
+      anchorId.current = id;
+    },
+    [store]
+  );
+
+  /**
+   * Clear all selection.
+   */
+  const clearSelection = useCallback(() => {
+    store.batch(() => {
+      store.setSelection(new Set());
+      store.setEditingId(null);
+      store.setEditingNumberId(null);
+    });
+    lastSelectedId.current = null;
+    anchorId.current = null;
+  }, [store]);
+
+  /**
+   * Move selection up or down.
+   */
+  const moveSelection = useCallback(
+    (direction: 'up' | 'down', extendSelection: boolean) => {
+      if (flattenedNodes.length === 0) return;
+
+      const currentId = lastSelectedId.current;
+      if (!currentId) {
+        // Start from first or last node
+        const newId =
+          direction === 'down'
+            ? flattenedNodes[0].node.id
+            : flattenedNodes[flattenedNodes.length - 1].node.id;
+        store.setSelection(new Set([newId]));
+        lastSelectedId.current = newId;
+        anchorId.current = newId;
+        return;
+      }
+
+      const currentIndex = nodeIdToFlatIndex.get(currentId);
+      if (currentIndex === undefined) return;
+
+      const newIndex =
+        direction === 'down'
+          ? Math.min(currentIndex + 1, flattenedNodes.length - 1)
+          : Math.max(currentIndex - 1, 0);
+
+      if (newIndex === currentIndex) return;
+
+      const newId = flattenedNodes[newIndex].node.id;
+
+      if (extendSelection && anchorId.current) {
+        // Extend range selection
+        const anchorIndex = nodeIdToFlatIndex.get(anchorId.current);
+        if (anchorIndex !== undefined) {
+          const start = Math.min(anchorIndex, newIndex);
+          const end = Math.max(anchorIndex, newIndex);
+
+          const rangeIds = new Set<string>();
+          for (let i = start; i <= end; i++) {
+            rangeIds.add(flattenedNodes[i].node.id);
+          }
+
+          store.setSelection(rangeIds);
+        }
+      } else {
+        store.setSelection(new Set([newId]));
+        anchorId.current = newId;
+      }
+
+      lastSelectedId.current = newId;
+    },
+    [flattenedNodes, nodeIdToFlatIndex, store]
+  );
+
+  return {
+    handleNodeClick,
+    handleNodeDoubleClick,
+    handleNumberDoubleClick,
+    clearSelection,
+    moveSelection,
+    anchorId,
+    lastSelectedId,
+  };
+};

--- a/src/hooks/useTreeEditor.ts
+++ b/src/hooks/useTreeEditor.ts
@@ -4,14 +4,9 @@ import type { DocumentRootNode, Language } from '../types/document';
 import type { FlattenedNode } from '../types/editor';
 import { DEFAULT_LANGUAGE } from '../utils/document-utils';
 import { flattenForRendering } from '../utils/tree-utils';
+import { useSelection } from './useSelection';
 import { useTreeHistory } from './useTreeHistory';
 import { useTreeOperations } from './useTreeOperations';
-
-interface ClickModifiers {
-  shiftKey: boolean;
-  ctrlKey: boolean;
-  metaKey: boolean;
-}
 
 export const useTreeEditor = (
   initialDocument: DocumentRootNode,
@@ -34,10 +29,6 @@ export const useTreeEditor = (
 
   // UI state store (stable reference, never changes)
   const store = useRef(new TreeUIStore()).current;
-
-  // Refs for selection anchoring
-  const anchorId = useRef<string | null>(null);
-  const lastSelectedId = useRef<string | null>(null);
 
   // Tree operations
   const {
@@ -75,159 +66,16 @@ export const useTreeEditor = (
     return map;
   }, [flattenedNodes]);
 
-  /**
-   * Handle single click on a node.
-   * Supports shift-click for range selection and ctrl/meta-click for multi-select.
-   */
-  const handleNodeClick = useCallback(
-    (id: string, modifiers: ClickModifiers) => {
-      const { shiftKey, ctrlKey, metaKey } = modifiers;
-
-      if (shiftKey && anchorId.current) {
-        // Range selection from anchor to clicked node
-        const anchorIndex = nodeIdToFlatIndex.get(anchorId.current);
-        const clickedIndex = nodeIdToFlatIndex.get(id);
-
-        if (anchorIndex !== undefined && clickedIndex !== undefined) {
-          const start = Math.min(anchorIndex, clickedIndex);
-          const end = Math.max(anchorIndex, clickedIndex);
-
-          const rangeIds = new Set<string>();
-          for (let i = start; i <= end; i++) {
-            rangeIds.add(flattenedNodes[i].node.id);
-          }
-
-          store.setSelection(rangeIds);
-          lastSelectedId.current = id;
-        }
-      } else if (ctrlKey || metaKey) {
-        // Toggle selection
-        const prev = store.getSelectedIds();
-        const next = new Set(prev);
-        if (next.has(id)) {
-          next.delete(id);
-        } else {
-          next.add(id);
-        }
-        store.setSelection(next);
-        lastSelectedId.current = id;
-        anchorId.current = id;
-      } else {
-        // Single selection
-        store.setSelection(new Set([id]));
-        lastSelectedId.current = id;
-        anchorId.current = id;
-      }
-
-      // Clear edit mode on click (unless double-click handles it)
-      const currentEditingId = store.getEditingId();
-      if (currentEditingId && currentEditingId !== id) {
-        store.setEditingId(null);
-      }
-    },
-    [flattenedNodes, nodeIdToFlatIndex, store]
-  );
-
-  /**
-   * Handle double click to enter edit mode.
-   */
-  const handleNodeDoubleClick = useCallback(
-    (id: string) => {
-      store.batch(() => {
-        store.setEditingNumberId(null);
-        store.setSelection(new Set([id]));
-        store.setEditingId(id);
-      });
-      lastSelectedId.current = id;
-      anchorId.current = id;
-    },
-    [store]
-  );
-
-  /**
-   * Handle double click on a node's number to enter number edit mode.
-   */
-  const handleNumberDoubleClick = useCallback(
-    (id: string) => {
-      store.batch(() => {
-        store.setEditingId(null);
-        store.setEditingNumberId(id);
-        store.setSelection(new Set([id]));
-      });
-      lastSelectedId.current = id;
-      anchorId.current = id;
-    },
-    [store]
-  );
-
-  /**
-   * Clear all selection.
-   */
-  const clearSelection = useCallback(() => {
-    store.batch(() => {
-      store.setSelection(new Set());
-      store.setEditingId(null);
-      store.setEditingNumberId(null);
-    });
-    lastSelectedId.current = null;
-    anchorId.current = null;
-  }, [store]);
-
-  /**
-   * Move selection up or down.
-   */
-  const moveSelection = useCallback(
-    (direction: 'up' | 'down', extendSelection: boolean) => {
-      if (flattenedNodes.length === 0) return;
-
-      const currentId = lastSelectedId.current;
-      if (!currentId) {
-        // Start from first or last node
-        const newId =
-          direction === 'down'
-            ? flattenedNodes[0].node.id
-            : flattenedNodes[flattenedNodes.length - 1].node.id;
-        store.setSelection(new Set([newId]));
-        lastSelectedId.current = newId;
-        anchorId.current = newId;
-        return;
-      }
-
-      const currentIndex = nodeIdToFlatIndex.get(currentId);
-      if (currentIndex === undefined) return;
-
-      const newIndex =
-        direction === 'down'
-          ? Math.min(currentIndex + 1, flattenedNodes.length - 1)
-          : Math.max(currentIndex - 1, 0);
-
-      if (newIndex === currentIndex) return;
-
-      const newId = flattenedNodes[newIndex].node.id;
-
-      if (extendSelection && anchorId.current) {
-        // Extend range selection
-        const anchorIndex = nodeIdToFlatIndex.get(anchorId.current);
-        if (anchorIndex !== undefined) {
-          const start = Math.min(anchorIndex, newIndex);
-          const end = Math.max(anchorIndex, newIndex);
-
-          const rangeIds = new Set<string>();
-          for (let i = start; i <= end; i++) {
-            rangeIds.add(flattenedNodes[i].node.id);
-          }
-
-          store.setSelection(rangeIds);
-        }
-      } else {
-        store.setSelection(new Set([newId]));
-        anchorId.current = newId;
-      }
-
-      lastSelectedId.current = newId;
-    },
-    [flattenedNodes, nodeIdToFlatIndex, store]
-  );
+  // Selection management (click modifiers, range math, anchor tracking)
+  const {
+    handleNodeClick,
+    handleNodeDoubleClick,
+    handleNumberDoubleClick,
+    clearSelection,
+    moveSelection,
+    anchorId,
+    lastSelectedId,
+  } = useSelection({ store, flattenedNodes, nodeIdToFlatIndex });
 
   /**
    * Delete selected nodes.


### PR DESCRIPTION
## Summary
- Extract selection logic from `useTreeEditor` into a dedicated `useSelection` hook: single/ctrl-meta/shift click handling, keyboard `moveSelection`, double-click edit entry, `clearSelection`, and the `anchorId`/`lastSelectedId` refs.
- `useTreeEditor` now composes `useSelection` and focuses on operation orchestration (history, store, tree ops). Bulk ops (`deleteSelected`, `mergeSelected`) consume the hook's returned `clearSelection` and refs.
- Pure refactor — **no behavior change**. The public API of `useTreeEditor` is identical, so `TreeEditor.tsx` and `useKeyboardShortcuts.ts` are untouched.
- Selection range math is now testable independently of operations (the motivation in #93).

## Test plan
- [x] New `src/hooks/useSelection.test.ts` — 16 focused tests: single/ctrl/meta click, shift-range + anchor behavior, shift-without-anchor fallback, `moveSelection` seed-from-empty (both directions), collapse/reset-anchor, range-extend, top + bottom boundary no-ops, stale-`lastSelectedId` guard, `clearSelection` ref nulling, both double-click paths, click-while-editing clears edit mode.
- [x] Existing `useTreeEditor.test.ts` passes unchanged (proves the composition preserves the public API).
- [x] Full suite green: 1285 + 16 tests.
- [x] `tsc --noEmit` clean.
- [x] Manual Playwright verification in the live app: single select, shift-range, keyboard collapse + extend, ctrl/meta non-contiguous multi-select, and double-click edit all behave identically.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)