### PR TITLE
Add JSON (DocTree envelope) support to loadFile URL import

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ StructEdit is an importer and editor of **tree-structured documents**.
 The current `main` branch is always deployed at https://structedit.demokratis.ch/.
 
 ## Loading from Demokratis
-StructEdit can be opened with a document preloaded from the [Demokratis](https://demokratis.ch) platform via a signed URL: `https://structedit.demokratis.ch/?loadFile=<url-encoded signed URL>`. The file is fetched, parsed, and opened in the editor. See the [remote-document-loading spec](./openspec/changes/add-loadfile-url-import/specs/remote-document-loading/spec.md).
+StructEdit can be opened with a document preloaded from the [Demokratis](https://demokratis.ch) platform via a signed URL: `https://structedit.demokratis.ch/?loadFile=<url-encoded signed URL>`. The file is fetched, parsed, and opened in the editor. The fetched document may be HTML (parsed like an upload) or a DocTree JSON envelope previously exported by StructEdit (opened directly as a tree). See the [remote-document-loading spec](./openspec/specs/remote-document-loading/spec.md).
 
 ## Planned features
 - Direct upload of the structured document to the [Demokratis](https://demokratis.ch) platform.

--- a/openspec/changes/add-loadfile-json-support/design.md
+++ b/openspec/changes/add-loadfile-json-support/design.md
@@ -1,0 +1,150 @@
+## Context
+
+The `loadFile` flow (shipped in `add-loadfile-url-import`) is split into a pure, React-free core
+([remote-document.ts](src/utils/remote-document.ts)) and a mount hook
+([useLoadFromUrl.ts](src/hooks/useLoadFromUrl.ts)). The core hardcodes HTML: `looksLikeHtml`
+rejects any other `Content-Type` as `unsupported-content`, and the success result carries an
+`html` string that the hook feeds to `processHtmlString`.
+
+Meanwhile the *upload* path already imports StructEdit's own JSON: `processJsonEnvelopeFile`
+([file-processing.ts](src/utils/file-processing.ts)) parses a DocTree envelope
+(`{ DocTreeVersion: 1, metadata, document }`, validated by `isValidDocTreeEnvelope` in
+[types/document.ts](src/types/document.ts)), returns the tree with `sourceUrl: null` (so the
+left pane shows Preview only — [LeftPane.tsx](src/components/LeftPane.tsx) renders the Original
+tab only when a `documentUrl` exists), and persists with `source.kind: 'json-envelope'`. The
+original design flagged this extension explicitly: "The module is shaped so a future
+content-type branch is possible."
+
+The user decided up front: `loadFile` accepts the **DocTree envelope only** — arbitrary JSON has
+no mapping onto the document tree and stays an unsupported format.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A signed `loadFile` URL that serves `application/json` containing a valid DocTree v1 envelope
+  opens the editor with the contained tree — same loading state, allowlist, param consumption,
+  and persistence as the HTML path.
+- A JSON-loaded document is indistinguishable from an uploaded `.json` envelope once open:
+  Preview-only left pane, `json-envelope` recents entry, autosave active.
+- Malformed JSON / invalid envelope / version mismatch produce the existing unsupported-format
+  error surface, never a blank or broken editor.
+- The HTML path, the upload path, and all existing error behavior are byte-for-byte unchanged.
+- Test-first (red → green → refactor) per [CLAUDE.md](CLAUDE.md).
+
+**Non-Goals:**
+
+- No support for JSON shapes other than the DocTree envelope, and no version migration (a
+  non-v1 envelope is rejected, not converted).
+- No content sniffing: a JSON body served as `text/plain` (or with no `Content-Type`) stays
+  unsupported. The backend controls the header on signed files.
+- No new error reasons, messages, or UI surfaces.
+- No synthesized "original" preview for JSON documents (there is no original to show).
+
+## Decisions
+
+### D1. Route by `Content-Type` header: JSON alongside HTML
+
+`fetchRemoteDocument` gains `looksLikeJson(contentType)`: `application/json` or any `+json`
+structured-syntax suffix (e.g. `application/ld+json`), mirroring how `looksLikeHtml` matches
+`text/html` / `application/xhtml`. Routing order: HTML-ish → HTML path; JSON-ish → JSON path;
+anything else → `unsupported-content` exactly as today. An empty/whitespace body remains
+`unsupported-content` for both kinds.
+
+_Rejected: sniffing the body (e.g. "starts with `{`")._ The signed files are served by the
+Demokratis backend, which sets correct headers; sniffing would blur the unsupported-format
+contract and invite mis-parsing HTML error pages as JSON (or vice versa).
+
+### D2. The fetch result carries a discriminated content payload
+
+The success arm of `RemoteFetchResult` changes from `{ ok: true; html; sourceUrl }` to:
+
+```ts
+type RemoteDocumentContent =
+  | { kind: 'html'; html: string }
+  | { kind: 'json'; raw: string };
+
+type RemoteFetchResult =
+  | { ok: true; content: RemoteDocumentContent; sourceUrl: string }
+  | { ok: false; reason: RemoteFetchErrorReason };
+```
+
+The fetch layer stays transport-only: it classifies the content type and reads the body, but
+does **not** parse JSON or validate the envelope — that belongs to the processing layer, keeping
+the status-mapping matrix unit-testable with plain strings.
+
+_Rejected: parsing/validating the envelope inside `fetchRemoteDocument`._ It would drag the
+document model into the transport module and duplicate the validation the processing layer
+already owns.
+
+### D3. Envelope validation reuses the upload path: `processJsonEnvelopeString`
+
+Factor the body of `processJsonEnvelopeFile` into
+`processJsonEnvelopeString(raw, { name, originalFilename })` — the same file/string split
+`processHtmlFile`/`processHtmlString` already have. `name` is the fallback display name (the
+envelope's localized title still wins) and the label used in error messages;
+`originalFilename` is `null` for fetched documents. `processJsonEnvelopeFile` becomes a thin
+wrapper passing `file.name`.
+
+The string entry point keeps the existing failure behavior — it **throws** on malformed JSON,
+an invalid envelope, or a `DocTreeVersion` mismatch. The hook catches any throw and maps it to
+the existing `unsupported-content` error state.
+
+_Rejected: a new error reason / message (e.g. `invalid-envelope`)._ To the user every variant is
+"this link didn't contain a document StructEdit can read"; the existing copy ("Couldn't read the
+document — it wasn't in a supported format.") already says exactly that, and adding a reason
+would touch the message map, the UI, and the spec for no user-visible benefit.
+_Rejected: duplicating parse/validate logic in the hook._ Divergence risk with the upload path;
+`isValidDocTreeEnvelope` must stay the single source of truth.
+
+### D4. A JSON load behaves like an uploaded JSON envelope
+
+`processJsonEnvelopeString` returns `sourceUrl: null` and no `html`, so the existing App wiring
+does the right thing with zero UI changes: [LeftPane.tsx](src/components/LeftPane.tsx) shows
+Preview only (no Original tab), and `persistInitialEntry` stores a `json-envelope` entry whose
+bytes are the raw fetched JSON — identical round-trip behavior to an uploaded `.json`. The
+display-name fallback is `deriveNameFromUrl(sourceUrl)` (the `/file/<uuid>` segment), the same
+helper the HTML path uses; the envelope's `metadata.title` takes precedence when present.
+
+The `isEmptyDocument` guard stays in place after processing, applying equally to both kinds.
+
+_Rejected: synthesizing an HTML preview from the tree for the Original tab._ The Original tab
+means "the document as it came in"; for a DocTree envelope the tree *is* the document, and the
+uploaded-JSON path already established Preview-only as the correct presentation.
+
+### D5. TDD ordering (bottom-up, mirroring the original change)
+
+1. `remote-document.ts` — JSON content-type success (incl. `+json` suffix), HTML success in the
+   new `content` shape, `text/plain` still `unsupported-content`, empty JSON body still
+   `unsupported-content`.
+2. `file-processing.ts` — `processJsonEnvelopeString` direct tests (valid envelope, malformed
+   JSON, invalid envelope, version mismatch, name precedence) plus characterization that
+   `processJsonEnvelopeFile` is unchanged.
+3. App-level — a JSON `loadFile` opens the editor with a `json-envelope` recents entry and no
+   Original tab; an invalid envelope shows the unsupported-format message and no editor.
+
+## Risks / Trade-offs
+
+- **[Backend must serve signed JSON with a JSON `Content-Type` and CORS headers]** → Same
+  contract as HTML today; a wrong `Content-Type` degrades to the unsupported-format error (not a
+  blank editor). Flag to the backend team alongside the existing CORS requirement.
+- **[Changing `RemoteFetchResult`'s success shape is a breaking type change]** → All consumers
+  are in-repo (`useLoadFromUrl`, tests); the compiler surfaces every site. No public API.
+- **[A huge or deeply nested JSON body]** → `JSON.parse` + recursive validation run on the main
+  thread, same as the existing `.json` upload path; no new exposure beyond what upload allows.
+- **[Envelope version drift]** → A `DocTreeVersion` ≠ 1 is rejected as unsupported (same as
+  upload). If Demokratis ever mints newer envelopes, that is a coordinated model upgrade, out of
+  scope here.
+
+## Migration Plan
+
+Purely additive; no stored-data changes. HTML `loadFile` links and all upload flows behave
+exactly as before. Rollback is a single revert. Coordinate with the backend only on serving
+DocTree JSON with `Content-Type: application/json` (plus the already-required CORS headers).
+
+## Open Questions
+
+- **Should a non-v1 envelope get its own message?** Deferred: upload shows a targeted version
+  message, but over `loadFile` the user can't act on the distinction (the fix is on the
+  Demokratis side), so v1 ships with the generic unsupported-format copy. Revisit if envelope
+  versions ever actually diverge in production.

--- a/openspec/changes/add-loadfile-json-support/proposal.md
+++ b/openspec/changes/add-loadfile-json-support/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+The `?loadFile=` flow lets the Demokratis backend hand a document to StructEdit for editing, but it
+only accepts HTML. Demokratis also holds documents that already exist as structured trees — the
+DocTree JSON envelope StructEdit itself produces via "Download JSON" and already re-imports through
+file upload. Forcing those documents back through the HTML pipeline would discard structure the
+tree already has. This change lets a signed `loadFile` URL serve `application/json` and open the
+contained DocTree envelope directly, completing the round-trip: Demokratis → StructEdit → JSON →
+Demokratis → StructEdit.
+
+## What Changes
+
+- `fetchRemoteDocument` accepts a `200 OK` response whose `Content-Type` is JSON
+  (`application/json` or a `+json` suffix) in addition to HTML, and returns a discriminated
+  content payload (`{ kind: 'html' } | { kind: 'json' }`) so the caller picks the right pipeline.
+- A JSON body is validated as a **DocTree envelope** (`{ DocTreeVersion: 1, metadata, document }`)
+  using the same validation as the `.json` file-upload path. On success the editor opens with the
+  contained tree directly — no HTML parsing.
+- A JSON-loaded document behaves exactly like an uploaded `.json` envelope: there is no separate
+  "original" document, so the left pane shows only the rendered Preview (no Original tab), and the
+  recents entry is persisted with `source.kind: 'json-envelope'` and the raw JSON as bytes.
+- Malformed JSON, a structurally invalid envelope, or a `DocTreeVersion` mismatch all surface the
+  existing unsupported-format error (no new error surface, no blank editor).
+- A `200 OK` whose `Content-Type` is neither HTML-ish nor JSON keeps the existing
+  unsupported-format behavior.
+- **Out of scope:** any JSON shape other than the DocTree envelope, DOCX/PDF over `loadFile`,
+  content sniffing when the `Content-Type` header is wrong or missing, and any change to the
+  HTML `loadFile` path or the upload/paste flows.
+- Red-green TDD throughout, per [CLAUDE.md](CLAUDE.md) and the precedent of
+  `add-loadfile-url-import`.
+
+## Capabilities
+
+### New Capabilities
+
+- _None._
+
+### Modified Capabilities
+
+- `remote-document-loading`: the `loadFile` fetch accepts JSON (DocTree envelope) content in
+  addition to HTML — content-type routing, direct tree opening without a source preview,
+  `json-envelope` persistence, and envelope-validation failures mapped to the existing
+  unsupported-format error state.
+
+## Impact
+
+- **Remote-loading module:** [src/utils/remote-document.ts](src/utils/remote-document.ts) —
+  `looksLikeJson` next to `looksLikeHtml`; `RemoteFetchResult`'s success arm changes from
+  `{ ok: true; html }` to `{ ok: true; content: { kind: 'html'; html } | { kind: 'json'; raw } }`.
+  No new error reasons; the message map is untouched.
+- **JSON processing reuse:** [src/utils/file-processing.ts](src/utils/file-processing.ts) —
+  factor `processJsonEnvelopeString(raw, { name, originalFilename })` out of
+  `processJsonEnvelopeFile` (the same split `processHtmlString`/`processHtmlFile` already have);
+  the file entry point becomes a thin wrapper. No behavior change to the upload path.
+- **Load hook:** [src/hooks/useLoadFromUrl.ts](src/hooks/useLoadFromUrl.ts) — branch on the
+  fetched content kind: HTML → `processHtmlString` (unchanged), JSON →
+  `processJsonEnvelopeString`; any envelope failure → the `unsupported-content` error state.
+- **No UI changes:** [src/App.tsx](src/App.tsx) and
+  [src/components/LeftPane.tsx](src/components/LeftPane.tsx) already handle a document with
+  `sourceUrl: null` (Preview only, no Original tab) via the uploaded-JSON path.
+- **Tests:** [src/utils/remote-document.test.ts](src/utils/remote-document.test.ts) (the
+  `application/json → unsupported-content` expectation inverts into success cases),
+  [src/utils/file-processing.test.ts](src/utils/file-processing.test.ts) (string entry point),
+  [src/App.test.tsx](src/App.test.tsx) (end-to-end JSON `loadFile` success + failure).
+- **No data migration, no config changes:** the host allowlist, param consumption, loading/error
+  surfaces, and persistence machinery are reused as-is.

--- a/openspec/changes/add-loadfile-json-support/specs/remote-document-loading/spec.md
+++ b/openspec/changes/add-loadfile-json-support/specs/remote-document-loading/spec.md
@@ -1,0 +1,107 @@
+## MODIFIED Requirements
+
+### Requirement: Load a document from the `loadFile` query parameter
+
+On application load the system SHALL inspect the `loadFile` query parameter. When the parameter is
+present, the system SHALL decode it to a source URL, fetch the document, and open the editor with
+the parsed document — without requiring the user to interact with the upload screen. HTML content
+SHALL be parsed through the HTML pipeline; JSON content SHALL be validated as a DocTree envelope
+(`DocTreeVersion` 1) and its contained tree opened directly. When the parameter is absent the
+system SHALL render the normal upload screen and SHALL NOT perform any fetch.
+
+#### Scenario: Valid loadFile opens the editor with the document
+
+- **WHEN** the app is opened with `?loadFile=<url-encoded URL>` whose host is allowlisted and the
+  fetch returns `200 OK` with HTML content
+- **THEN** the document is parsed into the tree, the editor view is shown with that tree and a source
+  preview built from the fetched HTML, and the upload screen is not shown
+
+#### Scenario: Valid loadFile with a DocTree JSON envelope opens the editor
+
+- **WHEN** the app is opened with `?loadFile=<url-encoded URL>` whose host is allowlisted and the
+  fetch returns `200 OK` with a JSON `Content-Type` and a body that is a valid DocTree envelope
+  (`DocTreeVersion` 1)
+- **THEN** the editor view is shown with the envelope's contained tree, without running the HTML
+  pipeline; because the envelope has no separate original document, no source preview is offered
+  (the left pane shows only the rendered Preview) and the upload screen is not shown
+
+#### Scenario: No loadFile param leaves the upload flow unchanged
+
+- **WHEN** the app is opened with no `loadFile` query parameter
+- **THEN** the upload screen renders exactly as before and no network request is made
+
+#### Scenario: The fetch runs at most once
+
+- **WHEN** the app mounts with a `loadFile` param (including under React StrictMode double-invocation
+  in development)
+- **THEN** the document is fetched at most once
+
+### Requirement: Distinct error states instead of a blank editor
+
+When a `loadFile` load fails, the system SHALL display a distinct, human-readable error message
+matched to the failure, SHALL NOT open a blank or empty editor, and SHALL offer the user a way to
+reach the normal upload screen. An expired link (HTTP 410) and an invalid link (HTTP 404) SHALL
+produce different messages.
+
+#### Scenario: Expired link (410) shows the expiry message
+
+- **WHEN** fetching the `loadFile` URL returns HTTP `410 Gone`
+- **THEN** the message "Link expired, re-open from demokratis.ch." is shown and the editor is not
+  opened
+
+#### Scenario: Invalid link (404) shows a distinct invalid-link message
+
+- **WHEN** fetching the `loadFile` URL returns HTTP `404 Not Found`
+- **THEN** an "invalid link" message distinct from the 410 message is shown and the editor is not
+  opened
+
+#### Scenario: Network or CORS failure shows a generic load error
+
+- **WHEN** the fetch throws (network offline, DNS, or a CORS rejection surfaced as a `TypeError`) or
+  returns a non-OK status other than 404 or 410
+- **THEN** a generic "couldn't load the document" message is shown and the editor is not opened
+
+#### Scenario: Unrecognized or empty content shows an unsupported-format error
+
+- **WHEN** the fetch returns `200 OK` but the content is neither HTML nor JSON (by `Content-Type`),
+  or the body is empty, or the parsed document contains no content
+- **THEN** an "unsupported format" / "couldn't read the document" message is shown and the editor is
+  not opened
+
+#### Scenario: JSON that is not a valid DocTree envelope shows the unsupported-format error
+
+- **WHEN** the fetch returns `200 OK` with a JSON `Content-Type` but the body is malformed JSON, is
+  not a structurally valid DocTree envelope, or declares a `DocTreeVersion` other than 1
+- **THEN** the unsupported-format error message is shown and the editor is not opened
+
+#### Scenario: Every error surface offers a path to upload
+
+- **WHEN** any `loadFile` error message is shown
+- **THEN** an action is available that dismisses the error and shows the normal upload screen
+
+### Requirement: A URL-loaded document is persisted like an upload
+
+A document loaded via `loadFile` SHALL be persisted as a recents entry in the same way as an uploaded
+file, so that autosave protects the work and the document appears in the recents picker. A document
+loaded from a DocTree JSON envelope SHALL be persisted the same way as an uploaded `.json` envelope
+(the raw JSON as the stored source). A failure to persist (e.g. storage quota) SHALL NOT prevent the
+editor from opening; the document SHALL remain editable in memory and the existing quota
+notification SHALL apply.
+
+#### Scenario: Successful load creates a recents entry
+
+- **WHEN** a `loadFile` document is successfully fetched and parsed
+- **THEN** a recents entry is created carrying the parsed tree and the fetched source, and autosave is
+  active for the open document
+
+#### Scenario: A JSON load persists as a json-envelope entry
+
+- **WHEN** a `loadFile` document is successfully loaded from a DocTree JSON envelope
+- **THEN** the recents entry stores the raw fetched JSON as a `json-envelope` source, so reopening it
+  from recents behaves like reopening an uploaded `.json` document
+
+#### Scenario: Persistence failure still opens the editor
+
+- **WHEN** creating the recents entry for a `loadFile` document fails due to a storage error
+- **THEN** the editor still opens with the document in memory and the failure is surfaced via the
+  existing storage notification rather than blocking the load

--- a/openspec/changes/add-loadfile-json-support/tasks.md
+++ b/openspec/changes/add-loadfile-json-support/tasks.md
@@ -1,0 +1,56 @@
+## 1. Remote-loading module: JSON content-type routing
+
+- [ ] 1.1 Red: update [src/utils/remote-document.test.ts](src/utils/remote-document.test.ts) —
+  the `application/json → unsupported-content` expectation inverts: a `200` JSON response now
+  succeeds as `{ ok: true, content: { kind: 'json', raw } }` (cover `application/json` with a
+  charset parameter and a `+json` suffix type); a `200` HTML response succeeds as
+  `{ ok: true, content: { kind: 'html', html } }`; `text/plain` and a missing `Content-Type`
+  stay `unsupported-content`; an empty/whitespace JSON body stays `unsupported-content`; the
+  410/404/network mappings are unchanged
+- [ ] 1.2 Green: add `looksLikeJson(contentType)` in
+  [src/utils/remote-document.ts](src/utils/remote-document.ts) and change `RemoteFetchResult`'s
+  success arm to the discriminated `content` payload (design D1/D2); no new error reasons, the
+  message map untouched
+- [ ] 1.3 Refactor: confirm the fetch layer does not parse JSON or touch the document model, and
+  that every existing status branch still maps identically
+
+## 2. JSON envelope processing from a string
+
+- [ ] 2.1 Red: extend [src/utils/file-processing.test.ts](src/utils/file-processing.test.ts) with
+  direct `processJsonEnvelopeString` tests — valid envelope returns the tree with
+  `sourceUrl: null`, no `html`, `source.kind: 'json-envelope'`, raw JSON as bytes,
+  `originalFilename` as passed; envelope title wins over the fallback `name`; malformed JSON,
+  invalid envelope, and a mismatched `DocTreeVersion` throw; plus a characterization test that
+  `processJsonEnvelopeFile` output is unchanged for a valid file
+- [ ] 2.2 Green: extract `processJsonEnvelopeString(raw, { name, originalFilename })` in
+  [src/utils/file-processing.ts](src/utils/file-processing.ts) and re-implement
+  `processJsonEnvelopeFile` as a thin wrapper over it (design D3; no behavior change to the
+  upload path)
+- [ ] 2.3 Refactor: confirm the upload path is unchanged (characterization test green) and the
+  error messages still name the source
+
+## 3. App-level flow: JSON loadFile end to end
+
+- [ ] 3.1 Red: extend [src/App.test.tsx](src/App.test.tsx) — a `loadFile` fetch returning a valid
+  DocTree envelope as `application/json` opens the editor, creates a recents entry with
+  `source.kind: 'json-envelope'`, and offers no Original tab (Preview only); a `loadFile` fetch
+  returning JSON that is not a valid envelope shows the unsupported-format message and no editor
+- [ ] 3.2 Green: branch on `content.kind` in
+  [src/hooks/useLoadFromUrl.ts](src/hooks/useLoadFromUrl.ts) — `html` → `processHtmlString`
+  (unchanged), `json` → `processJsonEnvelopeString` with `deriveNameFromUrl` as the fallback
+  name and `originalFilename: null`; catch any envelope failure and set the
+  `unsupported-content` error state (design D3/D4)
+- [ ] 3.3 Refactor: confirm the `isEmptyDocument` guard, persistence (`persistInitialEntry`), and
+  param consumption apply identically to both content kinds; no changes needed in
+  [src/App.tsx](src/App.tsx) or [src/components/LeftPane.tsx](src/components/LeftPane.tsx)
+
+## 4. Verification & docs
+
+- [ ] 4.1 Run `npm run test` and confirm the entire suite is green
+- [ ] 4.2 Run `npm run build` and confirm it succeeds with no new TypeScript errors
+- [ ] 4.3 Update [README.md](README.md): mention JSON (DocTree envelope) alongside HTML in
+  "Loading from Demokratis" and point the spec link at the live spec
+  ([openspec/specs/remote-document-loading/spec.md](openspec/specs/remote-document-loading/spec.md))
+  instead of the archived change path
+- [ ] 4.4 Confirm with the backend that signed DocTree JSON files are served with
+  `Content-Type: application/json` and the same CORS headers required for HTML (design Risks)

--- a/openspec/changes/add-loadfile-json-support/tasks.md
+++ b/openspec/changes/add-loadfile-json-support/tasks.md
@@ -1,54 +1,54 @@
 ## 1. Remote-loading module: JSON content-type routing
 
-- [ ] 1.1 Red: update [src/utils/remote-document.test.ts](src/utils/remote-document.test.ts) —
+- [x] 1.1 Red: update [src/utils/remote-document.test.ts](src/utils/remote-document.test.ts) —
   the `application/json → unsupported-content` expectation inverts: a `200` JSON response now
   succeeds as `{ ok: true, content: { kind: 'json', raw } }` (cover `application/json` with a
   charset parameter and a `+json` suffix type); a `200` HTML response succeeds as
   `{ ok: true, content: { kind: 'html', html } }`; `text/plain` and a missing `Content-Type`
   stay `unsupported-content`; an empty/whitespace JSON body stays `unsupported-content`; the
   410/404/network mappings are unchanged
-- [ ] 1.2 Green: add `looksLikeJson(contentType)` in
+- [x] 1.2 Green: add `looksLikeJson(contentType)` in
   [src/utils/remote-document.ts](src/utils/remote-document.ts) and change `RemoteFetchResult`'s
   success arm to the discriminated `content` payload (design D1/D2); no new error reasons, the
   message map untouched
-- [ ] 1.3 Refactor: confirm the fetch layer does not parse JSON or touch the document model, and
+- [x] 1.3 Refactor: confirm the fetch layer does not parse JSON or touch the document model, and
   that every existing status branch still maps identically
 
 ## 2. JSON envelope processing from a string
 
-- [ ] 2.1 Red: extend [src/utils/file-processing.test.ts](src/utils/file-processing.test.ts) with
+- [x] 2.1 Red: extend [src/utils/file-processing.test.ts](src/utils/file-processing.test.ts) with
   direct `processJsonEnvelopeString` tests — valid envelope returns the tree with
   `sourceUrl: null`, no `html`, `source.kind: 'json-envelope'`, raw JSON as bytes,
   `originalFilename` as passed; envelope title wins over the fallback `name`; malformed JSON,
   invalid envelope, and a mismatched `DocTreeVersion` throw; plus a characterization test that
   `processJsonEnvelopeFile` output is unchanged for a valid file
-- [ ] 2.2 Green: extract `processJsonEnvelopeString(raw, { name, originalFilename })` in
+- [x] 2.2 Green: extract `processJsonEnvelopeString(raw, { name, originalFilename })` in
   [src/utils/file-processing.ts](src/utils/file-processing.ts) and re-implement
   `processJsonEnvelopeFile` as a thin wrapper over it (design D3; no behavior change to the
   upload path)
-- [ ] 2.3 Refactor: confirm the upload path is unchanged (characterization test green) and the
+- [x] 2.3 Refactor: confirm the upload path is unchanged (characterization test green) and the
   error messages still name the source
 
 ## 3. App-level flow: JSON loadFile end to end
 
-- [ ] 3.1 Red: extend [src/App.test.tsx](src/App.test.tsx) — a `loadFile` fetch returning a valid
+- [x] 3.1 Red: extend [src/App.test.tsx](src/App.test.tsx) — a `loadFile` fetch returning a valid
   DocTree envelope as `application/json` opens the editor, creates a recents entry with
   `source.kind: 'json-envelope'`, and offers no Original tab (Preview only); a `loadFile` fetch
   returning JSON that is not a valid envelope shows the unsupported-format message and no editor
-- [ ] 3.2 Green: branch on `content.kind` in
+- [x] 3.2 Green: branch on `content.kind` in
   [src/hooks/useLoadFromUrl.ts](src/hooks/useLoadFromUrl.ts) — `html` → `processHtmlString`
   (unchanged), `json` → `processJsonEnvelopeString` with `deriveNameFromUrl` as the fallback
   name and `originalFilename: null`; catch any envelope failure and set the
   `unsupported-content` error state (design D3/D4)
-- [ ] 3.3 Refactor: confirm the `isEmptyDocument` guard, persistence (`persistInitialEntry`), and
+- [x] 3.3 Refactor: confirm the `isEmptyDocument` guard, persistence (`persistInitialEntry`), and
   param consumption apply identically to both content kinds; no changes needed in
   [src/App.tsx](src/App.tsx) or [src/components/LeftPane.tsx](src/components/LeftPane.tsx)
 
 ## 4. Verification & docs
 
-- [ ] 4.1 Run `npm run test` and confirm the entire suite is green
-- [ ] 4.2 Run `npm run build` and confirm it succeeds with no new TypeScript errors
-- [ ] 4.3 Update [README.md](README.md): mention JSON (DocTree envelope) alongside HTML in
+- [x] 4.1 Run `npm run test` and confirm the entire suite is green
+- [x] 4.2 Run `npm run build` and confirm it succeeds with no new TypeScript errors
+- [x] 4.3 Update [README.md](README.md): mention JSON (DocTree envelope) alongside HTML in
   "Loading from Demokratis" and point the spec link at the live spec
   ([openspec/specs/remote-document-loading/spec.md](openspec/specs/remote-document-loading/spec.md))
   instead of the archived change path

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -264,6 +264,48 @@ describe('App — loadFile URL import', () => {
     expect(window.location.search).toBe('');
   });
 
+  it('loads a DocTree JSON envelope into the editor without an Original tab', async () => {
+    setLoadFile('https://demokratis.ch/file/abc-123');
+    const envelope = {
+      DocTreeVersion: 1,
+      metadata: { title: { de: 'Remote Envelope' } },
+      document: makeTree(),
+    };
+    const raw = JSON.stringify(envelope);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(makeFetchResponse(raw, { contentType: 'application/json' }));
+
+    render(<App />);
+
+    await screen.findByRole('button', { name: /close editor/i });
+    // The envelope *is* the document — no original to preview, only the rendered Preview.
+    expect(screen.queryByRole('tab', { name: 'Original' })).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Preview' })).toBeInTheDocument();
+
+    const recents = await listRecents();
+    expect(recents).toHaveLength(1);
+    const entry = recents[0];
+    expect('status' in entry).toBe(false);
+    if (!('status' in entry)) {
+      expect(entry.name).toBe('Remote Envelope');
+      expect(entry.source.kind).toBe('json-envelope');
+      expect(entry.source.bytes).toBe(raw);
+    }
+  });
+
+  it('shows the unsupported-format error when JSON is not a valid DocTree envelope', async () => {
+    setLoadFile('https://demokratis.ch/file/not-an-envelope');
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(makeFetchResponse('{"foo": 1}', { contentType: 'application/json' }));
+
+    render(<App />);
+
+    expect(await screen.findByText(/couldn.t read the document/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /close editor/i })).not.toBeInTheDocument();
+  });
+
   it('shows the expiry message on 410 and does not open the editor', async () => {
     setLoadFile('https://demokratis.ch/file/expired');
     globalThis.fetch = vi.fn().mockResolvedValue(makeFetchResponse('', { status: 410 }));

--- a/src/hooks/useLoadFromUrl.ts
+++ b/src/hooks/useLoadFromUrl.ts
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useToast } from '../components/ui/Toast';
 import type { DocumentRootNode } from '../types/document';
 import { isEmptyDocument } from '../utils/document-utils';
-import { deriveNameFromUrl, processHtmlString } from '../utils/file-processing';
+import {
+  deriveNameFromUrl,
+  type ProcessedDocument,
+  processHtmlString,
+  processJsonEnvelopeString,
+} from '../utils/file-processing';
 import { persistInitialEntry } from '../utils/persist-entry';
 import {
   fetchRemoteDocument,
@@ -92,10 +97,26 @@ export function useLoadFromUrl(onLoaded: OnRemoteDocumentLoaded): {
             return;
           }
 
-          const processed = processHtmlString(result.html, {
-            name: deriveNameFromUrl(result.sourceUrl),
-            originalFilename: null,
-          });
+          const name = deriveNameFromUrl(result.sourceUrl);
+          let processed: ProcessedDocument;
+          if (result.content.kind === 'json') {
+            // The body must be a DocTree envelope; anything else is not a document
+            // StructEdit can read, which is exactly the unsupported-content surface.
+            try {
+              processed = processJsonEnvelopeString(result.content.raw, {
+                name,
+                originalFilename: null,
+              });
+            } catch {
+              setState({ status: 'error', reason: 'unsupported-content' });
+              return;
+            }
+          } else {
+            processed = processHtmlString(result.content.html, {
+              name,
+              originalFilename: null,
+            });
+          }
           if (isEmptyDocument(processed.doc)) {
             setState({ status: 'error', reason: 'unsupported-content' });
             return;

--- a/src/utils/file-processing.test.ts
+++ b/src/utils/file-processing.test.ts
@@ -9,6 +9,7 @@ import {
   processHtmlFile,
   processHtmlString,
   processJsonEnvelopeFile,
+  processJsonEnvelopeString,
   processPdfFile,
   processTextInput,
 } from './file-processing';
@@ -428,6 +429,60 @@ describe('file-processing', () => {
       const envelope = { ...makeEnvelope({ de: 'X' }), DocTreeVersion: 2 };
       const file = jsonFile(JSON.stringify(envelope));
       await expect(processJsonEnvelopeFile(file)).rejects.toThrow(/version/i);
+    });
+
+    // The string entry point shared with the `loadFile` URL path. The file-based
+    // tests above double as the characterization that the upload path is unchanged.
+    describe('processJsonEnvelopeString', () => {
+      it('reconstructs the tree from a valid envelope string', () => {
+        const raw = JSON.stringify(makeEnvelope({ de: 'My Title' }));
+        const result = processJsonEnvelopeString(raw, { name: 'abc-123', originalFilename: null });
+
+        expect(result.doc.type).toBe('DOCUMENT');
+        expect((result.doc.children[0] as ContentDocumentNode).contents).toEqual({
+          de: 'Hello envelope',
+        });
+        // A DocTree JSON *is* the tree — no separate original to preview.
+        expect(result.sourceUrl).toBeNull();
+        expect(result.html).toBeUndefined();
+        expect(result.source.kind).toBe('json-envelope');
+        expect(result.source.mime).toBe('application/json');
+        expect(result.source.bytes).toBe(raw);
+        expect(result.source.originalFilename).toBeNull();
+        expect(result.subtitle).toBeNull();
+      });
+
+      it('prefers the envelope title over the fallback name', () => {
+        const raw = JSON.stringify(makeEnvelope({ de: 'Verordnung X' }));
+        const result = processJsonEnvelopeString(raw, { name: 'abc-123', originalFilename: null });
+        expect(result.name).toBe('Verordnung X');
+      });
+
+      it('falls back to the given name when the title is empty', () => {
+        const raw = JSON.stringify(makeEnvelope({}));
+        const result = processJsonEnvelopeString(raw, { name: 'abc-123', originalFilename: null });
+        expect(result.name).toBe('abc-123');
+      });
+
+      it('throws on malformed JSON', () => {
+        expect(() =>
+          processJsonEnvelopeString('{ not valid json', { name: 'x', originalFilename: null })
+        ).toThrow(/not valid JSON/i);
+      });
+
+      it('throws on a structurally invalid envelope', () => {
+        const raw = JSON.stringify({ DocTreeVersion: 1, metadata: {}, document: {} });
+        expect(() => processJsonEnvelopeString(raw, { name: 'x', originalFilename: null })).toThrow(
+          /not a valid StructEdit document/i
+        );
+      });
+
+      it('throws on an unsupported DocTreeVersion', () => {
+        const raw = JSON.stringify({ ...makeEnvelope({ de: 'X' }), DocTreeVersion: 2 });
+        expect(() => processJsonEnvelopeString(raw, { name: 'x', originalFilename: null })).toThrow(
+          /version/i
+        );
+      });
     });
   });
 

--- a/src/utils/file-processing.ts
+++ b/src/utils/file-processing.ts
@@ -145,21 +145,27 @@ function pickEnvelopeName(title: LocalizedText, filename: string): string {
 }
 
 /**
- * Re-import a DocTree envelope JSON previously produced by StructEdit's "Download JSON".
+ * Build a {@link ProcessedDocument} from a DocTree envelope JSON string. Shared by the
+ * `.json` file-upload path ({@link processJsonEnvelopeFile}) and the `loadFile` URL path.
+ * `name` is the fallback display name (the envelope's localized title wins) and the label
+ * used in error messages; `originalFilename` is null for fetched documents.
  *
  * A DocTree JSON *is* the document tree — there is no separate "original" document — so
  * `sourceUrl` is null and `html` is omitted, which makes the editor show only the rendered
  * Preview (no Original tab). The raw JSON text is kept as the persisted source bytes so the
  * entry still round-trips through IndexedDB.
+ *
+ * Throws on malformed JSON, a structurally invalid envelope, or a `DocTreeVersion` mismatch.
  */
-export async function processJsonEnvelopeFile(file: File): Promise<ProcessedDocument> {
-  const raw = await file.text();
-
+export function processJsonEnvelopeString(
+  raw: string,
+  options: { name: string; originalFilename: string | null }
+): ProcessedDocument {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    throw new Error(`"${file.name}" is not valid JSON.`);
+    throw new Error(`"${options.name}" is not valid JSON.`);
   }
 
   // A present-but-mismatched *numeric* version gets a targeted message rather than the
@@ -169,13 +175,13 @@ export async function processJsonEnvelopeFile(file: File): Promise<ProcessedDocu
   const version = (parsed as { DocTreeVersion?: unknown } | null)?.DocTreeVersion;
   if (typeof version === 'number' && version !== DOC_TREE_VERSION) {
     throw new Error(
-      `"${file.name}" was created by an incompatible version of StructEdit ` +
+      `"${options.name}" was created by an incompatible version of StructEdit ` +
         `(DocTree v${version}; this version reads v${DOC_TREE_VERSION}).`
     );
   }
 
   if (!isValidDocTreeEnvelope(parsed)) {
-    throw new Error(`"${file.name}" is not a valid StructEdit document (DocTree envelope).`);
+    throw new Error(`"${options.name}" is not a valid StructEdit document (DocTree envelope).`);
   }
 
   return {
@@ -185,11 +191,17 @@ export async function processJsonEnvelopeFile(file: File): Promise<ProcessedDocu
       kind: 'json-envelope',
       mime: 'application/json',
       bytes: raw,
-      originalFilename: file.name,
+      originalFilename: options.originalFilename,
     },
-    name: pickEnvelopeName(parsed.metadata.title, file.name),
+    name: pickEnvelopeName(parsed.metadata.title, options.name),
     subtitle: null,
   };
+}
+
+/** Re-import a DocTree envelope JSON previously produced by StructEdit's "Download JSON". */
+export async function processJsonEnvelopeFile(file: File): Promise<ProcessedDocument> {
+  const raw = await file.text();
+  return processJsonEnvelopeString(raw, { name: file.name, originalFilename: file.name });
 }
 
 /**

--- a/src/utils/remote-document.test.ts
+++ b/src/utils/remote-document.test.ts
@@ -116,11 +116,35 @@ describe('resolveAllowedHosts', () => {
 describe('fetchRemoteDocument', () => {
   const URL_OK = 'https://demokratis.ch/file/abc-123';
 
-  it('returns the html for a 200 HTML response', async () => {
+  it('returns html content for a 200 HTML response', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(makeResponse('<h1>Hi</h1>'));
     const result = await fetchRemoteDocument(URL_OK, fetchImpl);
-    expect(result).toEqual({ ok: true, html: '<h1>Hi</h1>', sourceUrl: URL_OK });
+    expect(result).toEqual({
+      ok: true,
+      content: { kind: 'html', html: '<h1>Hi</h1>' },
+      sourceUrl: URL_OK,
+    });
     expect(fetchImpl).toHaveBeenCalledWith(URL_OK);
+  });
+
+  it('returns raw json content for a 200 JSON response', async () => {
+    const body = '{"DocTreeVersion":1}';
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(makeResponse(body, { contentType: 'application/json; charset=utf-8' }));
+    expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({
+      ok: true,
+      content: { kind: 'json', raw: body },
+      sourceUrl: URL_OK,
+    });
+  });
+
+  it('treats a +json structured-syntax content-type as json', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(makeResponse('{}', { contentType: 'application/ld+json' }));
+    const result = await fetchRemoteDocument(URL_OK, fetchImpl);
+    expect(result).toEqual({ ok: true, content: { kind: 'json', raw: '{}' }, sourceUrl: URL_OK });
   });
 
   it('maps 410 to expired', async () => {
@@ -146,18 +170,28 @@ describe('fetchRemoteDocument', () => {
     expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({ ok: false, reason: 'network' });
   });
 
-  it('maps a non-HTML content-type to unsupported-content', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValue(makeResponse('{"a":1}', { contentType: 'application/json' }));
+  it('maps a content-type that is neither HTML nor JSON to unsupported-content', async () => {
+    for (const contentType of ['text/plain', 'application/pdf', null]) {
+      const fetchImpl = vi.fn().mockResolvedValue(makeResponse('some body', { contentType }));
+      expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({
+        ok: false,
+        reason: 'unsupported-content',
+      });
+    }
+  });
+
+  it('maps an empty HTML body to unsupported-content', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse('   '));
     expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({
       ok: false,
       reason: 'unsupported-content',
     });
   });
 
-  it('maps an empty HTML body to unsupported-content', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(makeResponse('   '));
+  it('maps an empty JSON body to unsupported-content', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(makeResponse('   ', { contentType: 'application/json' }));
     expect(await fetchRemoteDocument(URL_OK, fetchImpl)).toEqual({
       ok: false,
       reason: 'unsupported-content',

--- a/src/utils/remote-document.ts
+++ b/src/utils/remote-document.ts
@@ -90,8 +90,16 @@ export function parseLoadFileParam(search: string, allowedHosts: string[]): Pars
 /** Failure reasons that can arise from the network fetch itself. */
 export type RemoteFetchErrorReason = 'expired' | 'not-found' | 'network' | 'unsupported-content';
 
+/**
+ * What a successful fetch carried, so the caller picks the matching pipeline:
+ * HTML goes through the legal-HTML parser, JSON is validated as a DocTree envelope.
+ * This layer stays transport-only — it classifies the content type and reads the
+ * body, but never parses JSON or touches the document model.
+ */
+export type RemoteDocumentContent = { kind: 'html'; html: string } | { kind: 'json'; raw: string };
+
 export type RemoteFetchResult =
-  | { ok: true; html: string; sourceUrl: string }
+  | { ok: true; content: RemoteDocumentContent; sourceUrl: string }
   | { ok: false; reason: RemoteFetchErrorReason };
 
 function looksLikeHtml(contentType: string | null): boolean {
@@ -100,13 +108,20 @@ function looksLikeHtml(contentType: string | null): boolean {
   return ct.includes('text/html') || ct.includes('application/xhtml');
 }
 
+function looksLikeJson(contentType: string | null): boolean {
+  if (!contentType) return false;
+  const ct = contentType.toLowerCase();
+  // `+json` covers structured-syntax suffixes like application/ld+json.
+  return ct.includes('application/json') || ct.includes('+json');
+}
+
 /**
  * Fetch a (pre-validated) document URL and map the outcome to a discriminated result.
  * `fetchImpl` is injectable so tests exercise every status branch without a network.
  *
  * Mapping: 410 → expired, 404 → not-found, any other non-OK status or thrown error
- * (CORS/offline surface as `TypeError`) → network, a non-HTML or empty 2xx body →
- * unsupported-content.
+ * (CORS/offline surface as `TypeError`) → network, a 2xx body that is neither HTML
+ * nor JSON, or is empty → unsupported-content.
  */
 export async function fetchRemoteDocument(
   url: string,
@@ -125,22 +140,26 @@ export async function fetchRemoteDocument(
     return { ok: false, reason: 'network' };
   }
 
-  if (!looksLikeHtml(response.headers.get('content-type'))) {
+  const contentType = response.headers.get('content-type');
+  const kind = looksLikeHtml(contentType) ? 'html' : looksLikeJson(contentType) ? 'json' : null;
+  if (!kind) {
     return { ok: false, reason: 'unsupported-content' };
   }
 
-  let html: string;
+  let body: string;
   try {
-    html = await response.text();
+    body = await response.text();
   } catch {
     return { ok: false, reason: 'network' };
   }
 
-  if (!html.trim()) {
+  if (!body.trim()) {
     return { ok: false, reason: 'unsupported-content' };
   }
 
-  return { ok: true, html, sourceUrl: url };
+  const content: RemoteDocumentContent =
+    kind === 'html' ? { kind, html: body } : { kind, raw: body };
+  return { ok: true, content, sourceUrl: url };
 }
 
 /** Every reason a `loadFile` load can fail, across parsing and fetching. */


### PR DESCRIPTION
## Summary

Extends the `?loadFile=` URL parameter to accept `application/json` responses containing DocTree envelopes, completing the round-trip: Demokratis → StructEdit → JSON → Demokratis → StructEdit. JSON-loaded documents behave identically to uploaded `.json` envelopes (Preview-only left pane, `json-envelope` persistence, no separate original document).

## Key Changes

- **Remote-document transport layer** (`src/utils/remote-document.ts`):
  - Added `looksLikeJson(contentType)` to recognize `application/json` and `+json` structured-syntax suffixes alongside HTML detection
  - Changed `RemoteFetchResult`'s success arm from `{ ok: true; html }` to a discriminated `{ ok: true; content: { kind: 'html' | 'json'; ... } }` payload
  - Transport layer remains pure: classifies content type and reads body, but does not parse JSON or validate the document model

- **JSON envelope processing** (`src/utils/file-processing.ts`):
  - Extracted `processJsonEnvelopeString(raw, { name, originalFilename })` from `processJsonEnvelopeFile` (mirrors the existing `processHtmlString`/`processHtmlFile` split)
  - `processJsonEnvelopeFile` now wraps the string entry point; upload path behavior unchanged
  - String entry point throws on malformed JSON, invalid envelope, or `DocTreeVersion` mismatch

- **Load hook** (`src/hooks/useLoadFromUrl.ts`):
  - Branches on fetched content kind: HTML → `processHtmlString` (unchanged), JSON → `processJsonEnvelopeString`
  - Catches envelope validation failures and maps them to the existing `unsupported-content` error state
  - Uses `deriveNameFromUrl` as fallback display name for both kinds

- **No UI changes**: `App.tsx` and `LeftPane.tsx` already handle documents with `sourceUrl: null` (Preview-only, no Original tab) via the uploaded-JSON path

- **Tests** (TDD throughout):
  - `remote-document.test.ts`: JSON content-type success cases (with charset and `+json` suffix), empty JSON body still unsupported, HTML success in new shape
  - `file-processing.test.ts`: `processJsonEnvelopeString` direct tests (valid envelope, malformed JSON, invalid envelope, version mismatch, name precedence), characterization that upload path is unchanged
  - `App.test.tsx`: end-to-end JSON `loadFile` success (no Original tab, `json-envelope` recents entry) and failure (invalid envelope shows unsupported-format error)

## Implementation Details

- **Content-type routing** (D1): HTML-ish → HTML path; JSON-ish → JSON path; anything else → `unsupported-content` (unchanged)
- **No new error reasons or messages**: envelope validation failures map to the existing `unsupported-content` surface
- **Envelope validation reuses upload logic** (D3): single source of truth in `isValidDocTreeEnvelope`
- **JSON-loaded documents behave like uploaded envelopes** (D4): `sourceUrl: null`, no `html`, `source.kind: 'json-envelope'`, raw JSON as persisted bytes
- **Purely additive**: HTML `loadFile` links, upload flows, and all existing error behavior are byte-for-byte unchanged; rollback is a single revert

## Coordination

Backend must serve signed DocTree JSON files with `Content-Type: application/json` and the same CORS headers required for HTML (existing requirement).

https://claude.ai/code/session_01PGyWLQxjSStNrhzjKZFMLd