### PR TITLE
Fix add-node buttons being clipped at the node border (#135)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -267,6 +267,18 @@ html {
 .tree-node:not(:has(.tree-node)) {
   content-visibility: auto;
   contain-intrinsic-size: auto 80px;
+  /* The add-node buttons protrude ~12px past the border box (-top-3 / -bottom-3 in
+   * RecursiveTreeNode.tsx). content-visibility's implied paint containment would clip
+   * them; widen the paint clip edge so the selected node's buttons stay visible. This
+   * does NOT remove containment, so the off-screen-leaf optimization above is fully
+   * preserved — even on select-all. (issue #135)
+   *
+   * Load-bearing assumption: the engine applies overflow-clip-margin to the clip
+   * imposed by content-visibility's paint containment (not just to `overflow: clip`).
+   * True in Chromium, the only engine that currently ships content-visibility. If a
+   * future engine ships content-visibility without honoring this, the buttons would
+   * clip again — see this rule before the #102 graceful-degradation note above. */
+  overflow-clip-margin: 16px;
 }
 
 /* Table Support in Editor */


### PR DESCRIPTION
## Summary
- The `+` buttons that add a node before/after a selected node were clipped at the node's border — only the inner half of each circle showed (issue #135).
- Root cause: the #102 leaf-node performance optimization applies `content-visibility: auto`, whose implied paint containment clips the buttons (positioned to protrude ~12px past the border box via `-top-3` / `-bottom-3`).
- Fix: add `overflow-clip-margin: 16px` to the leaf rule (`.tree-node:not(:has(.tree-node))`) to widen the paint clip edge. This keeps `content-visibility` on every leaf, so the #102 select-all optimization is fully preserved.

## Test plan
- [x] Browser: selected leaf node shows both `+` buttons as full, un-clipped circles
- [x] `+` buttons still insert nodes before/after (behavior unchanged)
- [x] No perf regression — `content-visibility` never removed, so select-all behaves identically
- [x] `npm run test` — 1361/1361 pass

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)