### PR TITLE
Support importing StructEdit DocTree JSON via file upload

### DIFF
--- a/src/components/LoadDocument.tsx
+++ b/src/components/LoadDocument.tsx
@@ -172,7 +172,7 @@ export function LoadDocument({
               type="file"
               ref={fileInputRef}
               className="hidden"
-              accept=".docx,.doc,.html,.htm"
+              accept=".docx,.doc,.html,.htm,.json"
               onChange={handleFileInputChange}
             />
             <button
@@ -199,7 +199,7 @@ export function LoadDocument({
               <span className="text-base font-medium text-gray-700">
                 Click or drop a document to upload
               </span>
-              <span className="text-xs text-gray-500">DOCX or HTML supported</span>
+              <span className="text-xs text-gray-500">DOCX, HTML, or DocTree JSON supported</span>
             </button>
           </section>
 

--- a/src/hooks/useRecentDocuments.ts
+++ b/src/hooks/useRecentDocuments.ts
@@ -11,7 +11,9 @@ import {
 
 export interface LoadedEntry {
   entry: StoredDocumentEntry;
-  documentUrl: string;
+  /** Blob URL for the "Original" preview, or null when the source has no separate
+   *  original to render (e.g. a re-imported DocTree JSON, which *is* the tree). */
+  documentUrl: string | null;
 }
 
 export interface UseRecentDocuments {
@@ -47,6 +49,11 @@ export function useRecentDocuments(): UseRecentDocuments {
   const loadEntry = useCallback(async (id: string): Promise<LoadedEntry | null> => {
     const raw = await loadEntryFromStorage(id);
     if (!raw || 'status' in raw) return null;
+    // A re-imported DocTree JSON has no separate original to preview — the stored bytes
+    // are the tree itself — so skip the blob URL and let the editor show Preview only.
+    if (raw.source.kind === 'json-envelope') {
+      return { entry: raw, documentUrl: null };
+    }
     const blob = new Blob([raw.source.bytes], { type: raw.source.mime });
     const documentUrl = URL.createObjectURL(blob);
     return { entry: raw, documentUrl };

--- a/src/test/fixtures/realistic/doctree/vora-edi.doctree.json
+++ b/src/test/fixtures/realistic/doctree/vora-edi.doctree.json
@@ -1,0 +1,718 @@
+{
+  "DocTreeVersion": 1,
+  "metadata": {
+    "title": {
+      "de": "fedlex-data-admin-ch-eli-dl-proj-2025-104-cons_1-doc_1-de-pdf-a"
+    }
+  },
+  "document": {
+    "id": "bajufpc",
+    "type": "DOCUMENT",
+    "children": [
+      {
+        "id": "ub75nsx",
+        "number": null,
+        "type": "HEADING",
+        "format": "TEXT",
+        "contents": {
+          "de": "Verordnung des EDI über die Umsetzung des Risikoausgleichs in der Krankenversicherung (VORA-EDI)"
+        },
+        "children": [
+          {
+            "id": "i4aqg1p",
+            "number": null,
+            "type": "CONTENT",
+            "format": "MARKDOWN",
+            "contents": {
+              "de": "**vom …**"
+            },
+            "children": []
+          },
+          {
+            "id": "j6ydlow",
+            "number": null,
+            "type": "CONTENT",
+            "format": "MARKDOWN",
+            "contents": {
+              "de": "*Das Eidgenössische Departement des Innern (EDI)*"
+            },
+            "children": []
+          },
+          {
+            "id": "7z0tasr",
+            "number": null,
+            "type": "CONTENT",
+            "format": "MARKDOWN",
+            "contents": {
+              "de": "gestützt auf die Artikel 4 Absätze 1 und 4, 5 Absatz 5 und 13 Absatz 2 der Verordnung vom 19. Oktober 2016^1^ über den Risikoausgleich in der Krankenversicherung (VORA),"
+            },
+            "children": [
+              {
+                "id": "ti1azu3",
+                "number": "^1^",
+                "type": "FOOTNOTE",
+                "format": "TEXT",
+                "contents": {
+                  "de": "SR 832.112.1"
+                }
+              }
+            ]
+          },
+          {
+            "id": "rcge3o0",
+            "number": null,
+            "type": "CONTENT",
+            "format": "MARKDOWN",
+            "contents": {
+              "de": "*verordnet:*"
+            },
+            "children": []
+          },
+          {
+            "id": "a1lw5sv",
+            "number": "Art. 1",
+            "type": "HEADING",
+            "format": "TEXT",
+            "contents": {
+              "de": "PCG-Liste"
+            },
+            "children": [
+              {
+                "id": "sle54kv",
+                "number": null,
+                "type": "CONTENT",
+                "format": "TEXT",
+                "contents": {
+                  "de": "Die pharmazeutischen Kostengruppen (PCG) sind im Anhang festgelegt."
+                },
+                "children": []
+              }
+            ]
+          },
+          {
+            "id": "pmtj449",
+            "number": "Art. 2",
+            "type": "HEADING",
+            "format": "TEXT",
+            "contents": {
+              "de": "Hierarchisierung der PCG"
+            },
+            "children": [
+              {
+                "id": "dxrjsjg",
+                "number": null,
+                "type": "CONTENT",
+                "format": "TEXT",
+                "contents": {
+                  "de": "Es gelten folgende Hierarchisierungen:"
+                },
+                "children": []
+              },
+              {
+                "id": "e4rqwnw",
+                "number": null,
+                "type": "LIST",
+                "children": [
+                  {
+                    "id": "i2zhkbv",
+                    "number": "a.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "0if58tp",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Die PCG «Autoimmunkrankheiten (AIK)» ist hierarchisch höher als die PCG «Rheuma (RHE)»."
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "i4tnprq",
+                    "number": "b.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "wh0plqt",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Die PCG «Bipolare Störung regulär (BSR)», die PCG «Psychose (PSY)», die PCG «Neuropathischer Schmerz (SMN)» und die PCG «Sucht ohne Nikotin (ABH)» sind hierarchisch höher als die PCG «Depression (DEP)»."
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ky3jkgt",
+                    "number": "c.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "r9uxmel",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Die PCG «COPD / Schweres Asthma (COP)» ist hierarchisch höher als die PCG «Asthma (AST)»."
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "rt5prx7",
+                    "number": "d.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "yjtvpnw",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Die PCG «Krebs Biologika (KRB)» und die PCG «Krebs (KRE)» sind hierarchisch höher als die PCG «Hormonsensitive Tumore (KHO)»."
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "evqugdp",
+                    "number": "e.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "lbqh2y3",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Die PCG «Krebs Biologika (KRB)» ist hierarchisch höher als die PCG «Krebs (KRE)»."
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "f4mgf7u",
+                    "number": "f.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "53b5hwu",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Die PCG «Psychose Depot (PSD)» ist hierarchisch höher als die PCG «Psychose (PSY)»."
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "6bs5s2b",
+                    "number": "g.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "frff28s",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Die PCG «Neuropathischer Schmerz (SMN)» ist hierarchisch höher als die PCG «Chronische Schmerzen ohne Opioide (SMC)»."
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "voh0978",
+                    "number": "h.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "8twoksg",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Die PCG «Zystische Fibrose zielgerichtete Therapie (ZFZ)» ist hierarchisch höher als die PCG «Zystische Fibrose (ZFI)»."
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "e6lxjy4",
+                    "number": "i.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "fiyofcc",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Die PCG «Krankheiten des zentralen Nervensystems ohne Multiple Sklerose (ZNS)» ist hierarchisch höher als die PCG «Chronische Schmerzen ohne Opioide (SMC)»."
+                        },
+                        "children": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "8zxnkyf",
+            "number": "Art. 3",
+            "type": "HEADING",
+            "format": "TEXT",
+            "contents": {
+              "de": "Mindestanzahl Arzneimittelpackungen und standardisierte Tagesdosen von Arzneimitteln"
+            },
+            "children": [
+              {
+                "id": "ycz4s31",
+                "number": null,
+                "type": "CONTENT",
+                "format": "TEXT",
+                "contents": {
+                  "de": "Für die Einteilung in eine PCG muss eine versicherte Person im Jahr vor dem Ausgleichsjahr (Vorjahr) mindestens bezogen haben:"
+                },
+                "children": []
+              },
+              {
+                "id": "303w7lu",
+                "number": null,
+                "type": "LIST",
+                "children": [
+                  {
+                    "id": "wh50cia",
+                    "number": "a.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "vx1ijjk",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "für die Einteilung in die PCG «Hämophilie (HMP)» und die PCG «Immunglobuline (IMM)»: mindestens eine Arzneimittelpackung;"
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "1hrskdx",
+                    "number": "b.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "fozrejd",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "für die Einteilung in die PCG «Krebs Biologika (KRB)», die PCG «Krebs (KRE)», die PCG «Makuladegeneration (MAC)», die PCG «Psychose Depot (PSD)», die PCG «Zystische Fibrose (ZFI)» und die PCG «Zystische Fibrose zielgerichtete Therapie (ZFZ)»: mindestens drei Arzneimittelpackungen;"
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "8aaclso",
+                    "number": "c.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "ftuex79",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "für die Einteilung in die PCG «Alzheimer (ALZ)», die PCG «Bipolare Störung regulär (BSR)», die PCG «Hormonsensitive Tumore (KHO)», die PCG «Rheuma (RHE)» und die PCG «Transplantationen (TRA)»: mindestens 90 standardisierte Tagesdosen (DDD) von Arzneimitteln;"
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "5jbibim",
+                    "number": "d.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "1awowq7",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "für die Einteilung in die übrigen PCG: mindestens 180 DDD von Arzneimitteln."
+                        },
+                        "children": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "z5kpjrw",
+            "number": "Art. 4",
+            "type": "HEADING",
+            "format": "TEXT",
+            "contents": {
+              "de": "Teuerungsfaktoren"
+            },
+            "children": [
+              {
+                "id": "5wdu0au",
+                "number": null,
+                "type": "CONTENT",
+                "format": "MARKDOWN",
+                "contents": {
+                  "de": "^1^ Für jeden Kanton wird, ausgehend von den jeweils in den ersten 14 Monaten abgerechneten Leistungsdaten des Ausgleichsjahres und des Vorjahres, in aggregierten Risikogruppen je ein Teuerungsfaktor ermittelt."
+                },
+                "children": []
+              },
+              {
+                "id": "0ryhcyx",
+                "number": null,
+                "type": "CONTENT",
+                "format": "MARKDOWN",
+                "contents": {
+                  "de": "^2^ Zur Bildung der aggregierten Risikogruppen werden die Risikogruppen nach Artikel 11 VORA wie folgt zusammengefasst:"
+                },
+                "children": []
+              },
+              {
+                "id": "noly9kz",
+                "number": null,
+                "type": "LIST",
+                "children": [
+                  {
+                    "id": "3pzy3ph",
+                    "number": "a.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "8732jur",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Versicherte von 19 -35 Jahren, ohne Indikator Aufenthalt;"
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "fdb1j00",
+                    "number": "b.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "1frfdfj",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Versicherte von 36 -55 Jahren, ohne Indikator Aufenthalt;"
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "u0wvb96",
+                    "number": "c.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "8fif0j1",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Versicherte von 56 -75 Jahren, ohne Indikator Aufenthalt;"
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ud9ehnb",
+                    "number": "d.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "xii8ovj",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Versicherte ab 76 Jahren, ohne Indikator Aufenthalt;"
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "njwg6k2",
+                    "number": "e.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "8v9rpxi",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "Versicherte mit Indikator Aufenthalt."
+                        },
+                        "children": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "8pdqyrk",
+                "number": null,
+                "type": "CONTENT",
+                "format": "MARKDOWN",
+                "contents": {
+                  "de": "^3^ Der Teuerungsfaktor wird durch Division der durchschnittlichen Nettoleistungen im Ausgleichsjahr durch die durchschnittlichen Nettoleistungen im Vorjahr ermittelt."
+                },
+                "children": []
+              },
+              {
+                "id": "zh8zqip",
+                "number": null,
+                "type": "CONTENT",
+                "format": "MARKDOWN",
+                "contents": {
+                  "de": "^4^ Die durchschnittlichen Nettoleistungen werden über alle Versicherer hinweg pro aggregierte Risikogruppe nach Absatz 2 berechnet."
+                },
+                "children": []
+              }
+            ]
+          },
+          {
+            "id": "ot6i9ns",
+            "number": "Art. 5",
+            "type": "HEADING",
+            "format": "TEXT",
+            "contents": {
+              "de": "Anteil der in der Schweiz in Anspruch genommenen Leistungen"
+            },
+            "children": [
+              {
+                "id": "h1lxxmg",
+                "number": null,
+                "type": "CONTENT",
+                "format": "TEXT",
+                "contents": {
+                  "de": "Der Anteil nach Artikel 17 Absatz 5 KVG beträgt:"
+                },
+                "children": []
+              },
+              {
+                "id": "6qfx87o",
+                "number": null,
+                "type": "LIST",
+                "children": [
+                  {
+                    "id": "2k4nslg",
+                    "number": "a.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "ns78ry1",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "für die in Deutschland wohnhaften Versicherten: 40 Prozent;"
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "7l4ez4a",
+                    "number": "b.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "a1wa3ah",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "für die in Frankreich wohnhaften Versicherten: 75 Prozent;"
+                        },
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": "wwee5l4",
+                    "number": "c.",
+                    "type": "LIST_ITEM",
+                    "children": [
+                      {
+                        "id": "7dkgggx",
+                        "number": null,
+                        "type": "CONTENT",
+                        "format": "TEXT",
+                        "contents": {
+                          "de": "für die in allen übrigen Wohnsitzstaaten wohnhaften Versicherten: 65 Prozent."
+                        },
+                        "children": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "pq8n1ak",
+            "number": "Art. 6",
+            "type": "HEADING",
+            "format": "TEXT",
+            "contents": {
+              "de": "Aufhebung eines anderen Erlasses"
+            },
+            "children": [
+              {
+                "id": "v0yqszs",
+                "number": null,
+                "type": "CONTENT",
+                "format": "MARKDOWN",
+                "contents": {
+                  "de": "Die Verordnung des EDI vom 14. Oktober 2019^2^ über die Umsetzung des Risikoausgleichs in der Krankenversicherung wird aufgehoben."
+                },
+                "children": []
+              },
+              {
+                "id": "wokx8a8",
+                "number": "^2^",
+                "type": "FOOTNOTE",
+                "format": "TEXT",
+                "contents": {
+                  "de": "AS 2019 3415; 2021 62; 2025 146"
+                }
+              }
+            ]
+          },
+          {
+            "id": "ijrut8j",
+            "number": "Art. 7",
+            "type": "HEADING",
+            "format": "TEXT",
+            "contents": {
+              "de": "Übergangsbestimmung"
+            },
+            "children": [
+              {
+                "id": "4hh68br",
+                "number": null,
+                "type": "CONTENT",
+                "format": "TEXT",
+                "contents": {
+                  "de": "Für die Berechnung des Risikoausgleichs des Ausgleichsjahres 2027 gilt das bisherige Recht."
+                },
+                "children": []
+              }
+            ]
+          },
+          {
+            "id": "bb7jlau",
+            "number": "Art. 8",
+            "type": "HEADING",
+            "format": "TEXT",
+            "contents": {
+              "de": "Inkrafttreten"
+            },
+            "children": [
+              {
+                "id": "75golcy",
+                "number": null,
+                "type": "CONTENT",
+                "format": "TEXT",
+                "contents": {
+                  "de": "Diese Verordnung tritt am 1. Januar 2028 in Kraft."
+                },
+                "children": []
+              }
+            ]
+          },
+          {
+            "id": "j7n9bg2",
+            "number": null,
+            "type": "CONTENT",
+            "format": "TEXT",
+            "contents": {
+              "de": "Eidgenössisches Departement des Innern:"
+            },
+            "children": []
+          },
+          {
+            "id": "x8pt45h",
+            "number": null,
+            "type": "CONTENT",
+            "format": "TEXT",
+            "contents": {
+              "de": "Elisabeth Baume-Schneider"
+            },
+            "children": []
+          },
+          {
+            "id": "nxjuham",
+            "number": null,
+            "type": "HEADING",
+            "format": "TEXT",
+            "contents": {
+              "de": "Anhang (Art. 1)"
+            },
+            "children": [
+              {
+                "id": "1w9yv5w",
+                "number": null,
+                "type": "HEADING",
+                "format": "MARKDOWN_MINIMAL",
+                "contents": {
+                  "de": "PCG-Liste^3^"
+                },
+                "children": [
+                  {
+                    "id": "w12w1ym",
+                    "number": "^3^",
+                    "type": "FOOTNOTE",
+                    "format": "TEXT",
+                    "contents": {
+                      "de": "Der Inhalt dieses Anhangs wird in der AS und in der SR nur durch Verweis veröffentlicht. Er kann abgerufen werden unter https://fedlex.data.admin.ch/eli/oc/xxx >; Allgemeine Informationen >; Umfang der Veröffentlichung >; Veröffentlichung eines Textteils durch Verweis."
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/utils/document-storage.ts
+++ b/src/utils/document-storage.ts
@@ -9,7 +9,7 @@ const DB_VERSION = 1;
 const STORE = 'documents';
 const UPDATED_AT_INDEX = 'updatedAt';
 
-export type SourceKind = 'docx' | 'html' | 'pasted-text';
+export type SourceKind = 'docx' | 'html' | 'pasted-text' | 'json-envelope';
 
 export interface StoredEntrySource {
   kind: SourceKind;

--- a/src/utils/document-utils.ts
+++ b/src/utils/document-utils.ts
@@ -24,7 +24,7 @@ export const generateId = () => Math.random().toString(36).substring(2, 9);
 
 // Strips only the final extension (e.g. "archive.tar.gz" -> "archive.tar"), so
 // the JSON filename and the envelope title agree on what the "base name" is.
-const stripFileExtension = (filename: string): string => filename.replace(/\.[^/.]+$/, '');
+export const stripFileExtension = (filename: string): string => filename.replace(/\.[^/.]+$/, '');
 
 export const deriveJsonFilename = (filename: string | null | undefined): string => {
   if (!filename) return 'document.json';

--- a/src/utils/file-processing.integration.test.ts
+++ b/src/utils/file-processing.integration.test.ts
@@ -2,10 +2,11 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { DocumentNode, NumberedDocumentNode } from '../types/document';
-import { processDocxFile, processHtmlFile } from './file-processing';
+import { processDocxFile, processHtmlFile, processJsonEnvelopeFile } from './file-processing';
 
 const FIXTURE_DIR = path.join(__dirname, '../test/fixtures/realistic/docx/without_table');
 const HTML_FIXTURE_DIR = path.join(__dirname, '../test/fixtures/realistic/html');
+const DOCTREE_FIXTURE_DIR = path.join(__dirname, '../test/fixtures/realistic/doctree');
 const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 
 /**
@@ -50,6 +51,13 @@ async function importHtmlFixture(filename: string) {
   const buffer = fs.readFileSync(path.join(HTML_FIXTURE_DIR, filename));
   const file = new File([buffer], filename, { type: 'text/html' });
   return processHtmlFile(file);
+}
+
+/** Read a DocTree JSON envelope fixture and run it through processJsonEnvelopeFile. */
+async function importDoctreeFixture(filename: string) {
+  const buffer = fs.readFileSync(path.join(DOCTREE_FIXTURE_DIR, filename));
+  const file = new File([buffer], filename, { type: 'application/json' });
+  return processJsonEnvelopeFile(file);
 }
 
 /** Assert that the only console.warn calls came from the expected Mammoth prefix. */
@@ -365,6 +373,42 @@ describe('file-processing integration', () => {
       expect(para16).toBeDefined();
       expect(textOf(para16!)).toBe('');
       expect(headings.some((h) => numberOf(h) === null && textOf(h) === 'Grundsatz')).toBe(true);
+    });
+  });
+
+  // A real DocTree envelope previously exported by StructEdit (Download JSON). Re-importing it
+  // must reconstruct the exact tree — no parsing/transform pipeline runs, so the structure is
+  // byte-for-byte what was saved.
+  describe('real DocTree JSON: VORA-EDI', () => {
+    let allNodes: DocumentNode[];
+
+    beforeAll(async () => {
+      const result = await importDoctreeFixture('vora-edi.doctree.json');
+      allNodes = flattenTree(result.doc);
+    });
+
+    it('reconstructs the document root and all node types from the envelope', () => {
+      const counts = (type: string) => allNodes.filter((n) => n.type === type).length;
+      expect(counts('DOCUMENT')).toBe(1);
+      expect(counts('HEADING')).toBe(11);
+      expect(counts('CONTENT')).toBe(38);
+      expect(counts('LIST')).toBe(4);
+      expect(counts('LIST_ITEM')).toBe(21);
+      expect(counts('FOOTNOTE')).toBe(3);
+    });
+
+    it('preserves the law title heading and list-item content', () => {
+      expect(
+        allNodes
+          .filter((n) => n.type === 'HEADING')
+          .map(textOf)
+          .some((t) => t.includes('Verordnung des EDI') && t.includes('(VORA-EDI)'))
+      ).toBe(true);
+      // The lettered list items survive with their numbers intact.
+      const letteredA = allNodes.find(
+        (n) => n.type === 'LIST_ITEM' && (n as NumberedDocumentNode).number === 'a.'
+      );
+      expect(letteredA).toBeDefined();
     });
   });
 });

--- a/src/utils/file-processing.test.ts
+++ b/src/utils/file-processing.test.ts
@@ -8,6 +8,7 @@ import {
   processFile,
   processHtmlFile,
   processHtmlString,
+  processJsonEnvelopeFile,
   processPdfFile,
   processTextInput,
 } from './file-processing';
@@ -284,6 +285,20 @@ describe('file-processing', () => {
       await expect(processFile(file)).rejects.toThrow('TODO: set up backend for PDF conversion');
     });
 
+    it('routes .json files to processJsonEnvelopeFile', async () => {
+      const envelope = {
+        DocTreeVersion: 1,
+        metadata: { title: { de: 'Routed' } },
+        document: { id: 'r', type: 'DOCUMENT', children: [] },
+      };
+      const file = new File([JSON.stringify(envelope)], 'doc.json', {
+        type: 'application/json',
+      });
+      const result = await processFile(file);
+      expect(result.doc.type).toBe('DOCUMENT');
+      expect(result.source.kind).toBe('json-envelope');
+    });
+
     it('throws for unsupported file types', async () => {
       const file = new File(['data'], 'test.csv', { type: 'text/csv' });
       await expect(processFile(file)).rejects.toThrow('Unsupported file type');
@@ -328,6 +343,91 @@ describe('file-processing', () => {
       expect(result.source.originalFilename).toBeNull();
       expect(result.subtitle).toBeNull();
       expect(result.sourceUrl).toBe('blob:fake-url');
+    });
+  });
+
+  describe('processJsonEnvelopeFile', () => {
+    // A minimal but structurally valid DocTree envelope (DocTreeVersion 1).
+    const makeEnvelope = (title: Record<string, string>) => ({
+      DocTreeVersion: 1,
+      metadata: { title },
+      document: {
+        id: 'root1',
+        type: 'DOCUMENT',
+        children: [
+          {
+            id: 'c1',
+            number: null,
+            type: 'CONTENT',
+            format: 'TEXT',
+            contents: { de: 'Hello envelope' },
+            children: [],
+          },
+        ],
+      },
+    });
+
+    const jsonFile = (body: string, name = 'doc.json') =>
+      new File([body], name, { type: 'application/json' });
+
+    beforeEach(() => {
+      // jsdom's File doesn't implement .text(); polyfill via FileReader.
+      if (!Blob.prototype.text) {
+        Blob.prototype.text = function () {
+          return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result as string);
+            reader.onerror = reject;
+            reader.readAsText(this);
+          });
+        };
+      }
+    });
+
+    it('reconstructs the tree and metadata from a valid envelope', async () => {
+      const file = jsonFile(JSON.stringify(makeEnvelope({ de: 'My Title' })));
+      const result = await processJsonEnvelopeFile(file);
+
+      expect(result.doc.type).toBe('DOCUMENT');
+      expect((result.doc.children[0] as ContentDocumentNode).contents).toEqual({
+        de: 'Hello envelope',
+      });
+      // A DocTree JSON *is* the tree — there is no separate original to preview.
+      expect(result.sourceUrl).toBeNull();
+      expect(result.html).toBeUndefined();
+      expect(result.source.kind).toBe('json-envelope');
+      expect(result.source.mime).toBe('application/json');
+      expect(result.subtitle).toBeNull();
+    });
+
+    it('uses the German title as the display name', async () => {
+      const file = jsonFile(JSON.stringify(makeEnvelope({ de: 'Verordnung X' })), 'whatever.json');
+      const result = await processJsonEnvelopeFile(file);
+      expect(result.name).toBe('Verordnung X');
+    });
+
+    it('falls back to the filename (without extension) when the title is empty', async () => {
+      const file = jsonFile(JSON.stringify(makeEnvelope({})), 'my-law.json');
+      const result = await processJsonEnvelopeFile(file);
+      expect(result.name).toBe('my-law');
+    });
+
+    it('rejects malformed JSON', async () => {
+      const file = jsonFile('{ not valid json', 'broken.json');
+      await expect(processJsonEnvelopeFile(file)).rejects.toThrow(/not valid JSON/i);
+    });
+
+    it('rejects a structurally invalid envelope', async () => {
+      const file = jsonFile(JSON.stringify({ DocTreeVersion: 1, metadata: {}, document: {} }));
+      await expect(processJsonEnvelopeFile(file)).rejects.toThrow(
+        /not a valid StructEdit document/i
+      );
+    });
+
+    it('rejects an envelope from an unsupported DocTreeVersion', async () => {
+      const envelope = { ...makeEnvelope({ de: 'X' }), DocTreeVersion: 2 };
+      const file = jsonFile(JSON.stringify(envelope));
+      await expect(processJsonEnvelopeFile(file)).rejects.toThrow(/version/i);
     });
   });
 

--- a/src/utils/file-processing.ts
+++ b/src/utils/file-processing.ts
@@ -1,7 +1,8 @@
 import * as mammoth from 'mammoth';
-import type { DocumentRootNode } from '../types/document';
+import type { DocumentRootNode, LocalizedText } from '../types/document';
+import { DOC_TREE_VERSION, isValidDocTreeEnvelope } from '../types/document';
 import type { StoredEntrySource } from './document-storage';
-import { generateId, parseHtmlLegalToTree } from './document-utils';
+import { generateId, parseHtmlLegalToTree, stripFileExtension } from './document-utils';
 
 export interface ProcessedDocument {
   doc: DocumentRootNode;
@@ -136,6 +137,61 @@ export async function processHtmlFile(file: File): Promise<ProcessedDocument> {
   return processHtmlString(html, { name: file.name, originalFilename: file.name });
 }
 
+/** Prefer the German title, then any other localized title value, then the filename. */
+function pickEnvelopeName(title: LocalizedText, filename: string): string {
+  const candidates = [title.de, ...Object.values(title)];
+  const named = candidates.find((v): v is string => typeof v === 'string' && v.trim().length > 0);
+  return named?.trim() ?? stripFileExtension(filename);
+}
+
+/**
+ * Re-import a DocTree envelope JSON previously produced by StructEdit's "Download JSON".
+ *
+ * A DocTree JSON *is* the document tree — there is no separate "original" document — so
+ * `sourceUrl` is null and `html` is omitted, which makes the editor show only the rendered
+ * Preview (no Original tab). The raw JSON text is kept as the persisted source bytes so the
+ * entry still round-trips through IndexedDB.
+ */
+export async function processJsonEnvelopeFile(file: File): Promise<ProcessedDocument> {
+  const raw = await file.text();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`"${file.name}" is not valid JSON.`);
+  }
+
+  // A present-but-mismatched *numeric* version gets a targeted message rather than the
+  // generic "not a valid document" below (which `isValidDocTreeEnvelope` would also reject
+  // on). A non-numeric DocTreeVersion is malformed, not a real version, so it intentionally
+  // falls through to the generic envelope error.
+  const version = (parsed as { DocTreeVersion?: unknown } | null)?.DocTreeVersion;
+  if (typeof version === 'number' && version !== DOC_TREE_VERSION) {
+    throw new Error(
+      `"${file.name}" was created by an incompatible version of StructEdit ` +
+        `(DocTree v${version}; this version reads v${DOC_TREE_VERSION}).`
+    );
+  }
+
+  if (!isValidDocTreeEnvelope(parsed)) {
+    throw new Error(`"${file.name}" is not a valid StructEdit document (DocTree envelope).`);
+  }
+
+  return {
+    doc: parsed.document,
+    sourceUrl: null,
+    source: {
+      kind: 'json-envelope',
+      mime: 'application/json',
+      bytes: raw,
+      originalFilename: file.name,
+    },
+    name: pickEnvelopeName(parsed.metadata.title, file.name),
+    subtitle: null,
+  };
+}
+
 /**
  * Derive a display name for a document fetched from a signed URL. Uses the last path
  * segment (the `<uuid>` from `/file/<uuid>`), ignoring the query string, and falls back
@@ -257,6 +313,10 @@ export async function processFile(file: File): Promise<ProcessedDocument> {
 
   if (nameLower.endsWith('.pdf') || file.type === 'application/pdf') {
     return processPdfFile(file);
+  }
+
+  if (nameLower.endsWith('.json') || file.type === 'application/json') {
+    return processJsonEnvelopeFile(file);
   }
 
   throw new Error(`Unsupported file type: ${file.name}`);


### PR DESCRIPTION
## What & why

StructEdit can **export** a document as a DocTree-envelope JSON (the toolbar's *Download JSON*), but there was no way to **re-import** one — uploading a `.json` fell through `processFile` and threw `Unsupported file type`, breaking the export→import loop. A user who saved work as JSON couldn't reopen it to keep editing.

This wires a `.json` branch into the existing upload pipeline (click-to-upload, drag-drop, and the file picker all share it). The envelope format and its validator already existed in `types/document.ts`, so this reuses them rather than inventing anything.

## Changes

- **`processJsonEnvelopeFile`** (`utils/file-processing.ts`) — parses the file, returns a targeted error for malformed JSON or an incompatible `DocTreeVersion`, validates with the existing `isValidDocTreeEnvelope`, and reconstructs the tree.
- A DocTree JSON *is* the tree, so there's deliberately **no separate "Original" preview**: `sourceUrl` is `null` at import and `loadEntry` returns a `null` `documentUrl` on resume, keeping both paths Preview-only (`LeftPane` already hides the Original tab when the URL is null).
- Display name derived from `metadata.title` (German first, then any locale), falling back to the filename.
- `.json` added to the file-picker `accept` list and the upload helper text.
- `'json-envelope'` added to `SourceKind`; `stripFileExtension` exported for reuse.

## Tests

Red→green TDD. Unit tests cover the happy path, title/filename naming, malformed JSON, structurally-invalid envelope, incompatible version, and `.json` routing. An integration test round-trips a real exported fixture (`src/test/fixtures/realistic/doctree/vora-edi.doctree.json`), asserting node-type counts and content survival.

## Verification

- Full suite green (1361 tests); `npm run build` + `tsc` clean.
- Manually drove the running app: imported the fixture → editor opens with the full tree, Preview-only; resumed from recents → still Preview-only; uploaded a broken `.json` → friendly "is not valid JSON" alert, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)