### PR TITLE
Refactor #95: extract useFlatNodeIndex hook

### DIFF
--- a/src/hooks/useFlatNodeIndex.test.ts
+++ b/src/hooks/useFlatNodeIndex.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import type { DocumentRootNode } from '../types/document';
+import { flattenForRendering } from '../utils/tree-utils';
+import { useFlatNodeIndex } from './useFlatNodeIndex';
+
+const createTestDocument = (): DocumentRootNode => ({
+  id: 'root',
+  type: 'DOCUMENT',
+  children: [
+    {
+      id: 'h1',
+      number: '1',
+      type: 'HEADING',
+      format: 'TEXT',
+      contents: { de: 'First Heading' },
+      children: [
+        {
+          id: 'p1',
+          number: null,
+          type: 'CONTENT',
+          format: 'TEXT',
+          contents: { de: 'First paragraph' },
+          children: [],
+        },
+        {
+          id: 'p2',
+          number: null,
+          type: 'CONTENT',
+          format: 'TEXT',
+          contents: { de: 'Second paragraph' },
+          children: [],
+        },
+      ],
+    },
+    {
+      id: 'h2',
+      number: '2',
+      type: 'HEADING',
+      format: 'TEXT',
+      contents: { de: 'Second Heading' },
+      children: [],
+    },
+  ],
+});
+
+// Flat order of the test document: h1, p1, p2, h2.
+
+describe('useFlatNodeIndex', () => {
+  test('maps every node id to its flat index', () => {
+    const flattenedNodes = flattenForRendering(createTestDocument());
+    const { result } = renderHook(() => useFlatNodeIndex(flattenedNodes));
+
+    expect(result.current.size).toBe(flattenedNodes.length);
+    flattenedNodes.forEach((fn, idx) => {
+      expect(result.current.get(fn.node.id)).toBe(idx);
+    });
+    expect(result.current.get('h1')).toBe(0);
+    expect(result.current.get('p1')).toBe(1);
+    expect(result.current.get('p2')).toBe(2);
+    expect(result.current.get('h2')).toBe(3);
+  });
+
+  test('returns an empty map for an empty array', () => {
+    const { result } = renderHook(() => useFlatNodeIndex([]));
+
+    expect(result.current.size).toBe(0);
+  });
+
+  test('returns the same map instance while flattenedNodes is unchanged', () => {
+    const flattenedNodes = flattenForRendering(createTestDocument());
+    const { result, rerender } = renderHook(({ nodes }) => useFlatNodeIndex(nodes), {
+      initialProps: { nodes: flattenedNodes },
+    });
+    const firstMap = result.current;
+
+    rerender({ nodes: flattenedNodes });
+
+    expect(result.current).toBe(firstMap);
+  });
+
+  test('rebuilds the map when flattenedNodes changes', () => {
+    const flattenedNodes = flattenForRendering(createTestDocument());
+    const { result, rerender } = renderHook(({ nodes }) => useFlatNodeIndex(nodes), {
+      initialProps: { nodes: flattenedNodes },
+    });
+    const firstMap = result.current;
+
+    const shorter = flattenedNodes.slice(0, 2);
+    rerender({ nodes: shorter });
+
+    expect(result.current).not.toBe(firstMap);
+    expect(result.current.size).toBe(2);
+    expect(result.current.get('h1')).toBe(0);
+    expect(result.current.get('p1')).toBe(1);
+    expect(result.current.has('p2')).toBe(false);
+  });
+});

--- a/src/hooks/useFlatNodeIndex.ts
+++ b/src/hooks/useFlatNodeIndex.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import type { FlattenedNode } from '../types/editor';
+
+/**
+ * Memoized lookup from node id to its index in the flattened node list,
+ * used for range selection and ordering bulk operations.
+ */
+export function useFlatNodeIndex(flattenedNodes: FlattenedNode[]): Map<string, number> {
+  return useMemo(() => {
+    const map = new Map<string, number>();
+    flattenedNodes.forEach((fn, idx) => {
+      map.set(fn.node.id, idx);
+    });
+    return map;
+  }, [flattenedNodes]);
+}

