### PR TITLE
Fix flaky quota-toast test in App.test.tsx

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -209,7 +209,9 @@ describe('App', () => {
     expect(viewport.textContent?.toLowerCase()).toContain('storage');
 
     // The editor still opens — the in-memory tree is unaffected by the failed write.
-    expect(screen.getByRole('button', { name: /close editor/i })).toBeInTheDocument();
+    // Await it: the toast and the editor mount are independent async updates, so the
+    // button may not be present the instant the toast appears (races under CI load).
+    expect(await screen.findByRole('button', { name: /close editor/i })).toBeInTheDocument();
 
     // No entry was persisted (the failed write left no record).
     const recents = await listRecents();


### PR DESCRIPTION
## Problem

CI intermittently failed on `src/App.test.tsx > shows a quota toast when the initial create fails — editor still opens` with:

> Unable to find an accessible element with the role "button" and name `/close editor/i`

Seen in [run 29277481291](https://github.com/Demokratis-ch/structedit/actions/runs/29277481291) (Coverage Report job). Only this one test failed — 1409/1410 passed — and it always passed locally.

## Root cause

The test awaited the toast viewport, then asserted the "close editor" button **synchronously** with `getByRole`. But surfacing the toast and mounting the editor are two independent async state updates. Under CI load the toast could appear first, before the editor button had rendered, so the synchronous lookup threw. Every other test in the file already awaits this button via `findByRole`.

## Fix

Switch the single synchronous `getByRole` to the awaited `findByRole`, matching the rest of the file. Verified with 8/8 clean local runs of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)