### PR TITLE
Fix #129: preserve and render newlines in MARKDOWN-format nodes

### DIFF
--- a/openspec/changes/add-per-node-formatting-mode/specs/node-formatting/spec.md
+++ b/openspec/changes/add-per-node-formatting-mode/specs/node-formatting/spec.md
@@ -9,7 +9,7 @@ The system SHALL define exactly five formatting levels — `TEXT`, `NEWLINES`, `
 
 #### Scenario: Each level has a documented rendering contract
 - **WHEN** the renderer is asked to render a string under any level
-- **THEN** it follows the per-level contract: `TEXT` strips newlines and escapes; `NEWLINES` escapes and converts `\n` to `<br>`; `MARKDOWN_MINIMAL` is single-line and supports only bold/italic/strike/sup/sub (newlines are collapsed to a space, never preserved as `<br>`); `MARKDOWN_INLINE` supports CommonMark inline plus strike/sup/sub with no block elements **and no bare HTML**; `MARKDOWN` supports full CommonMark + GFM (paragraphs, lists, tables, strikethrough, autolinks) **with bare HTML disabled — raw `<tag>…</tag>` in source is dropped, not rendered**
+- **THEN** it follows the per-level contract: `TEXT` strips newlines and escapes; `NEWLINES` escapes and converts `\n` to `<br>`; `MARKDOWN_MINIMAL` is single-line and supports only bold/italic/strike/sup/sub (newlines are collapsed to a space, never preserved as `<br>`); `MARKDOWN_INLINE` supports CommonMark inline plus strike/sup/sub with no block elements **and no bare HTML**; `MARKDOWN` supports full CommonMark + GFM (paragraphs, lists, tables, strikethrough, autolinks) **with bare HTML disabled — raw `<tag>…</tag>` in source is dropped, not rendered**, and renders a single `\n` as a `<br>` line break (`marked` runs with `breaks: true` for MARKDOWN)
 
 ### Requirement: Every content-bearing node carries a required format field
 The system SHALL require a `format: NodeFormat` field on every node whose type can hold `contents` (`heading`, `content`, `footnote`, `image`). Container-only nodes (`document`, `list`, `list_item`) SHALL NOT carry a format. `isValidNode` and `isValidDocument` SHALL reject any tree that violates these rules.
@@ -82,6 +82,10 @@ The system SHALL provide a pure function `renderContent(raw: string, format: Nod
 #### Scenario: MARKDOWN renders full CommonMark
 - **WHEN** `renderContent('- a\n- b', 'MARKDOWN')` is called
 - **THEN** the output contains `<ul>` with two `<li>` children
+
+#### Scenario: MARKDOWN renders a single newline as a line break
+- **WHEN** `renderContent('line one\nline two', 'MARKDOWN')` is called
+- **THEN** the output contains a `<br>` between the lines (a single `\n` is a hard break — `marked` runs with `breaks: true`, so the editing view's literal newlines survive into the rendered preview)
 
 #### Scenario: MARKDOWN does not render bare block HTML
 - **WHEN** `renderContent('<div>raw</div>', 'MARKDOWN')` is called

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -495,7 +495,7 @@ describe('double-click inline editing', () => {
       fireEvent.keyDown(editingEl, { key: 'Enter' });
     });
 
-    expect(execCommandSpy).toHaveBeenCalledWith('insertText', false, '\n');
+    expect(execCommandSpy).toHaveBeenCalledWith('insertLineBreak');
 
     if (originalExec) {
       (
@@ -609,7 +609,7 @@ describe('double-click inline editing', () => {
       fireEvent.keyDown(editingEl, { key: 'Enter' });
     });
 
-    expect(execCommandSpy).toHaveBeenCalledWith('insertText', false, '\n');
+    expect(execCommandSpy).toHaveBeenCalledWith('insertLineBreak');
 
     if (originalExec) {
       (
@@ -705,7 +705,7 @@ describe('double-click inline editing', () => {
       fireEvent.keyDown(editingEl, { key: 'Enter', shiftKey: true });
     });
 
-    expect(execCommandSpy).toHaveBeenCalledWith('insertText', false, '\n');
+    expect(execCommandSpy).toHaveBeenCalledWith('insertLineBreak');
 
     if (originalExec) {
       (

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -260,6 +260,87 @@ describe('useKeyboardShortcuts — block handler', () => {
   });
 });
 
+describe('useKeyboardShortcuts — in-edit Enter inserts a newline', () => {
+  /** One content node per newline-relevant format, plus a single-line heading. */
+  const docPerFormat = (): DocumentRootNode => ({
+    id: 'root',
+    type: 'DOCUMENT',
+    children: [
+      {
+        id: 'text',
+        number: null,
+        type: 'CONTENT',
+        format: 'TEXT',
+        contents: { de: 'a' },
+        children: [],
+      },
+      {
+        id: 'newlines',
+        number: null,
+        type: 'CONTENT',
+        format: 'NEWLINES',
+        contents: { de: 'a' },
+        children: [],
+      },
+      {
+        id: 'markdown',
+        number: null,
+        type: 'CONTENT',
+        format: 'MARKDOWN',
+        contents: { de: 'a' },
+        children: [],
+      },
+      {
+        id: 'mdmin',
+        number: '1',
+        type: 'HEADING',
+        format: 'MARKDOWN_MINIMAL',
+        contents: { de: 'a' },
+        children: [],
+      },
+    ],
+  });
+
+  // `insertLineBreak` produces a real `\n` text node in a pre-wrap contentEditable, so the
+  // `textContent` read-back keeps it. `insertText '\n'` (the old behavior) made Chrome wrap
+  // the break in `<div>` blocks, and `textContent` silently dropped it — issue #129.
+  test.each([
+    'newlines',
+    'markdown',
+  ])('Enter in a %s node uses insertLineBreak (not insertText "\\n")', (id) => {
+    const result = setup(docPerFormat());
+    // jsdom doesn't define document.execCommand, so assign a mock directly rather than spy.
+    const exec = vi.fn().mockReturnValue(true);
+    (window.document as unknown as { execCommand?: unknown }).execCommand = exec;
+    const e = makeKbd({ key: 'Enter' });
+
+    act(() => result.current.handlers.handleBlockKeyDown(e, id));
+
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(exec).toHaveBeenCalledWith('insertLineBreak');
+    expect(exec).not.toHaveBeenCalledWith('insertText', expect.anything(), '\n');
+
+    delete (window.document as { execCommand?: unknown }).execCommand;
+  });
+
+  test.each([
+    'text',
+    'mdmin',
+  ])('Enter in a single-line %s node inserts nothing (no execCommand)', (id) => {
+    const result = setup(docPerFormat());
+    const exec = vi.fn().mockReturnValue(true);
+    (window.document as unknown as { execCommand?: unknown }).execCommand = exec;
+    const e = makeKbd({ key: 'Enter' });
+
+    act(() => result.current.handlers.handleBlockKeyDown(e, id));
+
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(exec).not.toHaveBeenCalled();
+
+    delete (window.document as { execCommand?: unknown }).execCommand;
+  });
+});
+
 describe('useKeyboardShortcuts — handleBulkUpdateType', () => {
   test('maps "CONTENT" to a content type change for the selection', () => {
     const result = setup(twoHeadings());

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -72,9 +72,15 @@ export function useKeyboardShortcuts({
       // TEXT and MARKDOWN_MINIMAL are single-line — Enter is a no-op. The other formats
       // accept a literal `\n`; execCommand is the only reliable cross-browser path inside
       // contentEditable, and its onInput propagates the new text via ContentBlock.
+      //
+      // Use `insertLineBreak`, NOT `insertText '\n'`: in a pre-wrap contentEditable Chrome
+      // turns an inserted '\n' into `<div>` block wrappers, and ContentBlock reads the
+      // source back with `el.textContent`, which emits no '\n' for block boundaries — so
+      // the newline was silently lost the instant it was typed (issue #129).
+      // `insertLineBreak` inserts a real '\n' text node that `textContent` preserves.
       const NEWLINE_FORMATS: NodeFormat[] = ['NEWLINES', 'MARKDOWN_INLINE', 'MARKDOWN'];
       if (NEWLINE_FORMATS.includes(format)) {
-        window.document.execCommand?.('insertText', false, '\n');
+        window.document.execCommand?.('insertLineBreak');
       }
       return;
     }

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -41,7 +41,8 @@ export type LocalizedText = Partial<{ [K in Language]: string }>;
  *                        Newlines are collapsed to a space (never preserved as `<br>`).
  * - `MARKDOWN_INLINE`  — CommonMark inline + strike/sup/sub, no block elements, no bare HTML.
  * - `MARKDOWN`         — full CommonMark + GFM (paragraphs, lists, tables, …) with bare HTML
- *                        disabled (raw `<tag>` in the source is dropped, not rendered).
+ *                        disabled (raw `<tag>` in the source is dropped, not rendered). A single
+ *                        `\n` renders as a `<br>` line break (`breaks: true`).
  *
  * Which levels a node may use depends on its type — see {@link ALLOWED_FORMATS}.
  */

--- a/src/utils/format-render.test.ts
+++ b/src/utils/format-render.test.ts
@@ -181,6 +181,13 @@ describe('renderContent — MARKDOWN', () => {
     expect(html).toContain('<li>b</li>');
   });
 
+  it('renders a single newline as a <br> hard break (breaks: true)', () => {
+    const html = renderContent('line one\nline two', 'MARKDOWN');
+    expect(html).toMatch(/<br\s*\/?>/);
+    expect(html).toContain('line one');
+    expect(html).toContain('line two');
+  });
+
   it('renders paragraphs and inline marks', () => {
     const html = renderContent('Hello **world**', 'MARKDOWN');
     expect(html).toContain('<strong>world</strong>');
@@ -378,11 +385,11 @@ describe('hasInlineMarkdownMarks', () => {
     expect(hasInlineMarkdownMarks('see [site](https://example.com)')).toBe(true);
   });
 
-  it('returns false for a literal newline alone (visually identical under TEXT and MARKDOWN)', () => {
-    // A bare `\n` does not render as a hard break in MARKDOWN (marked uses
-    // `breaks: false` by default) and TEXT collapses `\n` to space — so the
-    // newline is not a meaningful inline mark for downgrade decisions.
-    expect(hasInlineMarkdownMarks('line one\nline two')).toBe(false);
+  it('returns true for a literal newline alone (renders as a hard break under MARKDOWN)', () => {
+    // A bare `\n` renders as a `<br>` in MARKDOWN (marked runs with `breaks: true`)
+    // whereas TEXT collapses `\n` to a space — so the newline IS a meaningful mark
+    // and a node carrying only newlines must keep its MARKDOWN format on downgrade.
+    expect(hasInlineMarkdownMarks('line one\nline two')).toBe(true);
   });
 });
 

--- a/src/utils/format-render.ts
+++ b/src/utils/format-render.ts
@@ -320,8 +320,12 @@ export const renderContent = (raw: string, format: NodeFormat): string => {
       break;
     }
     case 'MARKDOWN': {
+      // breaks: render a single `\n` as a hard `<br>` (GitHub-comment behavior) rather than a
+      // soft break that collapses to a space. Users type Enter expecting a visible line break,
+      // and this keeps MARKDOWN display consistent with the pre-wrap edit view. Scoped to
+      // MARKDOWN only — MARKDOWN_INLINE (parseInline above) keeps the default soft-break.
       html = sanitize(
-        markedNoHtml.parse(protectSupSubMarks(raw), { async: false }) as string,
+        markedNoHtml.parse(protectSupSubMarks(raw), { async: false, breaks: true }) as string,
         'MARKDOWN'
       );
       break;
@@ -335,10 +339,11 @@ export const renderContent = (raw: string, format: NodeFormat): string => {
  * link). Detected by rendering the source as MARKDOWN and reusing `hasInlineMarks` on
  * the result — avoids re-deriving the mark grammar.
  *
- * Literal newlines are NOT treated as inline marks: a single `\n` doesn't render as a
- * hard break in MARKDOWN (marked's default has `breaks: false`), and TEXT collapses
- * `\n` to a space. Visually identical either way; we keep `\n` in the source so the
- * user can upgrade the format later if they want hard breaks.
+ * Literal newlines ARE treated as marks, by side effect of the rule above: MARKDOWN is
+ * rendered with `breaks: true`, so a single `\n` renders as a `<br>` (which `hasInlineMarks`
+ * detects) whereas TEXT collapses `\n` to a space. A source whose only mark is a newline
+ * therefore reports `true` and keeps its MARKDOWN format — downgrading to TEXT would
+ * silently drop the break.
  *
  * Used by `listNumberDedupTransform` to decide whether a content node still needs
  * MARKDOWN format after the only inline mark (a leading `<sup>N</sup>` Absatznummer)

--- a/src/utils/legal-transforms/list-number-dedup.test.ts
+++ b/src/utils/legal-transforms/list-number-dedup.test.ts
@@ -69,13 +69,13 @@ describe('listNumberDedupTransform', () => {
     expect(c1.contents.de).toBe('Er gilt für: ...');
     expect(c1.format).toBe('TEXT');
 
-    // The third item's source had a <br> (now `\n` in markdown source). The bare
-    // newline isn't treated as an inline mark for downgrade purposes — visually
-    // a single `\n` is rendered the same under TEXT and MARKDOWN — so the
-    // format downgrades to TEXT alongside the other two items.
+    // The third item's source had a <br> (now `\n` in markdown source). Under
+    // `breaks: true` a single `\n` renders as a `<br>` in MARKDOWN but collapses to a
+    // space under TEXT, so the newline is a meaningful mark — the format stays MARKDOWN
+    // rather than downgrading (downgrading would silently drop the line break).
     expect(c2.contents.de).toContain('Er regelt zudem');
     expect(c2.contents.de).toContain('\n');
-    expect(c2.format).toBe('TEXT');
+    expect(c2.format).toBe('MARKDOWN');
 
     expect(isValidDocument(result)).toBe(true);
   });


### PR DESCRIPTION
## Summary
- Enter in edit mode now uses `execCommand('insertLineBreak')` instead of `insertText '\n'`. In a `white-space: pre-wrap` contentEditable, Chrome wrapped the inserted `'\n'` in `<div>` blocks, and ContentBlock reads the source back via `el.textContent` — which emits no `'\n'` for block boundaries, so every newline was silently dropped the instant it was typed (and thus lost on re-edit). `insertLineBreak` inserts a real `'\n'` text node that `textContent` preserves, and still fires the `input` event. No ContentBlock change needed.
- MARKDOWN rendering now runs with `breaks: true` (passed per-call to `.parse()`), so a single `\n` renders as a `<br>`, matching the pre-wrap edit view. **Scoped to MARKDOWN only** — `MARKDOWN_INLINE` (`.parseInline()`) keeps the default soft break and is unchanged.
- A bare `\n` is now a meaningful mark in MARKDOWN, so `hasInlineMarkdownMarks` reports `true` for newline-only content and the Absatznummer downgrade keeps MARKDOWN instead of dropping to TEXT (which would collapse the break). Updated the doc comments and the OpenSpec node-formatting scenario.

## Test plan
- [x] New in-edit Enter tests: `insertLineBreak` for NEWLINES/MARKDOWN; no-op for TEXT/MARKDOWN_MINIMAL
- [x] New single-newline render test for MARKDOWN (`\n` → `<br>`)
- [x] `hasInlineMarkdownMarks` newline test flipped false→true; list-number-dedup downgrade test TEXT→MARKDOWN; 3 TreeEditor assertions updated to `insertLineBreak`
- [x] Full suite (1296 tests), `npm run typecheck`, `npm run lint` all green
- [x] Manual verification in the running app: typing lines with Enter in a MARKDOWN node preserves `\n` in the source and renders `<br>` in both the preview pane and the tree editor; newlines survive exit-edit and re-edit

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)