--- a/src/hooks/useSelection.test.ts
+++ b/src/hooks/useSelection.test.ts
@@ -4,6 +4,7 @@ import { TreeUIStore } from '../stores/TreeUIStore';
 import type { DocumentRootNode } from '../types/document';
 import type { FlattenedNode } from '../types/editor';
 import { flattenForRendering } from '../utils/tree-utils';
+import { useFlatNodeIndex } from './useFlatNodeIndex';
 import { useSelection } from './useSelection';
 
 const createTestDocument = (): DocumentRootNode => ({
@@ -51,17 +52,12 @@ const createTestDocument = (): DocumentRootNode => ({
 interface Harness {
   store: TreeUIStore;
   flattenedNodes: FlattenedNode[];
-  nodeIdToFlatIndex: Map<string, number>;
 }
 
 const createHarness = (doc: DocumentRootNode = createTestDocument()): Harness => {
   const store = new TreeUIStore();
   const flattenedNodes = flattenForRendering(doc);
-  const nodeIdToFlatIndex = new Map<string, number>();
-  flattenedNodes.forEach((fn, idx) => {
-    nodeIdToFlatIndex.set(fn.node.id, idx);
-  });
-  return { store, flattenedNodes, nodeIdToFlatIndex };
+  return { store, flattenedNodes };
 };
 
 describe('useSelection', () => {
@@ -71,7 +67,11 @@ describe('useSelection', () => {
     harness = createHarness();
   });
 
-  const render = () => renderHook(() => useSelection(harness));
+  const render = () =>
+    renderHook(() => {
+      const nodeIdToFlatIndex = useFlatNodeIndex(harness.flattenedNodes);
+      return useSelection({ ...harness, nodeIdToFlatIndex });
+    });
 
   test('single click selects one node and sets anchor + lastSelected', () => {
     const { result } = render();

--- a/src/hooks/useTreeEditor.ts
+++ b/src/hooks/useTreeEditor.ts
@@ -4,6 +4,7 @@ import type { DocumentRootNode, Language } from '../types/document';
 import type { FlattenedNode } from '../types/editor';
 import { DEFAULT_LANGUAGE } from '../utils/document-utils';
 import { flattenForRendering } from '../utils/tree-utils';
+import { useFlatNodeIndex } from './useFlatNodeIndex';
 import { useSelection } from './useSelection';
 import { useTreeHistory } from './useTreeHistory';
 import { useTreeOperations } from './useTreeOperations';
@@ -57,14 +58,8 @@ export const useTreeEditor = (
   // Flattened nodes for rendering
   const flattenedNodes = useMemo<FlattenedNode[]>(() => flattenForRendering(document), [document]);
 
-  // Create a lookup from id to flat index for range selection
-  const nodeIdToFlatIndex = useMemo(() => {
-    const map = new Map<string, number>();
-    flattenedNodes.forEach((fn, idx) => {
-      map.set(fn.node.id, idx);
-    });
-    return map;
-  }, [flattenedNodes]);
+  // Lookup from id to flat index for range selection and bulk-operation ordering
+  const nodeIdToFlatIndex = useFlatNodeIndex(flattenedNodes);
 
   // Selection management (click modifiers, range math, anchor tracking)
   const {


### PR DESCRIPTION
## Summary
- Extract `useFlatNodeIndex(flattenedNodes)` hook returning the memoized node-id → flat-index `Map`
- Replace the inline `useMemo` in `useTreeEditor` with the hook
- Remove the hand-rolled duplicate map from the `useSelection` test harness — it now exercises the real hook

## Test plan
- [x] 4 new unit tests for the hook (mapping, empty input, memoized reference stability, rebuild on change)
- [x] Full suite green: 1291 tests / 50 files
- [x] `tsc --noEmit` clean

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)