### PR TITLE
Keyboard-driven node editing: Enter to edit, Enter/Cmd+Enter to submit (#136)

### DIFF
--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import { ALLOWED_FORMATS, type ContentBearingNodeType, type NodeFormat } from '../types/document';
 import type { InlineMark } from '../utils/inline-mark';
+import { ALT, MOD, SHIFT } from '../utils/platform';
 
 type ToolbarBlockType = 'HEADING' | 'CONTENT' | 'ul' | 'ol' | 'abc' | 'FOOTNOTE';
 // Type used purely to drive the format selector — accepts every content-bearing node type
@@ -44,12 +45,6 @@ interface FloatingToolbarProps {
   markActiveState?: Partial<Record<InlineMark, boolean>>;
   onToggleMark?: (mark: InlineMark) => void;
 }
-
-const IS_MAC =
-  typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/i.test(navigator.platform ?? '');
-const MOD = IS_MAC ? '⌘' : 'Ctrl+';
-const ALT = IS_MAC ? '⌥' : 'Alt+';
-const SHIFT = IS_MAC ? '⇧' : 'Shift+';
 
 const INLINE_MARK_BUTTONS: ReadonlyArray<{
   mark: InlineMark;

--- a/src/components/NumberBadge.test.tsx
+++ b/src/components/NumberBadge.test.tsx
@@ -74,6 +74,26 @@ describe('NumberBadge', () => {
       fireEvent.keyDown(input, { key: 'Escape' });
       expect(onUpdateNumber).toHaveBeenCalledWith('n1', '1');
     });
+
+    test('Enter commits the number (via blur) and calls onSubmit with the node id', () => {
+      const onUpdateNumber = vi.fn();
+      const onSubmit = vi.fn();
+      const { container } = render(
+        <NumberBadge
+          {...baseProps}
+          value="1"
+          isEditing
+          onUpdateNumber={onUpdateNumber}
+          onSubmit={onSubmit}
+        />
+      );
+      const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+      input.value = '2.';
+      fireEvent.keyDown(input, { key: 'Enter' });
+      // Enter blurs, which commits the trimmed value, then hands focus back via onSubmit.
+      expect(onUpdateNumber).toHaveBeenCalledWith('n1', '2.');
+      expect(onSubmit).toHaveBeenCalledWith('n1');
+    });
   });
 
   describe('display mode with a value', () => {

--- a/src/components/NumberBadge.tsx
+++ b/src/components/NumberBadge.tsx
@@ -14,6 +14,12 @@ interface NumberBadgeProps {
   placeholder?: 'dashed' | 'bullet';
   onUpdateNumber: (nodeId: string, value: string | null) => void;
   onDoubleClick: (e: React.MouseEvent, nodeId: string) => void;
+  /**
+   * Invoked after the user commits via Enter (keyboard submit), so the parent can return
+   * focus to the tree container and the selection-mode shortcuts work right away (issue #136).
+   * Not called on blur-by-click, so clicking into another pane isn't fought for focus.
+   */
+  onSubmit?: (nodeId: string) => void;
 }
 
 /**
@@ -31,6 +37,7 @@ export function NumberBadge({
   placeholder = 'dashed',
   onUpdateNumber,
   onDoubleClick,
+  onSubmit,
 }: NumberBadgeProps) {
   if (isEditing) {
     return (
@@ -48,7 +55,8 @@ export function NumberBadge({
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
             e.preventDefault();
-            (e.target as HTMLInputElement).blur();
+            (e.target as HTMLInputElement).blur(); // commits via onBlur
+            onSubmit?.(nodeId); // return focus to the tree so shortcuts work right away
           }
           if (e.key === 'Escape') {
             e.preventDefault();

--- a/src/components/RecursiveTreeNode.test.tsx
+++ b/src/components/RecursiveTreeNode.test.tsx
@@ -41,6 +41,7 @@ const defaultCallbacks: TreeCallbacksContextValue = {
   onFocus: vi.fn(),
   onNumberDoubleClick: vi.fn(),
   onUpdateNumber: vi.fn(),
+  onNumberSubmit: vi.fn(),
   onAddNodeBefore: vi.fn(),
   onAddNodeAfter: vi.fn(),
 };

--- a/src/components/RecursiveTreeNode.tsx
+++ b/src/components/RecursiveTreeNode.tsx
@@ -92,6 +92,7 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
       onFocus,
       onNumberDoubleClick,
       onUpdateNumber,
+      onNumberSubmit,
       onAddNodeBefore,
       onAddNodeAfter,
     } = useTreeCallbacks();
@@ -173,6 +174,7 @@ export const RecursiveTreeNode = memo<RecursiveTreeNodeProps>(
         placeholder={placeholder}
         onUpdateNumber={onUpdateNumber}
         onDoubleClick={onNumberDoubleClick}
+        onSubmit={onNumberSubmit}
       />
     );
 

--- a/src/components/TreeEditor.test.tsx
+++ b/src/components/TreeEditor.test.tsx
@@ -412,8 +412,9 @@ describe('double-click inline editing', () => {
       vi.runAllTimers();
     });
 
-    // Press Enter — for TEXT-format nodes this is a no-op (no sibling, no newline)
+    // Press Enter — for TEXT-format nodes this submits: exits edit mode, no sibling, no newline.
     const editingEl = document.activeElement as HTMLElement;
+    const editingWrapper = editingEl.closest('.tree-node') as HTMLElement;
     await act(async () => {
       fireEvent.keyDown(editingEl, { key: 'Enter' });
     });
@@ -424,16 +425,19 @@ describe('double-click inline editing', () => {
     // No new editable node was inserted into the tree.
     const afterEditableCount = getContainer().querySelectorAll('[contenteditable]').length;
     expect(afterEditableCount).toBe(beforeEditableCount);
+    // Edit mode is exited (issue #136), leaving the node in selection mode for shortcuts.
+    expect(editingWrapper.getAttribute('data-editing')).toBe('false');
 
     vi.useRealTimers();
   });
 
-  test('pressing Enter on a selected (non-editing) node still creates a sibling', async () => {
+  test('pressing Enter on a selected (non-editing) node enters edit mode (no sibling)', async () => {
     vi.useFakeTimers();
     renderTreeEditor();
 
     const firstHeading = getTreePane().getByText('First Heading');
     fireEvent.click(firstHeading);
+    const wrapper = firstHeading.closest('.tree-node') as HTMLElement;
 
     const beforeEditableCount = getContainer().querySelectorAll('[contenteditable]').length;
     const container = getContainer();
@@ -442,9 +446,10 @@ describe('double-click inline editing', () => {
       vi.runAllTimers();
     });
 
-    // A new content node should now be inserted into the tree (one more contenteditable)
+    // No sibling was created — the node is now in edit mode (issue #136).
     const afterEditableCount = getContainer().querySelectorAll('[contenteditable]').length;
-    expect(afterEditableCount).toBe(beforeEditableCount + 1);
+    expect(afterEditableCount).toBe(beforeEditableCount);
+    expect(wrapper.getAttribute('data-editing')).toBe('true');
 
     vi.useRealTimers();
   });
@@ -870,27 +875,22 @@ describe('node operations via keyboard', () => {
     expect(getTreePane().getByText('Second Heading')).toBeInTheDocument();
   });
 
-  test('Enter key in selection mode creates a new node after the selected one', () => {
+  test('Enter key in selection mode edits the selected node (does not create a node)', () => {
     renderTreeEditor();
     const container = getContainer();
 
     selectFirstNode();
+    const firstWrapper = getTreePane().getByText('First Heading').closest('.tree-node');
 
     // Press Enter while in selection mode (not editing)
     fireEvent.keyDown(container, { key: 'Enter' });
 
-    // A new empty node should appear between the two headings
+    // No new node was inserted — still just the two headings.
     const allDraggables = container.querySelectorAll('[draggable]');
-    expect(allDraggables.length).toBe(3);
+    expect(allDraggables.length).toBe(2);
 
-    // The new node sits between First Heading and Second Heading
-    expect(allDraggables[0].textContent).toContain('First Heading');
-    expect(allDraggables[2].textContent).toContain('Second Heading');
-
-    // The new node is an empty content node with an editable area
-    const newNodeEditable = allDraggables[1].querySelector('[contenteditable]');
-    expect(newNodeEditable).not.toBeNull();
-    expect(newNodeEditable!.textContent).toBe('');
+    // The selected node is now in edit mode (issue #136).
+    expect(firstWrapper?.getAttribute('data-editing')).toBe('true');
   });
 
   test('Tab indents selected node under previous sibling', () => {

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -6,9 +6,11 @@ import { useInlineMarks } from '../hooks/useInlineMarks';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import type { TreeEditorHandle } from '../hooks/useTreeEditor';
 import type { Language, NodeFormat } from '../types/document';
+import { MOD } from '../utils/platform';
 import { FloatingToolbar } from './FloatingToolbar';
 import { RecursiveTreeNode } from './RecursiveTreeNode';
 import { TreeCallbacksContext, TreeUIStoreContext } from './TreeNodeContext';
+import { Kbd } from './ui/Kbd';
 
 interface TreeEditorProps {
   editor: TreeEditorHandle;
@@ -197,6 +199,12 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
     store.setEditingNumberId(null);
   };
 
+  // After a number is committed via the keyboard (Enter), return focus to the tree
+  // container so selection-mode shortcuts work right away (issue #136).
+  const handleNumberSubmit = () => {
+    containerRef.current?.focus();
+  };
+
   const handleSetHoveredHandleId = (id: string | null) => {
     store.setHoveredHandleId(id);
   };
@@ -221,6 +229,7 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
   cbRef.current.setEditingId = handleSetEditingId;
   cbRef.current.handleNumberDblClick = handleNumberDblClick;
   cbRef.current.handleUpdateNumber = handleUpdateNumber;
+  cbRef.current.handleNumberSubmit = handleNumberSubmit;
   cbRef.current.handleAddNodeBefore = handleAddNodeBefore;
   cbRef.current.handleAddNodeAfter = handleAddNodeAfter;
 
@@ -241,6 +250,7 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
       onNumberDoubleClick: (e: React.MouseEvent, id: string) =>
         cbRef.current.handleNumberDblClick(e, id),
       onUpdateNumber: (id: string, n: string | null) => cbRef.current.handleUpdateNumber(id, n),
+      onNumberSubmit: (id: string) => cbRef.current.handleNumberSubmit(id),
       onAddNodeBefore: (id: string) => cbRef.current.handleAddNodeBefore(id),
       onAddNodeAfter: (id: string) => cbRef.current.handleAddNodeAfter(id),
     }),
@@ -258,29 +268,15 @@ export function TreeEditor({ editor, language, onScrollToNode }: TreeEditorProps
       onClick={clearSelection}
     >
       <div className="max-w-5xl mx-auto py-12 pr-8 pl-16 pb-48 @max-[640px]:max-w-none @max-[640px]:pl-4 @max-[640px]:pr-2">
-        <div className="mb-8 pb-4 border-b border-gray-100 flex justify-between items-end">
-          <div>
-            <h2 className="text-2xl font-bold mb-1">Tree Editor</h2>
-            <p className="text-gray-500">
-              Click to select. Shift+Click to select range. Double-click to edit. Enter on a
-              selected node creates a new sibling; in edit mode it inserts a newline (for
-              newline-capable formats).
-            </p>
-          </div>
-          <div className="text-xs text-gray-400 hidden sm:block text-right space-y-1">
-            <div>
-              <kbd className="bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200 font-sans">
-                Tab
-              </kbd>{' '}
-              indent
-            </div>
-            <div>
-              <kbd className="bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200 font-sans">
-                Shift+Tab
-              </kbd>{' '}
-              outdent
-            </div>
-          </div>
+        <div className="mb-8 pb-4 border-b border-gray-100">
+          <h2 className="text-2xl font-bold mb-1">Tree Editor</h2>
+          <p className="text-gray-500">
+            Click to select. <Kbd>Shift</Kbd>+Click to select range. Double-click or press{' '}
+            <Kbd>Enter</Kbd> to edit; <Kbd>Tab</Kbd> and <Kbd>Shift+Tab</Kbd> indent and outdent.
+            Finish editing with <Kbd>Esc</Kbd> or <Kbd>{MOD}Enter</Kbd>; in single-line formats{' '}
+            <Kbd>Enter</Kbd> also finishes, while in newline-capable formats <Kbd>Enter</Kbd>{' '}
+            inserts a line break.
+          </p>
         </div>
         <div className="min-h-[300px] relative">
           {treeDocument.children.length === 0 ? (

--- a/src/components/TreeNodeContext.tsx
+++ b/src/components/TreeNodeContext.tsx
@@ -23,6 +23,7 @@ export interface TreeCallbacksContextValue {
   onFocus: (id: string) => void;
   onNumberDoubleClick: (e: React.MouseEvent, id: string) => void;
   onUpdateNumber: (id: string, number: string | null) => void;
+  onNumberSubmit: (id: string) => void;
   onAddNodeBefore: (id: string) => void;
   onAddNodeAfter: (id: string) => void;
 }

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+
+/** A single keyboard-key hint, styled consistently wherever shortcuts are shown. */
+export function Kbd({ children }: { children: ReactNode }) {
+  return (
+    <kbd className="bg-gray-100 px-1.5 py-0.5 rounded border border-gray-200 font-sans">
+      {children}
+    </kbd>
+  );
+}

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -115,13 +115,14 @@ describe('useKeyboardShortcuts — global handler', () => {
     expect([...result.current.editor.store.getSelectedIds()]).toEqual(['h2']);
   });
 
-  test('Enter on a selected node creates a sibling after it', () => {
+  test('Enter on a selected node enters edit mode (does not create a sibling)', () => {
     const result = setup(twoHeadings());
     select(result, 'h1');
 
     act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'Enter' })));
 
-    expect(result.current.editor.document.children.length).toBe(3);
+    expect(result.current.editor.store.getEditingId()).toBe('h1');
+    expect(result.current.editor.document.children.length).toBe(2);
   });
 
   test('Delete removes the selected node', () => {
@@ -335,6 +336,148 @@ describe('useKeyboardShortcuts — in-edit Enter inserts a newline', () => {
     act(() => result.current.handlers.handleBlockKeyDown(e, id));
 
     expect(e.preventDefault).toHaveBeenCalled();
+    expect(exec).not.toHaveBeenCalled();
+
+    delete (window.document as { execCommand?: unknown }).execCommand;
+  });
+});
+
+describe('useKeyboardShortcuts — Enter enters edit mode (issue #136)', () => {
+  /** A list with a single list item, plus a content node, for edit-entry tests. */
+  const listAndContent = (): DocumentRootNode => ({
+    id: 'root',
+    type: 'DOCUMENT',
+    children: [
+      {
+        id: 'content',
+        number: null,
+        type: 'CONTENT',
+        format: 'TEXT',
+        contents: { de: 'Body' },
+        children: [],
+      },
+      {
+        id: 'list',
+        number: null,
+        type: 'LIST',
+        children: [
+          {
+            id: 'item',
+            number: 'a',
+            type: 'LIST_ITEM',
+            children: [],
+          },
+        ],
+      },
+    ],
+  });
+
+  test('Enter on a selected content node enters text edit mode', () => {
+    const result = setup(listAndContent());
+    select(result, 'content');
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'Enter' })));
+
+    expect(result.current.editor.store.getEditingId()).toBe('content');
+    expect(result.current.editor.store.getEditingNumberId()).toBeNull();
+  });
+
+  test('Enter on a selected list item (no contents) enters number edit mode', () => {
+    const result = setup(listAndContent());
+    select(result, 'item');
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'Enter' })));
+
+    expect(result.current.editor.store.getEditingNumberId()).toBe('item');
+    expect(result.current.editor.store.getEditingId()).toBeNull();
+  });
+
+  test('Enter collapses a multi-selection to the focused node before editing', () => {
+    const result = setup(listAndContent());
+    select(result, 'content');
+    select(result, 'item', { ctrlKey: true }); // now {content, item}, focus on item
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'Enter' })));
+
+    expect([...result.current.editor.store.getSelectedIds()]).toEqual(['item']);
+    expect(result.current.editor.store.getEditingNumberId()).toBe('item');
+  });
+
+  test('Enter with no selection is a no-op', () => {
+    const result = setup(listAndContent());
+
+    act(() => result.current.handlers.handleGlobalKeyDown(makeKbd({ key: 'Enter' })));
+
+    expect(result.current.editor.store.getEditingId()).toBeNull();
+    expect(result.current.editor.store.getEditingNumberId()).toBeNull();
+  });
+});
+
+describe('useKeyboardShortcuts — Enter submits a single-line edit (issue #136)', () => {
+  const singleLineDoc = (): DocumentRootNode => ({
+    id: 'root',
+    type: 'DOCUMENT',
+    children: [
+      {
+        id: 'text',
+        number: null,
+        type: 'CONTENT',
+        format: 'TEXT',
+        contents: { de: 'a' },
+        children: [],
+      },
+      {
+        id: 'markdown',
+        number: null,
+        type: 'CONTENT',
+        format: 'MARKDOWN',
+        contents: { de: 'a' },
+        children: [],
+      },
+    ],
+  });
+
+  test('Enter in a single-line node exits edit mode (keeps the node selected)', () => {
+    const result = setup(singleLineDoc());
+    select(result, 'text');
+    act(() => result.current.editor.store.setEditingId('text'));
+
+    act(() => result.current.handlers.handleBlockKeyDown(makeKbd({ key: 'Enter' }), 'text'));
+
+    expect(result.current.editor.store.getEditingId()).toBeNull();
+    expect([...result.current.editor.store.getSelectedIds()]).toEqual(['text']);
+  });
+
+  test('Enter in a newline-format node stays in edit mode (inserts a break instead)', () => {
+    const result = setup(singleLineDoc());
+    const exec = vi.fn().mockReturnValue(true);
+    (window.document as unknown as { execCommand?: unknown }).execCommand = exec;
+    act(() => result.current.editor.store.setEditingId('markdown'));
+
+    act(() => result.current.handlers.handleBlockKeyDown(makeKbd({ key: 'Enter' }), 'markdown'));
+
+    expect(result.current.editor.store.getEditingId()).toBe('markdown');
+    expect(exec).toHaveBeenCalledWith('insertLineBreak');
+
+    delete (window.document as { execCommand?: unknown }).execCommand;
+  });
+
+  // Cmd/Ctrl+Enter is the explicit "commit and exit" for multi-line formats (where a bare
+  // Enter inserts a newline) — applied to single-line formats too for simplicity.
+  test.each([
+    ['metaKey', { metaKey: true }],
+    ['ctrlKey', { ctrlKey: true }],
+  ])('%s+Enter in a newline-format node commits and exits edit mode', (_label, mods) => {
+    const result = setup(singleLineDoc());
+    const exec = vi.fn().mockReturnValue(true);
+    (window.document as unknown as { execCommand?: unknown }).execCommand = exec;
+    act(() => result.current.editor.store.setEditingId('markdown'));
+
+    act(() =>
+      result.current.handlers.handleBlockKeyDown(makeKbd({ key: 'Enter', ...mods }), 'markdown')
+    );
+
+    expect(result.current.editor.store.getEditingId()).toBeNull();
     expect(exec).not.toHaveBeenCalled();
 
     delete (window.document as { execCommand?: unknown }).execCommand;

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -49,7 +49,6 @@ export function useKeyboardShortcuts({
     flattenedNodes,
     store,
     moveSelection,
-    addNodeAfter,
     removeNodes,
     changeNodeTypes,
     indentSelected,
@@ -60,16 +59,21 @@ export function useKeyboardShortcuts({
     undo,
     redo,
     lastSelectedId,
+    anchorId,
   } = editor;
 
   const handleBlockKeyDown = (e: React.KeyboardEvent, id: string) => {
     if (e.key === 'Enter') {
-      // Sibling creation moves to the global (selected, non-editing) handler.
-      // In edit mode Enter never creates a sibling; behaviour depends on the node's format.
+      // Sibling creation lives in the global (selected, non-editing) handler; stop this
+      // keydown from also bubbling there. Otherwise the single-line branch below clears
+      // editingId and the same event would then hit the global handler and create a
+      // sibling. Same guard as the Escape branch.
       e.preventDefault();
+      e.stopPropagation();
       const node = flattenedNodes.find((fn) => fn.node.id === id)?.node;
       const format = node && 'format' in node ? (node as { format: NodeFormat }).format : 'TEXT';
-      // TEXT and MARKDOWN_MINIMAL are single-line — Enter is a no-op. The other formats
+      // TEXT and MARKDOWN_MINIMAL are single-line — Enter submits (exit edit mode, keep the
+      // node selected). The other formats
       // accept a literal `\n`; execCommand is the only reliable cross-browser path inside
       // contentEditable, and its onInput propagates the new text via ContentBlock.
       //
@@ -79,7 +83,16 @@ export function useKeyboardShortcuts({
       // the newline was silently lost the instant it was typed (issue #129).
       // `insertLineBreak` inserts a real '\n' text node that `textContent` preserves.
       const NEWLINE_FORMATS: NodeFormat[] = ['NEWLINES', 'MARKDOWN_INLINE', 'MARKDOWN'];
-      if (NEWLINE_FORMATS.includes(format)) {
+      // Cmd/Ctrl+Enter always commits and exits — the explicit submit for multi-line formats
+      // where a bare Enter inserts a newline (also honoured on single-line formats for
+      // simplicity). A bare Enter submits single-line formats and inserts a break otherwise.
+      const submit = e.metaKey || e.ctrlKey || !NEWLINE_FORMATS.includes(format);
+      if (submit) {
+        // Leave edit mode but keep the node selected and return focus to the container, so
+        // the selection-mode shortcuts work immediately (issue #136). Mirrors Escape below.
+        store.setEditingId(null);
+        containerRef.current?.focus();
+      } else {
         window.document.execCommand?.('insertLineBreak');
       }
       return;
@@ -209,8 +222,40 @@ export function useKeyboardShortcuts({
       e.preventDefault();
       moveSelection(e.key === 'ArrowDown' ? 'down' : 'up', e.shiftKey);
     } else if (e.key === 'Enter' && lastSelectedId.current) {
+      // Enter edit mode on the focused selected node (issue #136). Collapse to that single
+      // node and edit — mirroring the double-click path (useSelection.handleNodeDoubleClick).
+      // Content-bearing nodes get text edit (caret placed at the end); container nodes that
+      // only carry a number (LIST / LIST_ITEM) get number edit instead.
       e.preventDefault();
-      addNodeAfter(lastSelectedId.current);
+      const id = lastSelectedId.current;
+      const fn = flattenedNodes.find((f) => f.node.id === id);
+      if (fn) {
+        const isTextEdit = 'contents' in fn.node;
+        store.batch(() => {
+          store.setSelection(new Set([id]));
+          if (isTextEdit) {
+            store.setEditingNumberId(null);
+            store.setEditingId(id);
+          } else if ('number' in fn.node) {
+            store.setEditingId(null);
+            store.setEditingNumberId(id);
+          }
+        });
+        anchorId.current = id;
+        if (isTextEdit) {
+          setTimeout(() => {
+            const el = blockRefs.current[id];
+            if (el) {
+              el.focus();
+              const r = window.document.createRange();
+              r.selectNodeContents(el);
+              r.collapse(false);
+              window.getSelection()?.removeAllRanges();
+              window.getSelection()?.addRange(r);
+            }
+          }, 0);
+        }
+      }
     } else if (e.key === 'Backspace' || e.key === 'Delete') {
       e.preventDefault();
       deleteSelected();

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,14 @@
+/**
+ * Platform detection and keyboard-modifier labels, shared across the UI so key
+ * hints read natively per-OS: Mac shows the glyph shortcuts (⌘ ⌥ ⇧), everything
+ * else spells them out with a trailing `+` (`Ctrl+`, `Alt+`, `Shift+`).
+ */
+export const IS_MAC =
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/i.test(navigator.platform ?? '');
+
+/** The Cmd/Ctrl modifier: `⌘` on Mac, `Ctrl+` elsewhere. */
+export const MOD = IS_MAC ? '⌘' : 'Ctrl+';
+/** The Alt/Option modifier: `⌥` on Mac, `Alt+` elsewhere. */
+export const ALT = IS_MAC ? '⌥' : 'Alt+';
+/** The Shift modifier: `⇧` on Mac, `Shift+` elsewhere. */
+export const SHIFT = IS_MAC ? '⇧' : 'Shift+';


### PR DESCRIPTION
## Summary
- Press **Enter** (or double-click) on a selected node to enter edit mode — text edit for content nodes, number edit for list items
- While editing, **Enter** submits single-line formats and **Cmd/Ctrl+Enter** submits any format; both keep the node selected and return focus to the tree so selection shortcuts work immediately
- In newline-capable formats a bare **Enter** still inserts a line break
- Removed the Enter-creates-sibling keyboard shortcut so Enter has one meaning per mode (select→edit, editing→submit); use the + buttons to add nodes
- Extracted a shared `Kbd` component and a `platform` util (⌘ on Mac, `Ctrl+` elsewhere), reused by the help text and the floating toolbar; the help text was consolidated into a single paragraph

## Test plan
- [x] `npm run test` (1388 pass), `tsc --noEmit`, `biome check` — all green
- [x] Manual: select → Enter → type → Enter submits → shortcut (h) applies with no click
- [x] Manual: MARKDOWN node → Enter edits → Cmd+Enter submits (no newline inserted)
- [x] Manual: double-click number badge → type → Enter → focus returns to tree
- [x] Manual: Enter no longer creates a sibling; help text shows ⌘ on Mac

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)