### PR TITLE
Preserve tab scroll position when switching Original ↔ Preview

### DIFF
--- a/src/components/LeftPane.test.tsx
+++ b/src/components/LeftPane.test.tsx
@@ -92,6 +92,48 @@ describe('LeftPane', () => {
     expect(screen.getByRole('heading', { level: 1, name: /heading one/i })).toBeInTheDocument();
   });
 
+  test('keeps the Preview panel mounted while the Original tab is active', () => {
+    render(
+      <LeftPane
+        documentUrl="http://example.com/doc.html"
+        document={docWithHeading}
+        language="de"
+        onHeadingClick={() => {}}
+      />
+    );
+
+    // Original is the default tab when a documentUrl exists.
+    expect(screen.getByRole('tab', { name: /original/i })).toHaveAttribute('aria-selected', 'true');
+    // The Preview panel stays mounted (just hidden) even while inactive, so its
+    // rendered content and scroll position survive switching back and forth.
+    const previewPanel = screen.getByRole('tabpanel', { name: /preview/i });
+    expect(previewPanel).toHaveAttribute('data-state', 'inactive');
+    expect(
+      within(previewPanel).getByRole('heading', { level: 1, name: /heading one/i })
+    ).toBeInTheDocument();
+  });
+
+  test('keeps the Original panel mounted while the Preview tab is active', async () => {
+    const user = userEvent.setup();
+    render(
+      <LeftPane
+        documentUrl="http://example.com/doc.html"
+        document={docWithHeading}
+        language="de"
+        onHeadingClick={() => {}}
+      />
+    );
+
+    await user.click(screen.getByRole('tab', { name: /preview/i }));
+
+    expect(screen.getByRole('tab', { name: /preview/i })).toHaveAttribute('aria-selected', 'true');
+    // The Original panel (and its iframe) stays mounted while inactive, so the
+    // source document's scroll position is not reset.
+    const originalPanel = screen.getByRole('tabpanel', { name: /original/i });
+    expect(originalPanel).toHaveAttribute('data-state', 'inactive');
+    expect(within(originalPanel).getByTitle('Document Viewer')).toBeInTheDocument();
+  });
+
   test('passes onHeadingClick through to DocumentPreview TOC', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();

--- a/src/components/LeftPane.tsx
+++ b/src/components/LeftPane.tsx
@@ -30,24 +30,41 @@ export function LeftPane({ documentUrl, document, language, onHeadingClick }: Le
             Preview
           </Tabs.Trigger>
         </Tabs.List>
-        {documentUrl && (
-          <Tabs.Content value="original" className="flex-1 overflow-hidden flex flex-col">
-            <div className="px-4 py-2 bg-amber-50 border-b border-amber-200 text-amber-700 text-xs shrink-0">
-              This preview has been processed and may not correspond to the original document
-              exactly.
-            </div>
-            <div className="flex-1 min-h-0">
-              <SourcePreview url={documentUrl} />
-            </div>
+        {/*
+          Both panels stay mounted (forceMount) and laid out across tab switches so their scroll
+          positions survive. The inactive panel is hidden with `invisible` (visibility:hidden)
+          rather than `display:none`: display:none would reset the iframe's scroll to 0 and let
+          scroll-anchoring drift the rendered preview. The panels are absolutely stacked inside a
+          relative wrapper so the hidden one stays sized but doesn't take up flow.
+        */}
+        <div className="relative flex-1 min-h-0">
+          {documentUrl && (
+            <Tabs.Content
+              forceMount
+              value="original"
+              className="absolute inset-0 flex flex-col overflow-hidden data-[state=inactive]:invisible data-[state=inactive]:pointer-events-none"
+            >
+              <div className="px-4 py-2 bg-amber-50 border-b border-amber-200 text-amber-700 text-xs shrink-0">
+                This preview has been processed and may not correspond to the original document
+                exactly.
+              </div>
+              <div className="flex-1 min-h-0">
+                <SourcePreview url={documentUrl} />
+              </div>
+            </Tabs.Content>
+          )}
+          <Tabs.Content
+            forceMount
+            value="preview"
+            className="absolute inset-0 overflow-hidden data-[state=inactive]:invisible data-[state=inactive]:pointer-events-none"
+          >
+            <DocumentPreview
+              document={document}
+              language={language}
+              onHeadingClick={onHeadingClick}
+            />
           </Tabs.Content>
-        )}
-        <Tabs.Content value="preview" className="flex-1 overflow-hidden">
-          <DocumentPreview
-            document={document}
-            language={language}
-            onHeadingClick={onHeadingClick}
-          />
-        </Tabs.Content>
+        </div>
       </Tabs.Root>
     </div>
   );


### PR DESCRIPTION
## Summary
- Keep both `LeftPane` tab panels mounted (`forceMount`) so switching tabs no longer resets scroll position.
- Hide the inactive panel with `visibility:hidden` + `pointer-events-none` instead of `display:none`. `display:none` resets the Original iframe's internal scroll to 0 and lets CSS scroll-anchoring drift the rendered preview by ~100px on every toggle; keeping the panel laid-out-but-invisible preserves both scroll positions exactly.
- Stack both panels `absolute inset-0` inside a new `relative flex-1 min-h-0` wrapper so the hidden panel stays sized but out of normal flow.

## Test plan
- [x] New `LeftPane` tests assert each panel stays mounted (`data-state="inactive"` + content present) while the other tab is active — confirmed failing before the fix
- [x] Full suite (1363 tests) and `tsc --noEmit` pass
- [x] Verified in a real browser: only one panel visible at a time; tabs stay clickable; Preview scroll and Original-iframe scroll both preserved exactly across multiple round-trips with no drift; the hidden panel and its buttons are not focusable (a11y)

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)