### PR TITLE
Make the document title editable from the header (#138)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -10,6 +10,7 @@ import {
   closeDb,
   createEntry,
   listRecents,
+  loadEntry,
 } from './utils/document-storage';
 
 function makeTree() {
@@ -143,6 +144,51 @@ describe('App', () => {
     await waitFor(() => {
       expect(revokedUrls).toContain(documentUrl);
     });
+  });
+
+  it('renaming in the header updates the breadcrumb and persists to the stored entry', async () => {
+    const seeded = makeInput({ name: 'renameme.docx' });
+    await createEntry(seeded);
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByText('renameme.docx'));
+    await screen.findByRole('button', { name: /close editor/i });
+
+    fireEvent.doubleClick(screen.getByText('renameme.docx'));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Vernehmlassung Q3' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(screen.getByText('Vernehmlassung Q3')).toBeInTheDocument();
+    expect(screen.queryByText('renameme.docx')).not.toBeInTheDocument();
+
+    await waitFor(async () => {
+      const entry = await loadEntry(seeded.id);
+      if (!entry || 'status' in entry) throw new Error('entry should be valid');
+      expect(entry.name).toBe('Vernehmlassung Q3');
+    });
+  });
+
+  it('renaming still updates the breadcrumb when the entry was never stored', async () => {
+    // Force the initial create to fail so currentEntryId stays null.
+    __setStorageEstimatorForTesting(() => null);
+    __setWriteFailHookForTesting(() => new DOMException('quota', 'QuotaExceededError'));
+
+    render(<App />);
+
+    const textarea = await screen.findByPlaceholderText(/paste unstructured text/i);
+    fireEvent.change(textarea, { target: { value: 'Hello world' } });
+    fireEvent.click(screen.getByRole('button', { name: /convert text/i }));
+    await screen.findByRole('button', { name: /close editor/i });
+
+    fireEvent.doubleClick(screen.getByText(/^Untitled \(/));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Renamed anyway' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(screen.getByText('Renamed anyway')).toBeInTheDocument();
+    expect(await listRecents()).toHaveLength(0);
   });
 
   it('shows a quota toast when the initial create fails — editor still opens', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Toast } from './components/ui/Toast';
 import { useLoadFromUrl } from './hooks/useLoadFromUrl';
 import { useRecentDocuments } from './hooks/useRecentDocuments';
 import type { DocumentRootNode } from './types/document';
+import { updateEntryName } from './utils/document-storage';
 
 function App() {
   const [document, setDocument] = useState<DocumentRootNode | null>(null);
@@ -53,6 +54,17 @@ function App() {
     setView('editor');
   };
 
+  const handleRename = (name: string) => {
+    setFileName(name);
+    // No entry id means the initial persist failed (e.g. storage full) — the
+    // rename still applies in-memory, it just won't survive a reload.
+    if (currentEntryId) {
+      updateEntryName(currentEntryId, name).catch((err) => {
+        console.error('Failed to persist rename', err);
+      });
+    }
+  };
+
   const handleBack = () => {
     setView('upload');
     setDocument(null);
@@ -69,7 +81,7 @@ function App() {
 
   return (
     <div className="h-screen flex flex-col bg-gray-50 font-sans text-gray-900 overflow-hidden">
-      <Header documentName={fileName} />
+      <Header documentName={fileName} onRename={handleRename} />
 
       <div className="flex-1 flex overflow-hidden">
         <main className="flex-1 flex flex-col min-w-0 bg-white">

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,17 +1,131 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { Header } from './Header';
+
+const noop = () => {};
+
+function renderWithName(onRename: (name: string) => void = noop) {
+  return render(<Header documentName="entwurf.docx" onRename={onRename} />);
+}
+
+function startEditing(): HTMLInputElement {
+  fireEvent.doubleClick(screen.getByText('entwurf.docx'));
+  return screen.getByRole('textbox') as HTMLInputElement;
+}
 
 describe('Header', () => {
   it('renders Demokratis and StructEdit breadcrumb without a document name', () => {
-    render(<Header />);
+    render(<Header onRename={noop} />);
     expect(screen.getByText('Demokratis')).toBeInTheDocument();
     expect(screen.getByText(/StructEdit/)).toBeInTheDocument();
     expect(screen.queryByText('entwurf.docx')).not.toBeInTheDocument();
   });
 
   it('shows the document name in the breadcrumb when provided', () => {
-    render(<Header documentName="entwurf.docx" />);
+    renderWithName();
     expect(screen.getByText('entwurf.docx')).toBeInTheDocument();
+  });
+
+  it('double-clicking the title replaces it with a focused input holding the current name', () => {
+    renderWithName();
+    const input = startEditing();
+    expect(input.value).toBe('entwurf.docx');
+    expect(input).toHaveFocus();
+  });
+
+  it('the title is keyboard-reachable and Enter starts editing', () => {
+    renderWithName();
+    const title = screen.getByRole('button', { name: 'entwurf.docx' });
+
+    fireEvent.keyDown(title, { key: 'Enter' });
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe('entwurf.docx');
+  });
+
+  it('Space also starts editing, like an ARIA button', () => {
+    renderWithName();
+    fireEvent.keyDown(screen.getByRole('button', { name: 'entwurf.docx' }), { key: ' ' });
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('the rename input has an accessible label', () => {
+    renderWithName();
+    startEditing();
+    expect(screen.getByRole('textbox', { name: /document title/i })).toBeInTheDocument();
+  });
+
+  it('Enter commits the new name via onRename exactly once and returns to display mode', () => {
+    const onRename = vi.fn();
+    renderWithName(onRename);
+    const input = startEditing();
+
+    fireEvent.change(input, { target: { value: 'Vernehmlassung Q3' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).toHaveBeenCalledExactlyOnceWith('Vernehmlassung Q3');
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('blur commits like Enter', () => {
+    const onRename = vi.fn();
+    renderWithName(onRename);
+    const input = startEditing();
+
+    fireEvent.change(input, { target: { value: 'Renamed' } });
+    fireEvent.blur(input);
+
+    expect(onRename).toHaveBeenCalledExactlyOnceWith('Renamed');
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('Escape cancels without calling onRename', () => {
+    const onRename = vi.fn();
+    renderWithName(onRename);
+    const input = startEditing();
+
+    fireEvent.change(input, { target: { value: 'Discarded' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    // In a real browser the unmounting input still emits a focusout, which must
+    // not commit. jsdom doesn't deliver events to detached nodes, so this blur
+    // is a no-op here — the guard itself is only exercisable in a browser.
+    fireEvent.blur(input);
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByText('entwurf.docx')).toBeInTheDocument();
+  });
+
+  it('whitespace-only input cancels without calling onRename', () => {
+    const onRename = vi.fn();
+    renderWithName(onRename);
+    const input = startEditing();
+
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByText('entwurf.docx')).toBeInTheDocument();
+  });
+
+  it('committing an unchanged name does not call onRename', () => {
+    const onRename = vi.fn();
+    renderWithName(onRename);
+    const input = startEditing();
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByText('entwurf.docx')).toBeInTheDocument();
+  });
+
+  it('trims the committed value', () => {
+    const onRename = vi.fn();
+    renderWithName(onRename);
+    const input = startEditing();
+
+    fireEvent.change(input, { target: { value: '  New Title  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).toHaveBeenCalledWith('New Title');
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,29 @@
+import { useRef, useState } from 'react';
+
 interface HeaderProps {
   documentName?: string | null;
+  onRename: (name: string) => void;
 }
 
-export function Header({ documentName }: HeaderProps = {}) {
+export function Header({ documentName, onRename }: HeaderProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  // Escape unmounts the input, which can still fire a blur with the discarded
+  // value — this flag makes that trailing blur a no-op.
+  const cancelledRef = useRef(false);
+
+  const startEditing = () => {
+    cancelledRef.current = false;
+    setIsEditing(true);
+  };
+
+  const commit = (value: string) => {
+    setIsEditing(false);
+    const trimmed = value.trim();
+    if (trimmed && trimmed !== documentName) {
+      onRename(trimmed);
+    }
+  };
+
   return (
     <header className="border-b border-gray-200 bg-white">
       <div className="px-6 py-4">
@@ -17,7 +38,55 @@ export function Header({ documentName }: HeaderProps = {}) {
             </div>
             {documentName && (
               <div className="text-grey-mid text-3xl font-light">
-                &nbsp;&rsaquo;&nbsp;&nbsp;<span>{documentName}</span>
+                &nbsp;&rsaquo;&nbsp;&nbsp;
+                {isEditing ? (
+                  <input
+                    type="text"
+                    defaultValue={documentName}
+                    ref={(el) => {
+                      el?.focus();
+                      el?.select();
+                    }}
+                    aria-label="Document title"
+                    className="font-serif text-3xl font-light text-grey-mid border border-blue-400 rounded px-1 outline-none bg-white"
+                    onBlur={(e) => {
+                      if (cancelledRef.current) return;
+                      commit(e.target.value);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        // Delegate to blur so commit has a single entry point —
+                        // a direct commit here would unmount the input and the
+                        // trailing focusout would commit a second time.
+                        (e.target as HTMLInputElement).blur();
+                      }
+                      if (e.key === 'Escape') {
+                        e.preventDefault();
+                        cancelledRef.current = true;
+                        setIsEditing(false);
+                      }
+                    }}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    className="cursor-pointer"
+                    title="Double-click or press Enter to rename"
+                    onDoubleClick={startEditing}
+                    onKeyDown={(e) => {
+                      // Explicit keyboard handling: a plain (single) click must
+                      // NOT start editing, so we can't rely on the native
+                      // Enter/Space → click activation.
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        startEditing();
+                      }
+                    }}
+                  >
+                    {documentName}
+                  </button>
+                )}
               </div>
             )}
           </div>

--- a/src/utils/document-storage.test.ts
+++ b/src/utils/document-storage.test.ts
@@ -12,6 +12,8 @@ import {
   loadEntry,
   MAX_RECENTS,
   StorageQuotaUnresolvableError,
+  subscribeToStructuralChanges,
+  updateEntryName,
   updateEntryTree,
 } from './document-storage';
 
@@ -199,6 +201,61 @@ describe('document-storage', () => {
 
     it('throws when the entry does not exist', async () => {
       await expect(updateEntryTree('missing-id', makeTree())).rejects.toThrow();
+    });
+  });
+
+  describe('updateEntryName', () => {
+    it('renames the entry and bumps updatedAt — everything else untouched', async () => {
+      const input = makeFileEntryInput();
+      const created = await createEntry(input);
+      await new Promise((r) => setTimeout(r, 5));
+
+      await updateEntryName(input.id, 'Vernehmlassung Q3');
+
+      const loaded = await loadEntry(input.id);
+      if (!loaded || 'status' in loaded) throw new Error('entry should be valid');
+
+      expect(loaded.name).toBe('Vernehmlassung Q3');
+      expect(loaded.updatedAt).toBeGreaterThan(created.updatedAt);
+      expect(loaded.createdAt).toBe(created.createdAt);
+      expect(loaded.tree).toEqual(created.tree);
+      expect(loaded.subtitle).toBe(created.subtitle);
+      expect(loaded.byteSize).toBe(created.byteSize);
+      expect(loaded.source.originalFilename).toBe('bill.docx');
+    });
+
+    it('throws when the entry does not exist', async () => {
+      await expect(updateEntryName('missing-id', 'x')).rejects.toThrow(/missing entry/);
+    });
+
+    it('does not fire the structural-change notifier', async () => {
+      const input = makeFileEntryInput();
+      await createEntry(input);
+
+      let notified = 0;
+      const unsubscribe = subscribeToStructuralChanges(() => {
+        notified++;
+      });
+      try {
+        await updateEntryName(input.id, 'renamed');
+        expect(notified).toBe(0);
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    it('propagates write failures without quota recovery', async () => {
+      const input = makeFileEntryInput();
+      await createEntry(input);
+
+      __setWriteFailHookForTesting(() => quotaError());
+
+      await expect(updateEntryName(input.id, 'renamed')).rejects.toThrow();
+
+      __setWriteFailHookForTesting(null);
+      const loaded = await loadEntry(input.id);
+      if (!loaded || 'status' in loaded) throw new Error('entry should be valid');
+      expect(loaded.name).toBe('bill.docx');
     });
   });
 

--- a/src/utils/document-storage.ts
+++ b/src/utils/document-storage.ts
@@ -357,6 +357,38 @@ async function attemptUpdate(id: string, tree: DocumentRootNode): Promise<void> 
   await awaitTransaction(tx);
 }
 
+export function updateEntryName(id: string, name: string): Promise<void> {
+  return trackWrite(updateEntryNameImpl(id, name));
+}
+
+// Unlike updateEntryTree there is no quota recovery here: a name write is tiny,
+// so evicting entries to make room for it is never warranted. Failures simply
+// propagate. No notifyStructuralChange either — same rationale as updateEntryTree.
+//
+// Racing autosave is safe: updateEntryTree never writes `name` (it spreads the
+// existing entry), and both read-modify-writes run inside a single readwrite
+// transaction, which IndexedDB serializes per object store — so neither ordering
+// can lose the rename.
+async function updateEntryNameImpl(id: string, name: string): Promise<void> {
+  checkWriteFailHook();
+
+  const db = await openDb();
+  const tx = db.transaction(STORE, 'readwrite');
+  const store = tx.objectStore(STORE);
+  const existing = await promisifyRequest<StoredDocumentEntry | undefined>(store.get(id));
+  if (!existing) {
+    tx.abort();
+    throw new Error(`Cannot update missing entry: ${id}`);
+  }
+  const updated: StoredDocumentEntry = {
+    ...existing,
+    name,
+    updatedAt: Date.now(),
+  };
+  store.put(updated);
+  await awaitTransaction(tx);
+}
+
 async function projectUpdatedEntry(
   id: string,
   tree: DocumentRootNode


### PR DESCRIPTION
## Summary
- Add inline rename of the document title in the Header breadcrumb: double-click (or focus + Enter/Space) to edit; Enter/blur commits, Escape cancels, empty or unchanged input is ignored
- New `updateEntryName` storage function persists renames to IndexedDB so they survive reloads and show up in recents
- Renamed title flows into JSON export (filename and `metadata.title`) through the existing `documentName` prop

## Test plan
- [x] Unit tests for `updateEntryName` (rename, missing entry, no structural notification, write-failure propagation)
- [x] Header tests for the full edit interaction incl. keyboard access and exactly-once commit
- [x] App integration tests: rename persists to the stored entry; rename works when storage previously failed
- [x] Full suite (1379 tests) + build green; manually verified in the browser (mouse + keyboard rename, persistence across reload, single IndexedDB write per commit)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)