### PR TITLE
Load documents from a signed loadFile URL (#131)

### DIFF
--- a/openspec/changes/add-loadfile-url-import/.openspec.yaml
+++ b/openspec/changes/add-loadfile-url-import/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/add-loadfile-url-import/design.md
+++ b/openspec/changes/add-loadfile-url-import/design.md
@@ -1,0 +1,235 @@
+## Context
+
+StructEdit is a static single-page app ([App.tsx](src/App.tsx)) with a two-view flow held in
+`useState`: `'upload'` (the [LoadDocument](src/components/LoadDocument.tsx) screen) and `'editor'`
+(the [EditorInterface](src/components/EditorInterface.tsx)). There is no router and no reading of
+query parameters anywhere today (`grep` for `URLSearchParams` / `window.location` finds only object-
+URL handling). The app is deployed at `https://structedit.demokratis.ch/`.
+
+Document ingestion already exists for uploads and pastes. The relevant primitive is
+[`processHtmlFile`](src/utils/file-processing.ts#L106): it takes raw HTML, builds a `text/html`
+blob + object URL for the side-by-side preview, runs [`parseHtmlLegalToTree`](src/utils/document-utils.ts#L359)
+to build the tree, and returns a `ProcessedDocument`. Uploads then persist an entry via
+`createEntry` ([document-storage.ts](src/utils/document-storage.ts)) and call `onConvert` to enter
+the editor. The fetched-URL path should land on this exact machinery so a URL-loaded document is
+indistinguishable from an uploaded one once it's open.
+
+The Demokratis backend will open `…/?loadFile=<url-encoded signed URL>`. The decoded URL looks like
+`https://demokratis.ch/file/<uuid>?_expiration=<ts>&_hash=<hmac>`. The server enforces a 90-minute
+TTL and returns `410 Gone` when expired and `404 Not Found` for an invalid/tampered link; StructEdit
+must turn those into distinct, non-blank messages (issue
+[#131](https://github.com/Demokratis-ch/structedit/issues/131) acceptance criteria).
+
+The user has decided two product questions up front:
+- **Configurable host allowlist** — default `demokratis.ch`, extendable via config (not "any URL").
+- **Persist like an upload** — a URL-loaded document gets an IndexedDB entry + autosave.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A valid `loadFile` link opens the editor with the fetched HTML already parsed into the tree and the
+  source preview populated — no upload screen, no extra clicks.
+- The user never sees a blank or half-rendered editor: there is an explicit loading state during the
+  fetch and an explicit error state on any failure.
+- `410` and `404` produce distinct, actionable messages; network/CORS/non-HTML/parse failures get a
+  generic "couldn't load" message. Every error offers a path to the normal upload screen.
+- StructEdit only fetches from allowlisted hosts; the allowlist is configurable without code changes.
+- A URL-loaded document is protected by the existing autosave/recents machinery, identical to an
+  upload.
+- A page refresh after a load does not re-fetch a now-expired link.
+- Every behavioural change ships test-first (red → green → refactor), per [CLAUDE.md](CLAUDE.md).
+
+**Non-Goals:**
+
+- No DOCX/PDF over `loadFile`. The issue scope is HTML; the response body is processed as HTML. The
+  module is shaped so a future content-type branch is possible, but it is not built here.
+- No client-side verification of `_hash` / `_expiration`. The server is authoritative (it returns
+  410/404); duplicating HMAC logic in the browser would be both impossible (no secret) and
+  redundant.
+- No upload-back-to-Demokratis. That is the next roadmap item, out of scope here.
+- No router/history library. A one-time `URLSearchParams` read plus `history.replaceState` is enough.
+- No change to the upload, paste, recents, or autosave flows when `loadFile` is absent.
+
+## Decisions
+
+### D1. Read `loadFile` once, on mount, in the App shell
+
+App.tsx gains a one-shot effect that runs on mount: read `new URLSearchParams(window.location.search)`,
+look for `loadFile`. If absent, behave exactly as today (render the upload view). If present, enter
+the new remote-load flow. A `useRef` guard ensures the effect fires its fetch exactly once even under
+React 18/19 StrictMode double-invocation in dev.
+
+_Rejected: adding a router (react-router)._ One query param does not justify a routing dependency and
+a re-architecture of the two-view `useState`. We can add one later if deep-linking grows.
+
+### D2. View states: add `loading` and `error` to the App flow
+
+Today `view` is `'upload' | 'editor'`. Extend the flow so the app can also render:
+
+- a **loading** surface (spinner + "Loading document from demokratis.ch…") while the fetch is in
+  flight, and
+- an **error** surface (the per-status message + a "Go to upload" button) when the load fails.
+
+The initial view is decided synchronously from `window.location.search` so there is no flash of the
+upload screen before the loading state when a `loadFile` param is present. Implementation can be a
+discriminated `view` union or a small `remoteLoad: { status }` state machine alongside `view` — the
+spec only constrains the observable states, the design leaves the exact shape to implementation, but
+favors a single discriminated state to avoid impossible combinations.
+
+_Rejected: rendering the upload screen with an inline banner during fetch._ The acceptance criterion
+is "not a blank editor"; a dedicated loading state is clearer than overloading the upload screen, and
+keeps the upload affordances from being clickable mid-fetch.
+
+### D3. Remote-loading module: pure, fetch-injectable, returns a discriminated result
+
+New module [src/utils/remote-document.ts](src/utils/remote-document.ts), free of React, holding the
+testable core:
+
+```ts
+// Parse + validate the query string. Returns the decoded URL or a typed reason it was rejected.
+function parseLoadFileParam(search: string, allowedHosts: string[]):
+  | { ok: true; url: string }
+  | { ok: false; reason: 'absent' | 'malformed' | 'forbidden-host' };
+
+type RemoteFetchResult =
+  | { ok: true; html: string; sourceUrl: string }            // sourceUrl = decoded URL, for naming
+  | { ok: false; reason: 'expired' }                          // HTTP 410
+  | { ok: false; reason: 'not-found' }                        // HTTP 404
+  | { ok: false; reason: 'network' }                          // TypeError / CORS / other non-OK status
+  | { ok: false; reason: 'unsupported-content' };             // body isn't HTML / empty
+
+async function fetchRemoteDocument(url: string, fetchImpl = fetch): Promise<RemoteFetchResult>;
+```
+
+`fetchImpl` is injected so tests pass a mock `fetch` and exercise each status branch without a
+network. Status mapping: `410 → expired`, `404 → not-found`, other non-`ok` statuses and thrown
+`TypeError`s (CORS, DNS, offline) `→ network`. A 2xx response whose `Content-Type` is not HTML-ish,
+or whose body is empty, `→ unsupported-content`.
+
+_Rejected: doing the fetch inside the React component._ Keeping it pure makes the status-branch matrix
+unit-testable and keeps App.tsx declarative.
+
+### D4. Host allowlist: configurable, default `demokratis.ch`, subdomain-aware
+
+The allowlist is read from a Vite env var `VITE_LOADFILE_ALLOWED_HOSTS` (comma-separated). When unset,
+it defaults to `['demokratis.ch']`. In dev (`import.meta.env.DEV`) `localhost` and `127.0.0.1` are
+also permitted so the flow can be exercised locally. A host matches if it equals an allowlist entry
+**or** is a subdomain of one (`*.demokratis.ch`) — matched by suffix on a dot boundary, never by bare
+`includes()` (so `demokratis.ch.evil.com` and `notdemokratis.ch` are both rejected). The scheme must
+be `https:` (except `http://localhost` in dev).
+
+Validation happens in `parseLoadFileParam` **before** any fetch. A forbidden host short-circuits to
+the error surface with the generic message and is never fetched.
+
+_Rejected: allowlisting by `String.includes`._ Classic bypass (`demokratis.ch.attacker.test`). Use
+`URL` parsing + exact-or-dot-suffix host comparison.
+_Rejected: hardcoding the host._ The user chose configurable so staging / signed object-storage hosts
+can be added without a code change.
+
+### D5. Reuse the HTML pipeline; derive a name from the URL
+
+Factor the body of [`processHtmlFile`](src/utils/file-processing.ts#L106) into a shared
+`processHtmlString(html, { name, originalFilename, kind })` so both the file path and the URL path
+produce a `ProcessedDocument` identically (same blob/object-URL preview, same `parseHtmlLegalToTree`).
+`processHtmlFile` becomes a thin wrapper over it.
+
+The display name comes from the decoded URL's path — the `<uuid>` from `/file/<uuid>` — falling back
+to `"Demokratis document"` if no usable segment exists. `source.kind` is `'html'`; `originalFilename`
+is null (there is no real filename). The query string (with the `_hash`) is **not** used in the name.
+
+_Rejected: a separate parallel pipeline for fetched HTML._ Divergence risk; the upload path already
+does exactly the right thing.
+
+### D6. Persist as a recents entry, like an upload
+
+After a successful fetch + parse, follow the upload path: `createEntry({...})` then `onConvert(...)`
+into the editor, so autosave (`useAutosave` in EditorInterface) and the recents picker work
+unchanged. If `isEmptyDocument(doc)` is true (the HTML parsed to nothing), treat it as
+`unsupported-content` and show the error surface rather than opening an empty editor — mirroring the
+existing upload guard in [LoadDocument.tsx](src/components/LoadDocument.tsx#L73).
+
+Persistence failures (quota) reuse the existing `persistInitialEntry` behavior: the editor still
+opens in-memory and the existing quota toast surfaces; a `loadFile` load is not aborted just because
+the local save failed.
+
+_Rejected: in-memory only for URL loads._ The user chose "treat like an upload" so the ephemeral link
+doesn't become a way to lose work.
+
+### D7. Consume the param once: `history.replaceState`
+
+Immediately after reading `loadFile` (before or right after the fetch resolves), strip it from the
+URL with `history.replaceState(null, '', window.location.pathname)`. This prevents a refresh from
+re-fetching an expired link (which would then show the expired error on every reload) and keeps the
+signed URL — including its `_hash` — out of the visible address bar longer than necessary. The
+in-memory document and editor state are unaffected.
+
+_Rejected: leaving the param in place._ A refresh after 90 minutes would always 410; worse, the
+signed URL would linger in the address bar / browser history.
+
+### D8. Error message copy (single source of truth)
+
+A small map from `reason` → user-facing message lives in the remote-loading module so UI and tests
+share one definition:
+
+- `expired` → "Link expired, re-open from demokratis.ch." (verbatim from the issue)
+- `not-found` → "This document link is invalid. Re-open it from demokratis.ch."
+- `network` → "Couldn't load the document. Check your connection and try re-opening it from demokratis.ch."
+- `unsupported-content` → "Couldn't read the document — it wasn't in a supported format."
+- `forbidden-host` / `malformed` → reuse the `network`/invalid copy (these only arise from a
+  hand-edited URL, not the backend).
+
+Each error surface includes a "Go to upload" action that clears the error and shows the normal upload
+screen.
+
+### D9. TDD ordering (bottom-up)
+
+1. `remote-document.ts` — `parseLoadFileParam` (allowlist + subdomain + scheme cases) and
+   `fetchRemoteDocument` (410 / 404 / ok / network / non-HTML / empty), with an injected mock fetch.
+2. `processHtmlString` extraction in `file-processing.ts` — characterization test that
+   `processHtmlFile` output is unchanged, plus a direct test of the string entry point.
+3. App-level wiring (`useLoadFromUrl` hook or App effect) — param present → loading → editor on
+   success; each error reason → its message and no editor; param absent → upload unchanged; refresh
+   doesn't re-fetch (param stripped).
+4. Error/loading UI components.
+
+## Risks / Trade-offs
+
+- **[CORS: the backend must allow `structedit.demokratis.ch` to fetch the signed URL]** → A missing
+  `Access-Control-Allow-Origin` makes the fetch throw a `TypeError`, which we map to `network` and
+  surface a non-blank error. Fixing the header is a backend task (out of scope), but the failure is
+  handled gracefully rather than as a blank editor. Flag to the backend team during rollout.
+- **[Opaque CORS status codes]** → If the server responds 410/404 but without permissive CORS
+  headers, the browser may surface a `TypeError` instead of a readable status, collapsing
+  expired/not-found into the generic `network` message. Mitigation: backend must send CORS headers on
+  error responses too; documented as a backend requirement. Distinct 410/404 messaging is only
+  guaranteed when CORS is correctly configured.
+- **[Open-fetcher / SSRF-ish abuse via the param]** → Mitigation: D4 host allowlist with strict
+  `URL`-based, dot-boundary matching and `https`-only. The app will not fetch arbitrary hosts.
+- **[Untrusted HTML in the preview]** → The fetched HTML flows through the same DOMPurify sanitize in
+  `parseHtmlToTree` and the same blob-URL preview as any upload; this vector already exists for
+  pasted/uploaded HTML and is not widened. No new trust assumption.
+- **[StrictMode double-fetch in dev]** → Mitigation: a `useRef` once-guard around the fetch effect.
+- **[Signed URL leaking via Referer/history]** → Mitigation: D7 strips the param promptly. (Referer
+  on the outbound fetch is a backend concern; not addressed here.)
+- **[`history.replaceState` on a static host with a base path]** → Use `window.location.pathname`
+  (not `'/'`) so a non-root deploy base is preserved.
+
+## Migration Plan
+
+Purely additive; no stored-data migration. Ship App wiring + the remote-loading module + UI in one
+PR. When `loadFile` is absent the app behaves exactly as before. Rollback is a single revert.
+Signed files are always served from `demokratis.ch`, so the built-in default allowlist covers prod
+with no extra configuration. Coordinate with the backend only on CORS: headers must be present on
+both success and 410/404 responses before announcing the feature.
+
+## Open Questions
+
+- **Default allowlist value in production** — _Resolved:_ signed files are always served from
+  `demokratis.ch`. The built-in `['demokratis.ch']` default therefore covers production with no
+  build-time configuration; `VITE_LOADFILE_ALLOWED_HOSTS` exists only as headroom for staging /
+  local hosts.
+- **Should a failed expired/invalid load offer a "retry"?** A retry can't succeed for an expired
+  link, so the affordance is "Go to upload" only for v1. Revisit if the backend adds a refresh.
+- **Param name casing / encoding** — assuming exactly `loadFile` (camelCase) and a single
+  `encodeURIComponent`-encoded value, per the issue. Confirm with the backend.

--- a/openspec/changes/add-loadfile-url-import/proposal.md
+++ b/openspec/changes/add-loadfile-url-import/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+The Demokratis backend wants to hand a document straight to StructEdit for editing: it opens
+`https://structedit.demokratis.ch/?loadFile=<url-encoded signed URL>` and expects the editor to
+appear with that document already loaded. Today StructEdit ignores query parameters entirely — the
+user lands on the upload screen and there is no way to bring a document in from the platform. This
+change closes the loop described in issue
+[#131](https://github.com/Demokratis-ch/structedit/issues/131) so a draft can flow from
+demokratis.ch into the editor in one click.
+
+## What Changes
+
+- On app load, read the `loadFile` query parameter. When present, decode it to the signed source
+  URL (shape: `https://demokratis.ch/file/<uuid>?_expiration=<ts>&_hash=<hmac>`), fetch the file,
+  parse it through the existing HTML pipeline, and open the editor — bypassing the upload screen.
+- Show a dedicated **loading state** while the fetch is in flight, so the user never sees a blank or
+  half-rendered editor mid-fetch.
+- **Distinct, actionable error states** instead of a blank editor (acceptance criterion):
+  - `410 Gone` → link expired (90-min TTL): _"Link expired, re-open from demokratis.ch."_
+  - `404 Not Found` → invalid or tampered link.
+  - Network / CORS / non-HTML / parse failures → a generic "couldn't load" message.
+  - Every error path offers a way forward (return to the normal upload screen).
+- **Validate the fetch target against a configurable host allowlist** before fetching. The allowlist
+  defaults to `demokratis.ch` (and its subdomains) and is read from build/env config so staging or
+  signed object-storage hosts can be added without a code change. A `loadFile` pointing at a host
+  outside the allowlist is rejected with an error and never fetched — this keeps StructEdit from
+  being abused as an open fetcher.
+- **Persist a URL-loaded document like an upload**: create an IndexedDB entry so autosave protects
+  the user's work and the document appears in the recents picker. Reuses the existing
+  `document-persistence` machinery; no new storage behavior.
+- **Strip the `loadFile` param from the URL** after a load attempt (via `history.replaceState`), so
+  a page refresh doesn't re-trigger a fetch against an already-expired link.
+- **Out of scope:** DOCX/PDF over `loadFile` (issue scope is HTML; the response is processed as
+  HTML), uploading the edited result back to Demokratis, authentication beyond the signed URL the
+  backend already mints, client-side verification of the `_hash`/`_expiration` (the server is
+  authoritative and returns 410/404), and any change to the existing upload/paste flows.
+- Implement red-green TDD throughout, per [CLAUDE.md](CLAUDE.md) and the precedent set by
+  `add-autosave-and-recents`.
+
+## Capabilities
+
+### New Capabilities
+
+- `remote-document-loading`: load a document into the editor from a signed URL passed in the
+  `loadFile` query parameter — host-allowlist validation, fetch with loading state, HTML processing,
+  distinct error states for expired (410) / invalid (404) / network-or-parse failures, persistence
+  of the loaded document as a recents entry, and one-shot consumption of the query parameter.
+
+### Modified Capabilities
+
+- _None._ The change reuses the existing `document-persistence` capability (entry creation +
+  autosave) without changing its requirements, and reuses the HTML parsing in
+  [file-processing.ts](src/utils/file-processing.ts) / [document-utils.ts](src/utils/document-utils.ts)
+  unchanged.
+
+## Impact
+
+- **App shell:** [src/App.tsx](src/App.tsx) — on mount, detect `loadFile`, drive a new
+  loading / error / loaded flow, and reuse the existing `onConvert`-style state transition into the
+  editor. New top-level view states beyond `'upload' | 'editor'` (a `'loading'` and an error
+  surface).
+- **Remote-loading module (new):** [src/utils/remote-document.ts](src/utils/remote-document.ts) —
+  `parseLoadFileParam(search)`, host-allowlist validation, `fetchRemoteDocument(url)` returning a
+  discriminated result (`ok` with HTML bytes, or a typed error: `expired` / `not-found` /
+  `forbidden-host` / `network` / `unsupported-content`).
+- **HTML processing reuse:** factor the HTML-string → `ProcessedDocument` core out of
+  [src/utils/file-processing.ts](src/utils/file-processing.ts) `processHtmlFile` so the fetched bytes
+  go through the identical parse + source-blob path (with a sensible name derived from the URL).
+- **Config:** the host allowlist constant/env read (e.g. `VITE_LOADFILE_ALLOWED_HOSTS`) with a
+  `demokratis.ch` default; documented in the design.
+- **Loading hook (new, optional):** [src/hooks/useLoadFromUrl.ts](src/hooks/useLoadFromUrl.ts) —
+  encapsulates "read param → validate → fetch → process → persist" so App.tsx stays declarative and
+  the flow is unit-testable apart from the DOM.
+- **Error UI:** a small error panel rendered in place of the upload/editor when a `loadFile` load
+  fails, with the per-status message and a "Go to upload" action. Reuses the existing alert styling
+  from [LoadDocument.tsx](src/components/LoadDocument.tsx) where practical.
+- **Tests:** every file above gains a `*.test.*`. `fetch` is mocked; status-code branches (410, 404,
+  ok, network error, disallowed host, non-HTML body) are each covered. No new production
+  dependencies expected.
+- **No data migration required:** purely additive. Existing upload/paste/recents flows are
+  untouched when no `loadFile` param is present.

--- a/openspec/changes/add-loadfile-url-import/specs/remote-document-loading/spec.md
+++ b/openspec/changes/add-loadfile-url-import/specs/remote-document-loading/spec.md
@@ -1,0 +1,138 @@
+## ADDED Requirements
+
+### Requirement: Load a document from the `loadFile` query parameter
+
+On application load the system SHALL inspect the `loadFile` query parameter. When the parameter is
+present, the system SHALL decode it to a source URL, fetch the document, parse it through the HTML
+pipeline, and open the editor with the parsed document — without requiring the user to interact with
+the upload screen. When the parameter is absent the system SHALL render the normal upload screen and
+SHALL NOT perform any fetch.
+
+#### Scenario: Valid loadFile opens the editor with the document
+
+- **WHEN** the app is opened with `?loadFile=<url-encoded URL>` whose host is allowlisted and the
+  fetch returns `200 OK` with HTML content
+- **THEN** the document is parsed into the tree, the editor view is shown with that tree and a source
+  preview built from the fetched HTML, and the upload screen is not shown
+
+#### Scenario: No loadFile param leaves the upload flow unchanged
+
+- **WHEN** the app is opened with no `loadFile` query parameter
+- **THEN** the upload screen renders exactly as before and no network request is made
+
+#### Scenario: The fetch runs at most once
+
+- **WHEN** the app mounts with a `loadFile` param (including under React StrictMode double-invocation
+  in development)
+- **THEN** the document is fetched at most once
+
+### Requirement: Loading state during the fetch
+
+While a `loadFile` document is being fetched, the system SHALL display an explicit loading state and
+SHALL NOT display a blank or partially-rendered editor. The loading state SHALL be shown immediately
+on load when a `loadFile` param is present, with no intervening flash of the upload screen.
+
+#### Scenario: Loading indicator shown while fetching
+
+- **WHEN** the app is opened with a valid `loadFile` param and the fetch has not yet resolved
+- **THEN** a loading indicator is visible and neither the upload screen nor an empty editor is shown
+
+### Requirement: Distinct error states instead of a blank editor
+
+When a `loadFile` load fails, the system SHALL display a distinct, human-readable error message
+matched to the failure, SHALL NOT open a blank or empty editor, and SHALL offer the user a way to
+reach the normal upload screen. An expired link (HTTP 410) and an invalid link (HTTP 404) SHALL
+produce different messages.
+
+#### Scenario: Expired link (410) shows the expiry message
+
+- **WHEN** fetching the `loadFile` URL returns HTTP `410 Gone`
+- **THEN** the message "Link expired, re-open from demokratis.ch." is shown and the editor is not
+  opened
+
+#### Scenario: Invalid link (404) shows a distinct invalid-link message
+
+- **WHEN** fetching the `loadFile` URL returns HTTP `404 Not Found`
+- **THEN** an "invalid link" message distinct from the 410 message is shown and the editor is not
+  opened
+
+#### Scenario: Network or CORS failure shows a generic load error
+
+- **WHEN** the fetch throws (network offline, DNS, or a CORS rejection surfaced as a `TypeError`) or
+  returns a non-OK status other than 404 or 410
+- **THEN** a generic "couldn't load the document" message is shown and the editor is not opened
+
+#### Scenario: Non-HTML or empty content shows an unsupported-format error
+
+- **WHEN** the fetch returns `200 OK` but the body is not HTML, or the parsed document contains no
+  content
+- **THEN** an "unsupported format" / "couldn't read the document" message is shown and the editor is
+  not opened
+
+#### Scenario: Every error surface offers a path to upload
+
+- **WHEN** any `loadFile` error message is shown
+- **THEN** an action is available that dismisses the error and shows the normal upload screen
+
+### Requirement: Fetch target restricted to an allowlist of hosts
+
+The system SHALL fetch a `loadFile` URL only when its host is on a configurable allowlist, and SHALL
+reject any other host before performing a fetch. The allowlist SHALL default to `demokratis.ch` and
+SHALL be configurable (without code changes) to add additional hosts. Host matching SHALL accept an
+exact host or a subdomain of an allowlisted host on a dot boundary, and SHALL reject look-alike hosts.
+The URL scheme SHALL be `https` (with `http://localhost` permitted only in development).
+
+#### Scenario: Allowlisted host is fetched
+
+- **WHEN** the decoded `loadFile` URL is `https://demokratis.ch/file/<uuid>?_expiration=…&_hash=…`
+- **THEN** the URL is fetched
+
+#### Scenario: Allowlisted subdomain is fetched
+
+- **WHEN** the decoded `loadFile` URL host is a subdomain of an allowlisted host (e.g.
+  `files.demokratis.ch`)
+- **THEN** the URL is fetched
+
+#### Scenario: Non-allowlisted host is rejected without fetching
+
+- **WHEN** the decoded `loadFile` URL points at a host not on the allowlist (e.g.
+  `https://evil.example.com/…`)
+- **THEN** no fetch is performed and an error surface is shown
+
+#### Scenario: Look-alike host is rejected
+
+- **WHEN** the decoded `loadFile` URL host is a look-alike such as `demokratis.ch.evil.com` or
+  `notdemokratis.ch`
+- **THEN** the host is treated as not allowlisted, no fetch is performed, and an error surface is
+  shown
+
+### Requirement: A URL-loaded document is persisted like an upload
+
+A document loaded via `loadFile` SHALL be persisted as a recents entry in the same way as an uploaded
+file, so that autosave protects the work and the document appears in the recents picker. A failure to
+persist (e.g. storage quota) SHALL NOT prevent the editor from opening; the document SHALL remain
+editable in memory and the existing quota notification SHALL apply.
+
+#### Scenario: Successful load creates a recents entry
+
+- **WHEN** a `loadFile` document is successfully fetched and parsed
+- **THEN** a recents entry is created carrying the parsed tree and the fetched source, and autosave is
+  active for the open document
+
+#### Scenario: Persistence failure still opens the editor
+
+- **WHEN** creating the recents entry for a `loadFile` document fails due to a storage error
+- **THEN** the editor still opens with the document in memory and the failure is surfaced via the
+  existing storage notification rather than blocking the load
+
+### Requirement: The `loadFile` parameter is consumed once
+
+After a `loadFile` load attempt, the system SHALL remove the `loadFile` parameter from the browser's
+URL so that reloading the page does not re-trigger a fetch against a possibly-expired link. Removing
+the parameter SHALL preserve the deployment path and SHALL NOT disrupt the open document.
+
+#### Scenario: Refresh does not re-fetch after a load
+
+- **WHEN** a `loadFile` load has been attempted and the user reloads the page
+- **THEN** no new fetch of the previous `loadFile` URL is performed because the parameter is no longer
+  present in the URL

--- a/openspec/changes/add-loadfile-url-import/tasks.md
+++ b/openspec/changes/add-loadfile-url-import/tasks.md
@@ -1,0 +1,43 @@
+## 1. Remote-loading module (param parsing + allowlist)
+
+- [x] 1.1 Red: create [src/utils/remote-document.test.ts](src/utils/remote-document.test.ts) covering `parseLoadFileParam(search, allowedHosts)` for the spec scenarios "Allowlisted host is fetched", "Allowlisted subdomain is fetched", "Non-allowlisted host is rejected without fetching", "Look-alike host is rejected" (`demokratis.ch.evil.com`, `notdemokratis.ch`), plus: absent param → `absent`, non-`https` scheme rejected (and `http://localhost` accepted only in dev), and a malformed/undecodable value → `malformed`
+- [x] 1.2 Green: implement `parseLoadFileParam` in [src/utils/remote-document.ts](src/utils/remote-document.ts) — read `loadFile`, `decodeURIComponent` + `new URL(...)`, validate scheme and host against the allowlist using exact-or-dot-suffix matching (never `includes`). Return the discriminated `{ ok: true; url } | { ok: false; reason }` result from design D3
+- [x] 1.3 Green: add the host-allowlist config: read `VITE_LOADFILE_ALLOWED_HOSTS` (comma-separated), default to `['demokratis.ch']`, and add `localhost`/`127.0.0.1` when `import.meta.env.DEV`. Expose a helper that resolves the effective allowlist so App and tests share one source
+- [x] 1.4 Refactor: confirm the dot-boundary matcher rejects look-alikes and that `parseLoadFileParam` performs no I/O
+
+## 2. Remote-loading module (fetch + status mapping)
+
+- [x] 2.1 Red: extend [src/utils/remote-document.test.ts](src/utils/remote-document.test.ts) for `fetchRemoteDocument(url, fetchImpl)` covering the spec scenarios — `200 OK` HTML → `{ ok: true; html }`, `410 → expired`, `404 → not-found`, other non-OK status → `network`, thrown `TypeError` (CORS/offline) → `network`, `200` non-HTML `Content-Type` → `unsupported-content`, and `200` empty body → `unsupported-content`. Use an injected mock `fetchImpl`
+- [x] 2.2 Green: implement `fetchRemoteDocument` with the status→reason mapping from design D3; read the body as text and check `Content-Type` is HTML-ish and non-empty
+- [x] 2.3 Green: add the `reason → message` map (design D8), including the verbatim "Link expired, re-open from demokratis.ch." copy, and export it for UI + tests to share
+- [x] 2.4 Refactor: confirm the fetch result type is a single discriminated union and the message map covers every `reason`
+
+## 3. HTML pipeline reuse
+
+- [x] 3.1 Red: extend [src/utils/file-processing.test.ts](src/utils/file-processing.test.ts) with "processHtmlString produces the same ProcessedDocument shape as a file upload" and "name is derived from the source URL's file segment, falling back to a default"
+- [x] 3.2 Green: extract `processHtmlString(html, { name, originalFilename, kind })` in [src/utils/file-processing.ts](src/utils/file-processing.ts) and re-implement `processHtmlFile` as a thin wrapper over it (no behavior change to the upload path)
+- [x] 3.3 Green: add a small `deriveNameFromUrl(url)` helper (uuid from `/file/<uuid>`, fallback `"Demokratis document"`, query string ignored) used by the URL-load path
+- [x] 3.4 Refactor: confirm the upload path output is unchanged (characterization test green)
+
+## 4. App-level load-from-URL flow
+
+- [x] 4.1 Red: create [src/hooks/useLoadFromUrl.test.ts](src/hooks/useLoadFromUrl.test.ts) (or extend [src/App.test.tsx](src/App.test.tsx)) covering: param present + 200 → loading then editor with tree + preview; `expired`/`not-found`/`network`/`unsupported-content` each → its message and no editor; `forbidden-host` → error, no fetch; `isEmptyDocument` result → `unsupported-content`; param absent → upload unchanged, no fetch; fetch fires at most once under StrictMode. Mock `fetchRemoteDocument`/`fetch` and the storage module
+- [x] 4.2 Green: implement the flow as `useLoadFromUrl` (or an App mount effect) — `parseLoadFileParam` → on `ok` set loading and `fetchRemoteDocument` → on `ok` `processHtmlString` + `isEmptyDocument` guard → `createEntry` → enter editor; map every failure reason to the error surface. Use a `useRef` once-guard
+- [x] 4.3 Green: wire into [src/App.tsx](src/App.tsx) — decide the initial view synchronously from `window.location.search` (no upload-screen flash), add `loading` and `error` view states, and reuse the existing `onConvert`-style transition into `EditorInterface` for the success path
+- [x] 4.4 Green: persist like an upload (design D6) — reuse the `persistInitialEntry`/`createEntry` path so a quota failure still opens the editor in memory with the existing toast
+- [x] 4.5 Green: strip the `loadFile` param via `history.replaceState(null, '', window.location.pathname)` after the load attempt (design D7); add/extend a test that a reload does not re-fetch
+- [x] 4.6 Refactor: confirm no fetch occurs when the param is absent and the once-guard holds under StrictMode
+
+## 5. Loading & error UI
+
+- [x] 5.1 Red: create a test for the error surface component covering each message variant and that the "Go to upload" action returns to the upload screen, plus a test that the loading surface renders a visible indicator
+- [x] 5.2 Green: add the loading surface (spinner + "Loading document from demokratis.ch…") and the error surface (per-`reason` message from the shared map + "Go to upload" action), reusing the alert styling from [LoadDocument.tsx](src/components/LoadDocument.tsx) where practical
+- [x] 5.3 Green: render these surfaces from [src/App.tsx](src/App.tsx) for the `loading` and `error` view states; "Go to upload" clears the error and shows the upload screen
+- [x] 5.4 Refactor: confirm 410 and 404 render visibly distinct messages
+
+## 6. Verification
+
+- [x] 6.1 Run `npm run test` and confirm the entire suite is green
+- [x] 6.2 Run `npm run build` and confirm it succeeds with no new TypeScript errors
+- [x] 6.3 Manually verify in `npm run dev` (port 3000): open `/?loadFile=<encoded http://localhost-served HTML>` and confirm the loading state then the editor with preview; simulate a 410 and a 404 (e.g. point at endpoints returning those) and confirm the two distinct messages and the "Go to upload" action; open with a non-allowlisted host and confirm it's rejected without a fetch; reload after a load and confirm no re-fetch (param gone)
+- [ ] 6.4 Confirm with the backend that CORS headers are present on both success and 410/404 responses (design Risks). The prod signed-URL host is always `demokratis.ch`, so the built-in default allowlist already covers it — no env config needed for prod

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { IDBFactory } from 'fake-indexeddb';
+import { StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
 import {
@@ -53,6 +54,8 @@ beforeEach(() => {
   URL.revokeObjectURL = vi.fn((url: string) => {
     revokedUrls.push(url);
   });
+  // Reset the URL so a loadFile param from one test never leaks into the next.
+  window.history.replaceState({}, '', '/');
 });
 
 afterEach(async () => {
@@ -165,5 +168,139 @@ describe('App', () => {
     // No entry was persisted (the failed write left no record).
     const recents = await listRecents();
     expect(recents).toHaveLength(0);
+  });
+});
+
+/** Build a minimal Response good enough for fetchRemoteDocument under jsdom. */
+function makeFetchResponse(
+  body: string,
+  init: { status?: number; contentType?: string | null } = {}
+): Response {
+  const { status = 200, contentType = 'text/html; charset=utf-8' } = init;
+  const headers = new Headers();
+  if (contentType !== null) headers.set('content-type', contentType);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers,
+    text: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('App — loadFile URL import', () => {
+  function setLoadFile(url: string) {
+    window.history.pushState({}, '', `/?loadFile=${encodeURIComponent(url)}`);
+  }
+
+  it('loads a valid loadFile document into the editor and creates a recents entry', async () => {
+    setLoadFile('https://demokratis.ch/file/abc-123');
+    const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse('<h1>Title</h1><p>Body</p>'));
+    globalThis.fetch = fetchMock;
+
+    render(<App />);
+
+    await screen.findByRole('button', { name: /close editor/i });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const recents = await listRecents();
+    expect(recents).toHaveLength(1);
+  });
+
+  it('strips the loadFile param after a load so a refresh would not re-fetch', async () => {
+    setLoadFile('https://demokratis.ch/file/abc-123');
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse('<h1>Title</h1>'));
+
+    render(<App />);
+
+    await screen.findByRole('button', { name: /close editor/i });
+    expect(window.location.search).toBe('');
+  });
+
+  it('shows the expiry message on 410 and does not open the editor', async () => {
+    setLoadFile('https://demokratis.ch/file/expired');
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse('', { status: 410 }));
+
+    render(<App />);
+
+    expect(
+      await screen.findByText('Link expired, re-open from demokratis.ch.')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /close editor/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a distinct invalid-link message on 404', async () => {
+    setLoadFile('https://demokratis.ch/file/missing');
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse('', { status: 404 }));
+
+    render(<App />);
+
+    const msg = await screen.findByText(/invalid/i);
+    expect(msg.textContent).not.toBe('Link expired, re-open from demokratis.ch.');
+  });
+
+  it('shows a generic load error on a network/CORS failure', async () => {
+    setLoadFile('https://demokratis.ch/file/x');
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+    render(<App />);
+
+    expect(await screen.findByText(/couldn.t load the document/i)).toBeInTheDocument();
+  });
+
+  it('shows an unsupported-format error when the document parses to nothing', async () => {
+    setLoadFile('https://demokratis.ch/file/empty');
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse('<div>   </div>'));
+
+    render(<App />);
+
+    expect(await screen.findByText(/couldn.t read the document/i)).toBeInTheDocument();
+  });
+
+  it('rejects a non-allowlisted host without fetching', async () => {
+    setLoadFile('https://evil.example.com/file/x');
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    render(<App />);
+
+    await screen.findByText(/invalid/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('offers a path back to the upload screen from an error surface', async () => {
+    setLoadFile('https://demokratis.ch/file/expired');
+    globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse('', { status: 410 }));
+
+    render(<App />);
+
+    await screen.findByText('Link expired, re-open from demokratis.ch.');
+    fireEvent.click(screen.getByRole('button', { name: /go to upload/i }));
+
+    await screen.findByPlaceholderText(/paste unstructured text/i);
+  });
+
+  it('leaves the upload flow unchanged and does not fetch when no loadFile param is present', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    render(<App />);
+
+    await screen.findByPlaceholderText(/paste unstructured text/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches at most once under StrictMode', async () => {
+    setLoadFile('https://demokratis.ch/file/abc-123');
+    const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse('<h1>Hi</h1>'));
+    globalThis.fetch = fetchMock;
+
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    );
+
+    await screen.findByRole('button', { name: /close editor/i });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react';
 import { EditorInterface } from './components/EditorInterface';
 import { Header } from './components/Header';
 import { LoadDocument } from './components/LoadDocument';
+import { RemoteLoadErrorView, RemoteLoadingView } from './components/RemoteDocumentStatus';
 import { Toast } from './components/ui/Toast';
+import { useLoadFromUrl } from './hooks/useLoadFromUrl';
 import { useRecentDocuments } from './hooks/useRecentDocuments';
 import type { DocumentRootNode } from './types/document';
 
@@ -37,6 +39,10 @@ function App() {
     setView('editor');
   };
 
+  // When opened with `?loadFile=<signed URL>`, fetch + load that document into the editor.
+  // Reuses `handleConvert` for the success path; surfaces loading/error states otherwise.
+  const { state: remoteLoad, dismiss: dismissRemoteLoad } = useLoadFromUrl(handleConvert);
+
   const handleResume = async (id: string) => {
     const loaded = await loadEntry(id);
     if (!loaded) return;
@@ -67,7 +73,19 @@ function App() {
 
       <div className="flex-1 flex overflow-hidden">
         <main className="flex-1 flex flex-col min-w-0 bg-white">
-          {view === 'upload' ? (
+          {view === 'editor' && document ? (
+            <EditorInterface
+              initialDocument={document}
+              documentUrl={documentUrl}
+              documentName={fileName}
+              currentEntryId={currentEntryId}
+              onBack={handleBack}
+            />
+          ) : remoteLoad.status === 'loading' ? (
+            <RemoteLoadingView />
+          ) : remoteLoad.status === 'error' ? (
+            <RemoteLoadErrorView reason={remoteLoad.reason} onGoToUpload={dismissRemoteLoad} />
+          ) : (
             <div className="flex-1 overflow-auto p-8">
               <LoadDocument
                 onConvert={handleConvert}
@@ -76,15 +94,7 @@ function App() {
                 onDeleteRecent={deleteEntry}
               />
             </div>
-          ) : document ? (
-            <EditorInterface
-              initialDocument={document}
-              documentUrl={documentUrl}
-              documentName={fileName}
-              currentEntryId={currentEntryId}
-              onBack={handleBack}
-            />
-          ) : null}
+          )}
         </main>
       </div>
       <Toast />

--- a/src/components/LoadDocument.tsx
+++ b/src/components/LoadDocument.tsx
@@ -2,14 +2,10 @@ import { AlertTriangle, ArrowRight, Loader2, Upload } from 'lucide-react';
 import type React from 'react';
 import { useRef, useState } from 'react';
 import type { DocumentRootNode } from '../types/document';
-import {
-  createEntry,
-  formatQuotaMessage,
-  type RecentEntry,
-  StorageQuotaUnresolvableError,
-} from '../utils/document-storage';
+import type { RecentEntry } from '../utils/document-storage';
 import { isEmptyDocument } from '../utils/document-utils';
 import { processFile, processTextInput } from '../utils/file-processing';
+import { persistInitialEntry } from '../utils/persist-entry';
 import { RecentDocumentsList } from './RecentDocumentsList';
 import { Button } from './ui/button';
 import { useToast } from './ui/Toast';
@@ -42,29 +38,6 @@ export function LoadDocument({
   const dragCounterRef = useRef(0);
   const { showToast } = useToast();
 
-  const persistInitialEntry = async (
-    name: string,
-    subtitle: string | null,
-    tree: DocumentRootNode,
-    source: ReturnType<typeof processTextInput>['source']
-  ): Promise<string | null> => {
-    const id = crypto.randomUUID();
-    try {
-      await createEntry({ id, name, subtitle, language: 'de', tree, source });
-      return id;
-    } catch (err) {
-      // Quota errors get the same user-visible toast that autosave uses; other failures
-      // fall back to a console warning. In either case the editor still opens so the
-      // user can keep working in memory (and can Download JSON to save).
-      if (err instanceof StorageQuotaUnresolvableError) {
-        showToast(formatQuotaMessage(err));
-      } else {
-        console.warn('Failed to persist initial entry; autosave disabled.', err);
-      }
-      return null;
-    }
-  };
-
   const handleFile = async (file: File) => {
     setIsLoading(true);
     setWarning(null);
@@ -80,10 +53,13 @@ export function LoadDocument({
       }
       setText(result.html ?? '');
       const entryId = await persistInitialEntry(
-        result.name,
-        result.subtitle,
-        result.doc,
-        result.source
+        {
+          name: result.name,
+          subtitle: result.subtitle,
+          tree: result.doc,
+          source: result.source,
+        },
+        showToast
       );
       onConvert(result.doc, result.sourceUrl, result.html, result.name, entryId);
     } catch (error) {
@@ -145,10 +121,13 @@ export function LoadDocument({
       return;
     }
     const entryId = await persistInitialEntry(
-      result.name,
-      result.subtitle,
-      result.doc,
-      result.source
+      {
+        name: result.name,
+        subtitle: result.subtitle,
+        tree: result.doc,
+        source: result.source,
+      },
+      showToast
     );
     onConvert(result.doc, result.sourceUrl, result.html, result.name, entryId);
   };

--- a/src/components/RemoteDocumentStatus.test.tsx
+++ b/src/components/RemoteDocumentStatus.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { REMOTE_LOAD_MESSAGES, type RemoteLoadErrorReason } from '../utils/remote-document';
+import { RemoteLoadErrorView, RemoteLoadingView } from './RemoteDocumentStatus';
+
+describe('RemoteLoadingView', () => {
+  it('renders a visible loading indicator', () => {
+    render(<RemoteLoadingView />);
+    expect(screen.getByText(/loading document from demokratis\.ch/i)).toBeInTheDocument();
+  });
+});
+
+describe('RemoteLoadErrorView', () => {
+  const ALL_REASONS: RemoteLoadErrorReason[] = [
+    'expired',
+    'not-found',
+    'network',
+    'unsupported-content',
+    'forbidden-host',
+    'malformed',
+  ];
+
+  it('renders the verbatim expiry message for an expired link', () => {
+    render(<RemoteLoadErrorView reason="expired" onGoToUpload={() => {}} />);
+    expect(screen.getByText('Link expired, re-open from demokratis.ch.')).toBeInTheDocument();
+  });
+
+  it('renders a message distinct from the expiry copy for a 404', () => {
+    render(<RemoteLoadErrorView reason="not-found" onGoToUpload={() => {}} />);
+    expect(screen.queryByText('Link expired, re-open from demokratis.ch.')).not.toBeInTheDocument();
+    expect(screen.getByText(REMOTE_LOAD_MESSAGES['not-found'])).toBeInTheDocument();
+  });
+
+  it.each(ALL_REASONS)('renders the mapped message for reason "%s"', (reason) => {
+    render(<RemoteLoadErrorView reason={reason} onGoToUpload={() => {}} />);
+    expect(screen.getByText(REMOTE_LOAD_MESSAGES[reason])).toBeInTheDocument();
+  });
+
+  it('invokes onGoToUpload when the action is clicked', () => {
+    const onGoToUpload = vi.fn();
+    render(<RemoteLoadErrorView reason="network" onGoToUpload={onGoToUpload} />);
+    fireEvent.click(screen.getByRole('button', { name: /go to upload/i }));
+    expect(onGoToUpload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/RemoteDocumentStatus.tsx
+++ b/src/components/RemoteDocumentStatus.tsx
@@ -1,0 +1,45 @@
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import { REMOTE_LOAD_MESSAGES, type RemoteLoadErrorReason } from '../utils/remote-document';
+import { Button } from './ui/button';
+
+/** Shown while a `loadFile` document is being fetched — never a blank editor. */
+export function RemoteLoadingView() {
+  return (
+    <output className="flex-1 flex flex-col items-center justify-center gap-3 p-8 text-gray-600">
+      <Loader2 className="w-8 h-8 animate-spin text-gray-400" />
+      <p className="text-base font-medium">Loading document from demokratis.ch…</p>
+    </output>
+  );
+}
+
+interface RemoteLoadErrorViewProps {
+  reason: RemoteLoadErrorReason;
+  onGoToUpload: () => void;
+}
+
+/**
+ * Shown when a `loadFile` load fails. Renders the per-reason message (410 expiry and 404
+ * invalid-link are distinct) and an action back to the normal upload screen.
+ */
+export function RemoteLoadErrorView({ reason, onGoToUpload }: RemoteLoadErrorViewProps) {
+  return (
+    <div className="flex-1 flex items-center justify-center p-8">
+      <div
+        role="alert"
+        className="max-w-md w-full flex flex-col items-start gap-4 rounded-lg border border-amber-300 bg-amber-50 px-5 py-4 text-amber-900"
+      >
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="w-5 h-5 shrink-0 text-amber-600 mt-0.5" />
+          <span className="text-sm">{REMOTE_LOAD_MESSAGES[reason]}</span>
+        </div>
+        <Button
+          variant="outline"
+          className="btn rounded-lg hover:opacity-90"
+          onClick={onGoToUpload}
+        >
+          Go to upload
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useLoadFromUrl.ts
+++ b/src/hooks/useLoadFromUrl.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useToast } from '../components/ui/Toast';
+import type { DocumentRootNode } from '../types/document';
+import { isEmptyDocument } from '../utils/document-utils';
+import { deriveNameFromUrl, processHtmlString } from '../utils/file-processing';
+import { persistInitialEntry } from '../utils/persist-entry';
+import {
+  fetchRemoteDocument,
+  parseLoadFileParam,
+  type RemoteLoadErrorReason,
+  resolveAllowedHosts,
+} from '../utils/remote-document';
+
+export type RemoteLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'error'; reason: RemoteLoadErrorReason };
+
+/** Matches App's `handleConvert` — the success path reuses the upload transition verbatim. */
+export type OnRemoteDocumentLoaded = (
+  doc: DocumentRootNode,
+  sourceUrl: string | null,
+  html: string | undefined,
+  name: string | null,
+  entryId: string | null
+) => void;
+
+/** Drop the `loadFile` param while preserving the deploy path (D7). */
+function stripLoadFileParam(): void {
+  window.history.replaceState(null, '', window.location.pathname);
+}
+
+/**
+ * Decide the first-render view synchronously so there is no flash of the upload screen
+ * before the loading state when a `loadFile` param is present.
+ */
+function computeInitialState(): RemoteLoadState {
+  const parsed = parseLoadFileParam(window.location.search, resolveAllowedHosts());
+  // `in`-narrowing (not `parsed.ok`): this project compiles without strictNullChecks,
+  // where boolean-discriminant narrowing doesn't apply but `in` does.
+  if (!('reason' in parsed)) return { status: 'loading' };
+  return parsed.reason === 'absent'
+    ? { status: 'idle' }
+    : { status: 'error', reason: parsed.reason };
+}
+
+/**
+ * Read the `loadFile` query parameter on mount and, when present, fetch + parse + persist
+ * the document, calling `onLoaded` on success. Returns the observable load state and a
+ * `dismiss` action for the error surface's "Go to upload". The fetch runs at most once,
+ * even under React StrictMode's double-mount.
+ */
+export function useLoadFromUrl(onLoaded: OnRemoteDocumentLoaded): {
+  state: RemoteLoadState;
+  dismiss: () => void;
+} {
+  const [state, setState] = useState<RemoteLoadState>(computeInitialState);
+  const { showToast } = useToast();
+
+  // Keep the latest callbacks without re-running the mount effect.
+  const onLoadedRef = useRef(onLoaded);
+  onLoadedRef.current = onLoaded;
+  const showToastRef = useRef(showToast);
+  showToastRef.current = showToast;
+
+  const initiatedRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (!initiatedRef.current) {
+      initiatedRef.current = true;
+
+      const parsed = parseLoadFileParam(window.location.search, resolveAllowedHosts());
+      if ('reason' in parsed) {
+        // `absent` leaves the normal upload flow alone; other reasons are a bad link.
+        if (parsed.reason !== 'absent') {
+          stripLoadFileParam();
+          setState({ status: 'error', reason: parsed.reason });
+        }
+      } else {
+        // Consume the param immediately so a refresh can't re-fetch an expired link.
+        stripLoadFileParam();
+        setState({ status: 'loading' });
+
+        void (async () => {
+          const result = await fetchRemoteDocument(parsed.url);
+          if (!mountedRef.current) return;
+          if ('reason' in result) {
+            setState({ status: 'error', reason: result.reason });
+            return;
+          }
+
+          const processed = processHtmlString(result.html, {
+            name: deriveNameFromUrl(result.sourceUrl),
+            originalFilename: null,
+          });
+          if (isEmptyDocument(processed.doc)) {
+            setState({ status: 'error', reason: 'unsupported-content' });
+            return;
+          }
+
+          // Persist like an upload (D6): a quota failure still opens the editor.
+          const entryId = await persistInitialEntry(
+            {
+              name: processed.name,
+              subtitle: processed.subtitle,
+              tree: processed.doc,
+              source: processed.source,
+            },
+            showToastRef.current
+          );
+          if (!mountedRef.current) return;
+
+          onLoadedRef.current(
+            processed.doc,
+            processed.sourceUrl,
+            processed.html,
+            processed.name,
+            entryId
+          );
+          // App switches to the editor view; clear our overlay state.
+          setState({ status: 'idle' });
+        })();
+      }
+    }
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const dismiss = useCallback(() => setState({ status: 'idle' }), []);
+  return { state, dismiss };
+}

--- a/src/utils/file-processing.test.ts
+++ b/src/utils/file-processing.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ContentDocumentNode } from '../types/document';
 import {
   createPlainTextDocument,
+  deriveNameFromUrl,
   processDocxFile,
   processFile,
   processHtmlFile,
+  processHtmlString,
   processPdfFile,
   processTextInput,
 } from './file-processing';
@@ -285,6 +287,59 @@ describe('file-processing', () => {
     it('throws for unsupported file types', async () => {
       const file = new File(['data'], 'test.csv', { type: 'text/csv' });
       await expect(processFile(file)).rejects.toThrow('Unsupported file type');
+    });
+  });
+
+  describe('processHtmlString', () => {
+    beforeEach(() => {
+      URL.createObjectURL = vi.fn(() => 'blob:fake-url');
+    });
+
+    it('produces the same ProcessedDocument shape as a file upload for the same HTML', async () => {
+      const html = '<h1>Title</h1><p>Body text</p>';
+
+      const fromString = processHtmlString(html, {
+        name: 'abc-123',
+        originalFilename: null,
+      });
+      // jsdom's File needs a .text() polyfill (already installed by the
+      // processHtmlFile describe's beforeEach when that block ran); re-add defensively.
+      if (!Blob.prototype.text) {
+        Blob.prototype.text = () => Promise.resolve(html);
+      }
+      const fromFile = await processHtmlFile(
+        new File([html], 'abc-123.html', { type: 'text/html' })
+      );
+
+      expect(fromString.html).toBe(fromFile.html);
+      expect(fromString.doc.type).toBe('DOCUMENT');
+      expect(fromString.doc.children.length).toBe(fromFile.doc.children.length);
+      expect(fromString.source.kind).toBe('html');
+      expect(fromString.source.mime).toBe('text/html');
+      expect(fromString.source.bytes).toBe(html);
+    });
+
+    it('uses the provided name, originalFilename, and a null subtitle', () => {
+      const result = processHtmlString('<p>Hi</p>', {
+        name: 'Demokratis document',
+        originalFilename: null,
+      });
+      expect(result.name).toBe('Demokratis document');
+      expect(result.source.originalFilename).toBeNull();
+      expect(result.subtitle).toBeNull();
+      expect(result.sourceUrl).toBe('blob:fake-url');
+    });
+  });
+
+  describe('deriveNameFromUrl', () => {
+    it('uses the uuid from a /file/<uuid> path, ignoring the query string', () => {
+      const url = 'https://demokratis.ch/file/abc-123?_expiration=999&_hash=deadbeef';
+      expect(deriveNameFromUrl(url)).toBe('abc-123');
+    });
+
+    it('falls back to a default when there is no usable path segment', () => {
+      expect(deriveNameFromUrl('https://demokratis.ch/')).toBe('Demokratis document');
+      expect(deriveNameFromUrl('not a url')).toBe('Demokratis document');
     });
   });
 });

--- a/src/utils/file-processing.ts
+++ b/src/utils/file-processing.ts
@@ -103,8 +103,16 @@ export function processTextInput(text: string): ProcessedDocument {
   };
 }
 
-export async function processHtmlFile(file: File): Promise<ProcessedDocument> {
-  const html = await file.text();
+/**
+ * Build a {@link ProcessedDocument} from an HTML string. Shared by the file-upload path
+ * ({@link processHtmlFile}) and the `loadFile` URL path, so fetched HTML goes through the
+ * identical parse + source-blob pipeline. The caller supplies the display name, original
+ * filename (null for fetched documents), and source kind.
+ */
+export function processHtmlString(
+  html: string,
+  options: { name: string; originalFilename: string | null; kind?: StoredEntrySource['kind'] }
+): ProcessedDocument {
   const blob = new Blob([html], { type: 'text/html' });
   const sourceUrl = URL.createObjectURL(blob);
   const doc = parseHtmlLegalToTree(html);
@@ -112,10 +120,35 @@ export async function processHtmlFile(file: File): Promise<ProcessedDocument> {
     doc,
     sourceUrl,
     html,
-    source: { kind: 'html', mime: 'text/html', bytes: html, originalFilename: file.name },
-    name: file.name,
+    source: {
+      kind: options.kind ?? 'html',
+      mime: 'text/html',
+      bytes: html,
+      originalFilename: options.originalFilename,
+    },
+    name: options.name,
     subtitle: null,
   };
+}
+
+export async function processHtmlFile(file: File): Promise<ProcessedDocument> {
+  const html = await file.text();
+  return processHtmlString(html, { name: file.name, originalFilename: file.name });
+}
+
+/**
+ * Derive a display name for a document fetched from a signed URL. Uses the last path
+ * segment (the `<uuid>` from `/file/<uuid>`), ignoring the query string, and falls back
+ * to a generic name when there is no usable segment or the URL doesn't parse.
+ */
+export function deriveNameFromUrl(url: string): string {
+  try {
+    const { pathname } = new URL(url);
+    const last = pathname.split('/').filter(Boolean).pop();
+    return last ? decodeURIComponent(last) : 'Demokratis document';
+  } catch {
+    return 'Demokratis document';
+  }
 }
 
 const MAMMOTH_STYLE_MAP = [

--- a/src/utils/persist-entry.ts
+++ b/src/utils/persist-entry.ts
@@ -1,0 +1,48 @@
+import type { DocumentRootNode, Language } from '../types/document';
+import {
+  createEntry,
+  formatQuotaMessage,
+  StorageQuotaUnresolvableError,
+  type StoredEntrySource,
+} from './document-storage';
+
+export interface PersistInitialEntryInput {
+  name: string;
+  subtitle: string | null;
+  tree: DocumentRootNode;
+  source: StoredEntrySource;
+  language?: Language;
+}
+
+/**
+ * Persist a freshly-created entry (upload, paste, or `loadFile` URL) to IndexedDB and
+ * return its id, or `null` when persistence fails.
+ *
+ * Quota errors surface via the supplied `showToast` (the same toast autosave uses);
+ * other failures fall back to a console warning. In every failure case the caller can
+ * still open the editor and work in memory — persistence is best-effort, never a gate.
+ */
+export async function persistInitialEntry(
+  input: PersistInitialEntryInput,
+  showToast: (message: string) => void
+): Promise<string | null> {
+  const id = crypto.randomUUID();
+  try {
+    await createEntry({
+      id,
+      name: input.name,
+      subtitle: input.subtitle,
+      language: input.language ?? 'de',
+      tree: input.tree,
+      source: input.source,
+    });
+    return id;
+  } catch (err) {
+    if (err instanceof StorageQuotaUnresolvableError) {
+      showToast(formatQuotaMessage(err));
+    } else {
+      console.warn('Failed to persist initial entry; autosave disabled.', err);
+    }
+    return null;
+  }
+}

--- a/src/utils/remote-document.test.ts
+++ b/src/utils/remote-document.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchRemoteDocument,
+  parseLoadFileParam,
+  REMOTE_LOAD_MESSAGES,
+  type RemoteLoadErrorReason,
+  resolveAllowedHosts,
+} from './remote-document';
+
+const ALLOWED = ['demokratis.ch'];
+
+/** Build a `?loadFile=...` search string with the URL properly encoded. */
+function searchFor(url: string): string {
+  return `?loadFile=${encodeURIComponent(url)}`;
+}
+
+/** Minimal Response stub good enough for fetchRemoteDocument. */
+function makeResponse(
+  body: string,
+  init: { status?: number; contentType?: string | null } = {}
+): Response {
+  const { status = 200, contentType = 'text/html; charset=utf-8' } = init;
+  const headers = new Headers();
+  if (contentType !== null) headers.set('content-type', contentType);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers,
+    text: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('parseLoadFileParam', () => {
+  it('returns the decoded URL for an allowlisted host', () => {
+    const url = 'https://demokratis.ch/file/abc-123?_expiration=999&_hash=deadbeef';
+    const result = parseLoadFileParam(searchFor(url), ALLOWED);
+    expect(result).toEqual({ ok: true, url });
+  });
+
+  it('accepts a subdomain of an allowlisted host', () => {
+    const url = 'https://files.demokratis.ch/file/abc-123';
+    const result = parseLoadFileParam(searchFor(url), ALLOWED);
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns absent when no loadFile param is present', () => {
+    expect(parseLoadFileParam('?foo=bar', ALLOWED)).toEqual({ ok: false, reason: 'absent' });
+    expect(parseLoadFileParam('', ALLOWED)).toEqual({ ok: false, reason: 'absent' });
+  });
+
+  it('rejects a non-allowlisted host without fetching', () => {
+    const url = 'https://evil.example.com/file/abc-123';
+    expect(parseLoadFileParam(searchFor(url), ALLOWED)).toEqual({
+      ok: false,
+      reason: 'forbidden-host',
+    });
+  });
+
+  it('rejects a look-alike host that merely contains the allowed host', () => {
+    for (const url of [
+      'https://demokratis.ch.evil.com/file/x',
+      'https://notdemokratis.ch/file/x',
+    ]) {
+      expect(parseLoadFileParam(searchFor(url), ALLOWED)).toEqual({
+        ok: false,
+        reason: 'forbidden-host',
+      });
+    }
+  });
+
+  it('rejects a non-https scheme on an allowlisted host', () => {
+    const url = 'http://demokratis.ch/file/abc-123';
+    expect(parseLoadFileParam(searchFor(url), ALLOWED).ok).toBe(false);
+  });
+
+  it('accepts http://localhost only when localhost is in the allowlist', () => {
+    const url = 'http://localhost:5173/file/abc-123';
+    expect(parseLoadFileParam(searchFor(url), [...ALLOWED, 'localhost']).ok).toBe(true);
+    // Without localhost in the allowlist (prod), the same URL is rejected.
+    expect(parseLoadFileParam(searchFor(url), ALLOWED).ok).toBe(false);
+  });
+
+  it('returns malformed for an unparseable value', () => {
+    expect(parseLoadFileParam('?loadFile=not%20a%20url', ALLOWED)).toEqual({
+      ok: false,
+      reason: 'malformed',
+    });
+  });
+});
+
+describe('resolveAllowedHosts', () => {
+  it('defaults to demokratis.ch when nothing is configured', () => {
+    expect(resolveAllowedHosts({})).toEqual(['demokratis.ch']);
+  });
+
+  it('reads a comma-separated VITE_LOADFILE_ALLOWED_HOSTS list', () => {
+    const hosts = resolveAllowedHosts({
+      VITE_LOADFILE_ALLOWED_HOSTS: 'demokratis.ch, staging.demokratis.ch',
+    });
+    expect(hosts).toContain('demokratis.ch');
+    expect(hosts).toContain('staging.demokratis.ch');
+  });
+
+  it('adds localhost in development', () => {
+    const hosts = resolveAllowedHosts({ DEV: true });
+    expect(hosts).toContain('localhost');
+    expect(hosts).toContain('127.0.0.1');
+  });
+
+  it('does not add localhost in production', () => {
+    const hosts = resolveAllowedHosts({ DEV: false });
+    expect(hosts).not.toContain('localhost');
+  });
+});
+
+describe('fetchRemoteDocument', () => {
+  const URL_OK = 'https://demokratis.ch/file/abc-123';
+
+  it('returns the html for a 200 HTML response', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse('<h1>Hi</h1>'));
+    const result = await fetchRemoteDocument(URL_OK, fetchImpl);
+    expect(result).toEqual({ ok: true, html: '<h1>Hi</h1>', sourceUrl: URL_OK });
+    expect(fetchImpl).toHaveBeenCalledWith(URL_OK);
+  });
+
+  it('maps 410 to expired', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse('', { status: 410 }));
+    expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('maps 404 to not-found', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse('', { status: 404 }));
+    expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({
+      ok: false,
+      reason: 'not-found',
+    });
+  });
+
+  it('maps other non-OK statuses to network', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse('', { status: 500 }));
+    expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({ ok: false, reason: 'network' });
+  });
+
+  it('maps a thrown TypeError (CORS/offline) to network', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({ ok: false, reason: 'network' });
+  });
+
+  it('maps a non-HTML content-type to unsupported-content', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(makeResponse('{"a":1}', { contentType: 'application/json' }));
+    expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({
+      ok: false,
+      reason: 'unsupported-content',
+    });
+  });
+
+  it('maps an empty HTML body to unsupported-content', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse('   '));
+    expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({
+      ok: false,
+      reason: 'unsupported-content',
+    });
+  });
+});
+
+describe('REMOTE_LOAD_MESSAGES', () => {
+  it('uses the verbatim issue copy for expired links', () => {
+    expect(REMOTE_LOAD_MESSAGES.expired).toBe('Link expired, re-open from demokratis.ch.');
+  });
+
+  it('has a distinct message for not-found vs expired', () => {
+    expect(REMOTE_LOAD_MESSAGES['not-found']).not.toBe(REMOTE_LOAD_MESSAGES.expired);
+  });
+
+  it('covers every error reason', () => {
+    const reasons: RemoteLoadErrorReason[] = [
+      'expired',
+      'not-found',
+      'network',
+      'unsupported-content',
+      'forbidden-host',
+      'malformed',
+    ];
+    for (const reason of reasons) {
+      expect(typeof REMOTE_LOAD_MESSAGES[reason]).toBe('string');
+      expect(REMOTE_LOAD_MESSAGES[reason].length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/utils/remote-document.ts
+++ b/src/utils/remote-document.ts
@@ -1,0 +1,162 @@
+/**
+ * Loading a document from a signed URL passed in the `?loadFile=` query parameter.
+ *
+ * The Demokratis backend opens StructEdit at `…/?loadFile=<url-encoded signed URL>`.
+ * This module holds the pure, React-free core of that flow: parsing + host-allowlist
+ * validation of the parameter, and fetching the document with the HTTP-status → reason
+ * mapping the UI needs. See `openspec/changes/add-loadfile-url-import/design.md`.
+ */
+
+/** Host always used for production signed files; the built-in default allowlist. */
+const DEFAULT_ALLOWED_HOSTS = ['demokratis.ch'];
+
+/** The subset of `import.meta.env` this module reads, so callers/tests can inject it. */
+interface AllowlistEnv {
+  DEV?: boolean;
+  VITE_LOADFILE_ALLOWED_HOSTS?: string;
+}
+
+/**
+ * Resolve the effective host allowlist. Defaults to `demokratis.ch`; a comma-separated
+ * `VITE_LOADFILE_ALLOWED_HOSTS` overrides the default; `localhost`/`127.0.0.1` are added
+ * in development so the flow can be exercised locally. App and tests share this one source.
+ */
+export function resolveAllowedHosts(env: AllowlistEnv = import.meta.env): string[] {
+  const configured = (env.VITE_LOADFILE_ALLOWED_HOSTS ?? '')
+    .split(',')
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean);
+  const hosts = configured.length > 0 ? configured : [...DEFAULT_ALLOWED_HOSTS];
+  if (env.DEV) {
+    hosts.push('localhost', '127.0.0.1');
+  }
+  return hosts;
+}
+
+function isLocalHost(host: string): boolean {
+  return host === 'localhost' || host === '127.0.0.1';
+}
+
+/**
+ * A host is allowed when it equals an allowlist entry or is a subdomain of one on a
+ * dot boundary. Never a bare `includes()` — that lets `demokratis.ch.evil.com` and
+ * `notdemokratis.ch` through.
+ */
+function isHostAllowed(host: string, allowedHosts: string[]): boolean {
+  const h = host.toLowerCase();
+  return allowedHosts.some((allowed) => h === allowed || h.endsWith(`.${allowed}`));
+}
+
+export type ParseLoadFileResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: 'absent' | 'malformed' | 'forbidden-host' };
+
+/**
+ * Read and validate the `loadFile` parameter from a query string. Performs no I/O.
+ * Returns the decoded URL only when it parses, targets an allowlisted host, and uses
+ * an allowed scheme (`https`, or `http` for an allowlisted localhost in dev).
+ */
+export function parseLoadFileParam(search: string, allowedHosts: string[]): ParseLoadFileResult {
+  const raw = new URLSearchParams(search).get('loadFile');
+  if (!raw) return { ok: false, reason: 'absent' };
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(decoded);
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+
+  if (!isHostAllowed(url.hostname, allowedHosts)) {
+    return { ok: false, reason: 'forbidden-host' };
+  }
+
+  const schemeOk =
+    url.protocol === 'https:' || (url.protocol === 'http:' && isLocalHost(url.hostname));
+  if (!schemeOk) {
+    return { ok: false, reason: 'forbidden-host' };
+  }
+
+  return { ok: true, url: url.toString() };
+}
+
+/** Failure reasons that can arise from the network fetch itself. */
+export type RemoteFetchErrorReason = 'expired' | 'not-found' | 'network' | 'unsupported-content';
+
+export type RemoteFetchResult =
+  | { ok: true; html: string; sourceUrl: string }
+  | { ok: false; reason: RemoteFetchErrorReason };
+
+function looksLikeHtml(contentType: string | null): boolean {
+  if (!contentType) return false;
+  const ct = contentType.toLowerCase();
+  return ct.includes('text/html') || ct.includes('application/xhtml');
+}
+
+/**
+ * Fetch a (pre-validated) document URL and map the outcome to a discriminated result.
+ * `fetchImpl` is injectable so tests exercise every status branch without a network.
+ *
+ * Mapping: 410 → expired, 404 → not-found, any other non-OK status or thrown error
+ * (CORS/offline surface as `TypeError`) → network, a non-HTML or empty 2xx body →
+ * unsupported-content.
+ */
+export async function fetchRemoteDocument(
+  url: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<RemoteFetchResult> {
+  let response: Response;
+  try {
+    response = await fetchImpl(url);
+  } catch {
+    return { ok: false, reason: 'network' };
+  }
+
+  if (!response.ok) {
+    if (response.status === 410) return { ok: false, reason: 'expired' };
+    if (response.status === 404) return { ok: false, reason: 'not-found' };
+    return { ok: false, reason: 'network' };
+  }
+
+  if (!looksLikeHtml(response.headers.get('content-type'))) {
+    return { ok: false, reason: 'unsupported-content' };
+  }
+
+  let html: string;
+  try {
+    html = await response.text();
+  } catch {
+    return { ok: false, reason: 'network' };
+  }
+
+  if (!html.trim()) {
+    return { ok: false, reason: 'unsupported-content' };
+  }
+
+  return { ok: true, html, sourceUrl: url };
+}
+
+/** Every reason a `loadFile` load can fail, across parsing and fetching. */
+export type RemoteLoadErrorReason = RemoteFetchErrorReason | 'forbidden-host' | 'malformed';
+
+/**
+ * User-facing copy per failure reason — single source of truth shared by the UI and
+ * tests. `forbidden-host`/`malformed` only arise from a hand-edited URL, so they reuse
+ * the "invalid link" copy.
+ */
+export const REMOTE_LOAD_MESSAGES: Record<RemoteLoadErrorReason, string> = {
+  expired: 'Link expired, re-open from demokratis.ch.',
+  'not-found': 'This document link is invalid. Re-open it from demokratis.ch.',
+  network:
+    "Couldn't load the document. Check your connection and try re-opening it from demokratis.ch.",
+  'unsupported-content': "Couldn't read the document — it wasn't in a supported format.",
+  'forbidden-host': 'This document link is invalid. Re-open it from demokratis.ch.',
+  malformed: 'This document link is invalid. Re-open it from demokratis.ch.',
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Comma-separated allowlist of hosts StructEdit may fetch a `loadFile` URL from. */
+  readonly VITE_LOADFILE_ALLOWED_HOSTS?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

Implements the frontend side of **issue #131**: the Demokratis backend opens StructEdit at `…/?loadFile=<url-encoded signed URL>`, and the editor now reads that parameter, fetches the document, parses it through the existing HTML pipeline, and opens with the document loaded — never a blank editor.

Related to #131. **This PR intentionally does not close the issue** — it stays open pending backend CORS coordination (see *Follow-up* below).

## What it does

- **Reads & validates `loadFile`** against a configurable host allowlist (`VITE_LOADFILE_ALLOWED_HOSTS`, default `demokratis.ch`). Strict dot-boundary host matching, `https`-only (`http://localhost` in dev). Disallowed hosts are rejected **before** any fetch — StructEdit can't be abused as an open fetcher.
- **Distinct, non-blank error states** (acceptance criterion):
  - `410` → "Link expired, re-open from demokratis.ch." (verbatim from the issue)
  - `404` → invalid-link message
  - network / CORS → generic "couldn't load"
  - non-HTML / empty → "couldn't read the document"
  - every error offers **Go to upload**
- **Loading surface** during the fetch; the first view is decided synchronously so there's no flash of the upload screen.
- **Persists like an upload** — a URL-loaded doc gets a recents entry + autosave; a quota failure still opens the editor in memory.
- **Consumes the param** via `history.replaceState`, so a refresh can't re-fetch an expired link. The fetch runs **once**, even under React StrictMode.
- Reuses the HTML pipeline (`processHtmlString`) and extracts a shared `persistInitialEntry` helper.

## Design / spec

Built via OpenSpec — proposal, design, spec, and tasks under [`openspec/changes/add-loadfile-url-import/`](openspec/changes/add-loadfile-url-import/).

## Testing

- `npm run test` → **1342 passed / 52 files**. New coverage: `remote-document` (param/allowlist/fetch matrix), `processHtmlString`/`deriveNameFromUrl`, the App flow (happy path, 410/404/network/unsupported/forbidden-host, param-strip, StrictMode once-guard), and the loading/error components.
- `npm run typecheck` and `npm run build` clean.
- **Real-browser smoke test** against the dev server: valid `loadFile` → editor + preview + recents entry + stripped param; non-allowlisted host → invalid message + working "Go to upload"; no console errors.

## Follow-up (why this doesn't close #131)

The backend must send **CORS headers on both success and `410`/`404` responses**. Without permissive CORS on error responses, the browser surfaces a `TypeError` and the distinct expired/invalid messages degrade to the generic one. Production always serves from `demokratis.ch`, so no env config is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)