### PR TITLE
Refuse type changes that would break the parent's child rules

### DIFF
--- a/src/utils/tree-mutations.test.ts
+++ b/src/utils/tree-mutations.test.ts
@@ -10,6 +10,7 @@ import type {
   NodeFormat,
   NumberedDocumentNode,
 } from '../types/document';
+import { isValidDocument } from '../types/document';
 import type { NodePath } from '../types/editor';
 import {
   canMergeIdsInDoc,
@@ -604,5 +605,48 @@ describe('mergeNodesInDoc', () => {
   test('returns null when the selection cannot be merged', () => {
     const d = doc([heading('h1', 'A'), heading('h2', 'B'), heading('h3', 'C')]);
     expect(mergeNodesInDoc(['h1', 'h3'], d, idx(d))).toBeNull();
+  });
+});
+
+describe('changeNodeTypeInDoc — parent-validity guard', () => {
+  // A footnote may live under a CONTENT node, but ALLOWED_CHILDREN.CONTENT is ['FOOTNOTE'] only.
+  // The in-place conversions replace the node where it stands, so without a parent check they can
+  // leave a node its parent may not hold — reachable from the UI by selecting such a footnote and
+  // pressing H.
+  const footnoteUnderContent = (): DocumentRootNode => {
+    const c: ContentDocumentNode = { ...content('c1', 'body'), children: [footnote('f1', 'note')] };
+    return doc([c]);
+  };
+
+  test('refuses to convert a footnote under a content node to a heading', () => {
+    const d = footnoteUnderContent();
+    expect(changeNodeTypeInDoc(d, idx(d), 'f1', 'HEADING')).toBeNull();
+  });
+
+  test('refuses to convert it to content, which the parent may not hold either', () => {
+    const d = footnoteUnderContent();
+    expect(changeNodeTypeInDoc(d, idx(d), 'f1', 'CONTENT')).toBeNull();
+  });
+
+  test('still allows the same conversion where the parent permits it', () => {
+    // Under a HEADING, both HEADING and CONTENT are allowed children.
+    const h: HeadingDocumentNode = { ...heading('h1', 'H'), children: [footnote('f1', 'note')] };
+    const d = doc([h]);
+    const asHeading = changeNodeTypeInDoc(d, idx(d), 'f1', 'HEADING');
+    expect(asHeading).not.toBeNull();
+    expect(isValidDocument(asHeading as DocumentRootNode)).toBe(true);
+    expect(changeNodeTypeInDoc(d, idx(d), 'f1', 'CONTENT')).not.toBeNull();
+  });
+
+  test('leaves the document valid wherever a conversion is allowed to proceed', () => {
+    const d = doc([content('c1', 'x'), heading('h1', 'H')]);
+    for (const [id, target] of [
+      ['c1', 'HEADING'],
+      ['h1', 'CONTENT'],
+      ['c1', 'FOOTNOTE'],
+    ] as const) {
+      const out = changeNodeTypeInDoc(d, idx(d), id, target);
+      if (out) expect(isValidDocument(out)).toBe(true);
+    }
   });
 });

--- a/src/utils/tree-mutations.ts
+++ b/src/utils/tree-mutations.ts
@@ -719,6 +719,11 @@ export const changeNodeTypeInDoc = (
   // Can only convert nodes with contents
   if (!hasContents(node)) return null;
 
+  // Safety: the conversions below replace the node in place, so never produce a child its current
+  // parent can't hold. Placed after the LIST/LIST_ITEM cases, which deliberately re-parent into a
+  // different container.
+  if (!canBeChildOf(targetType, parent.type as ParentType)) return null;
+
   // Handle conversion to footnote
   if (targetType === 'FOOTNOTE') {
     if (node.type === 'FOOTNOTE') return null; // Already a footnote


### PR DESCRIPTION
changeNodeTypeInDoc converts a node in place, replacing it where it stands, but never checked whether the parent may hold the new type. A footnote nested under a content node is the reachable case: select it, press H, and the tree ends up with a HEADING inside a CONTENT, which ALLOWED_CHILDREN does not permit — isValidDocument returns false. The type shortcuts apply to the whole selection without filtering by parent, so nothing upstream prevented it.

Add a canBeChildOf check before the in-place conversions. Placement is load-bearing: it has to sit after the LIST/LIST_ITEM branches, which deliberately re-parent a node into a different container, and guard only the conversions that replace a node where it is.