### PR TITLE
Fix #124: render MARKDOWN content inline with list/paragraph markers

### DIFF
--- a/src/components/PreviewNodeRenderers.tsx
+++ b/src/components/PreviewNodeRenderers.tsx
@@ -27,7 +27,9 @@ function MarkupSpan({ source, format }: { source: string; format: NodeFormat }) 
 function MarkupBlock({ source, format }: { source: string; format: NodeFormat }) {
   return (
     <div
-      className="markdown-rendered"
+      // flex-1 min-w-0: as a flex item beside an inline marker, fill the remaining width and
+      // allow wrapping rather than forcing the row wider than its container.
+      className="markdown-rendered flex-1 min-w-0"
       // biome-ignore lint/security/noDangerouslySetInnerHtml: renderContent sanitizes via DOMPurify
       dangerouslySetInnerHTML={{ __html: renderContent(source, format) }}
     />
@@ -112,7 +114,7 @@ export function ContentNode({
   return (
     <div className="my-1">
       {isBlockFormat(node.format) ? (
-        <div className="leading-relaxed">
+        <div className="leading-relaxed flex items-baseline">
           {numberBadge}
           <MarkupBlock source={text} format={node.format} />
         </div>
@@ -172,7 +174,7 @@ export function ListItemNode({
   return (
     <div className="my-1">
       {firstContent && firstContentIsBlock ? (
-        <div className="leading-relaxed">
+        <div className="leading-relaxed flex items-baseline">
           {marker}
           <MarkupBlock source={firstContentText} format={firstContent.format} />
         </div>
@@ -220,7 +222,7 @@ export function FootnoteSection({
           const numberBadge = <NumberBadgeDisplay value={fn.number} className="font-bold mr-1" />;
           if (isBlockFormat(fn.format)) {
             return (
-              <div key={fn.id} className="text-sm">
+              <div key={fn.id} className="text-sm flex items-baseline">
                 {numberBadge}
                 <MarkupBlock source={text} format={fn.format} />
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -334,6 +334,13 @@ td {
   margin-block: 0.5em 0.25em;
 }
 
+/* When rendered markdown sits beside an inline marker (list item / Absatz number /
+ * footnote), it is a baseline-aligned flex item; the first/last block's own outer
+ * margins would offset that baseline and add stray vertical space. The wrapper and
+ * node spacing already provide the gap, so collapse them. */
+.markdown-rendered > :first-child { margin-block-start: 0; }
+.markdown-rendered > :last-child { margin-block-end: 0; }
+
 .markdown-rendered p { margin-block: 0.5em; }
 .markdown-rendered ul {
   list-style: disc;


### PR DESCRIPTION
## Summary
- Fix inconsistent preview rendering where MARKDOWN-format `CONTENT` dropped *below* its marker instead of sitting beside it (TEXT/NEWLINES were already inline).
- Root cause: MARKDOWN renders into a block `markdown-rendered` div (it may contain block tags like `<ul>` that can't nest in a `<p>`), and the block branch laid the inline marker and that div out as ordinary flow siblings — so the div dropped to the next line. This affected the list-item marker, the Absatz number (`ContentNode`), and the footnote number (`FootnoteSection`).
- Make each block branch a baseline-aligned flex row (`flex items-baseline`) with the markdown div as a `flex-1 min-w-0` column, and collapse the markdown block's first/last outer margins so the marker aligns to the first content line.
- Pure layout/CSS change — no change to `isBlockFormat`, the rendering pipeline, or the data model. Brings the preview pane in line with the tree editor's existing `flex items-baseline` pattern (`RecursiveTreeNode`).

## Test plan
- [x] Full test suite green (`npm run test`)
- [x] `npm run build` type-checks clean
- [x] Browser-verified via DevTools with the production stylesheet: marker and first content line baselines coincide (0px delta, vs. 26px drop pre-fix); bulleted-list (genuine block) case also confirmed — marker aligns with the first list item and the list hangs beside it

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)